### PR TITLE
Update license headers to Sigstore Authors

### DIFF
--- a/bin/sigstore.js
+++ b/bin/sigstore.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/client/error.test.ts
+++ b/src/client/error.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/client/error.ts
+++ b/src/client/error.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/client/fulcio.test.ts
+++ b/src/client/fulcio.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/client/fulcio.ts
+++ b/src/client/fulcio.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/client/rekor.test.ts
+++ b/src/client/rekor.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/client/rekor.ts
+++ b/src/client/rekor.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto.test.ts
+++ b/src/crypto.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/dsse.test.ts
+++ b/src/dsse.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/dsse.ts
+++ b/src/dsse.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/identity/ci.test.ts
+++ b/src/identity/ci.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/identity/ci.ts
+++ b/src/identity/ci.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/identity/index.ts
+++ b/src/identity/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/identity/issuer.test.ts
+++ b/src/identity/issuer.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/identity/issuer.ts
+++ b/src/identity/issuer.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/identity/oauth.test.ts
+++ b/src/identity/oauth.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/identity/oauth.ts
+++ b/src/identity/oauth.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/identity/provider.ts
+++ b/src/identity/provider.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/sign.test.ts
+++ b/src/sign.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/sigstore.test.ts
+++ b/src/sigstore.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 GitHub, Inc
+Copyright 2022 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Change "GitHub, Inc" to "The Sigstore Authors" in all of the license headers.