### PR TITLE
Manual Package Signing POC

### DIFF
--- a/.github/workflows/build-sign-verify-manual.yml
+++ b/.github/workflows/build-sign-verify-manual.yml
@@ -53,7 +53,6 @@ jobs:
 
         echo "OIDC token:"
         cat id_token | jq --raw-input 'split(".") | .[0],.[1] | @base64d | fromjson'
-        # cat id_token | base64 --wrap=0
 
     - name: Request signing cert from Fulcio
       run: |


### PR DESCRIPTION
Adds a GHA Workflow which builds, signs, and verifies the node package contained in this repository.

This deconstruction of the `cosign sign` and `cosign verify` commands mirrors the rough workflow we'll need to implement in the `sigstore-node` library.

See the following workflow run: https://github.com/github/sigstore-node/actions/runs/2387270515

<img width="950" alt="image" src="https://user-images.githubusercontent.com/398027/170372507-7aba8911-3ee5-4802-b540-e267bd95ae4b.png">

Closes github/package-security#94