### PR TITLE
make certificate mandatory for verification

### DIFF
--- a/.github/workflows/build-sign-verify.yml
+++ b/.github/workflows/build-sign-verify.yml
@@ -94,6 +94,11 @@ jobs:
       with:
         name: signature
         path: artifact.sig
+    - name: Archive certificate
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3
+      with:
+        name: certificate
+        path: signingcert.pem
 
   verify-signature:
     name: Verify Signature
@@ -117,9 +122,13 @@ jobs:
       uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3
       with:
         name: signature
+    - name: Download certificate
+      uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3
+      with:
+        name: certificate
     - name: Compile sigstore
       run: |
         npm run build
     - name: Verify artifact signature
       run: |
-        ./bin/sigstore.js verify sigstore-0.0.0.tgz artifact.sig
+        ./bin/sigstore.js verify sigstore-0.0.0.tgz artifact.sig signingcert.pem

--- a/README.md
+++ b/README.md
@@ -83,6 +83,90 @@ $ cat signature
 MEUCIQC7Rrrjmrwdxuc2qvWiWzaoUdV8+VFv+fvDquvAGmxr3AIgaPEqQ5YvxjfeqgXYXvISzgyVA8y/Zw+G/LDYlt2RHMk=
 ```
 
+The Fulcio signing certificate will be written to a file named
+`signingcert.pem`. You can inspect the contents of the signing certificate with
+the following:
+
+```
+$ openssl x509 -in signingcert.pem -text
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            1a:8a:25:49:b9:86:46:1e:4a:4f:70:e8:5c:20:52:03:e6:04:ee:7b
+        Signature Algorithm: ecdsa-with-SHA384
+        Issuer: O = sigstore.dev, CN = sigstore-intermediate
+        Validity
+            Not Before: Jun 17 17:12:01 2022 GMT
+            Not After : Jun 17 17:22:01 2022 GMT
+        Subject:
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:77:55:0b:20:32:67:bb:a1:eb:9a:da:18:a7:11:
+                    30:d8:b2:0b:50:90:9f:7c:ef:31:8c:c3:09:4d:b4:
+                    17:6d:f2:ed:d4:36:90:15:8e:a1:21:35:aa:88:03:
+                    09:16:fb:07:f8:25:a1:6b:ae:47:db:df:08:a0:c3:
+                    42:3a:43:14:eb
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage:
+                Code Signing
+            X509v3 Subject Key Identifier:
+                AD:4D:65:B1:5D:18:6C:E7:DA:E6:79:04:F3:83:DB:B0:AA:D8:C6:FF
+            X509v3 Authority Key Identifier:
+                DF:D3:E9:CF:56:24:11:96:F9:A8:D8:E9:28:55:A2:C6:2E:18:64:3F
+            X509v3 Subject Alternative Name: critical
+                email:foo@bar.com
+            1.3.6.1.4.1.57264.1.1:
+                https://github.com/login/oauth
+            CT Precertificate SCTs:
+                Signed Certificate Timestamp:
+                    Version   : v1 (0x0)
+                    Log ID    : 08:60:92:F0:28:52:FF:68:45:D1:D1:6B:27:84:9C:45:
+                                67:18:AC:16:3D:C3:38:D2:6D:E6:BC:22:06:36:6F:72
+                    Timestamp : Jun 17 17:12:01.084 2022 GMT
+                    Extensions: none
+                    Signature : ecdsa-with-SHA256
+                                30:45:02:20:27:19:2F:A7:20:53:8D:27:92:AC:F8:08:
+                                73:DC:F9:DB:9C:B7:1C:3C:77:90:C0:6E:CC:CA:1D:8A:
+                                79:55:4E:05:02:21:00:FF:70:1D:86:F1:7C:CB:A2:B2:
+                                ED:F5:16:0B:0D:C9:A1:7D:97:7A:31:62:DC:1B:3F:E9:
+                                E2:6B:EE:11:9C:20:2B
+    Signature Algorithm: ecdsa-with-SHA384
+    Signature Value:
+        30:65:02:30:30:d3:7c:0e:fc:6f:0f:8e:35:4c:ae:f6:5d:37:
+        51:da:1d:36:a7:33:ba:ab:5f:1f:e1:80:fa:1c:7f:b2:44:6c:
+        cd:4e:e0:21:ec:91:de:01:95:60:17:be:88:c8:8f:9c:02:31:
+        00:ee:d6:c6:23:ff:b6:6c:66:65:82:9f:9b:ca:f0:ed:cc:4d:
+        63:5d:70:58:b4:c2:1e:55:8f:21:b3:d7:27:16:6d:cb:22:0a:
+        92:37:d6:61:38:ff:bc:43:69:eb:28:9d:af
+-----BEGIN CERTIFICATE-----
+MIICoDCCAiagAwIBAgIUGoolSbmGRh5KT3DoXCBSA+YE7nswCgYIKoZIzj0EAwMw
+NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
+cm1lZGlhdGUwHhcNMjIwNjE3MTcxMjAxWhcNMjIwNjE3MTcyMjAxWjAAMFkwEwYH
+KoZIzj0CAQYIKoZIzj0DAQcDQgAEd1ULIDJnu6HrmtoYpxEw2LILUJCffO8xjMMJ
+TbQXbfLt1DaQFY6hITWqiAMJFvsH+CWha65H298IoMNCOkMU66OCAUUwggFBMA4G
+A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUrU1l
+sV0YbOfa5nkE84PbsKrYxv8wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
+ZD8wHwYDVR0RAQH/BBUwE4ERYnJpYW5AZGVoYW1lci5jb20wLAYKKwYBBAGDvzAB
+AQQeaHR0cHM6Ly9naXRodWIuY29tL2xvZ2luL29hdXRoMIGKBgorBgEEAdZ5AgQC
+BHwEegB4AHYACGCS8ChS/2hF0dFrJ4ScRWcYrBY9wzjSbea8IgY2b3IAAAGBcqZ3
+PAAABAMARzBFAiAnGS+nIFONJ5Ks+Ahz3PnbnLccPHeQwG7Myh2KeVVOBQIhAP9w
+HYbxfMuisu31FgsNyaF9l3oxYtwbP+nia+4RnCArMAoGCCqGSM49BAMDA2gAMGUC
+MDDTfA78bw+ONUyu9l03UdodNqczuqtfH+GA+hx/skRszU7gIeyR3gGVYBe+iMiP
+nAIxAO7WxiP/tmxmZYKfm8rw7cxNY11wWLTCHlWPIbPXJxZtyyIKkjfWYTj/vENp
+6yidrw==
+-----END CERTIFICATE-----
+```
+
+The SAN in the certificate should match the identity that was used to
+authenticate with the OAuth provider.
+
 Using the Rekor URL displayed as part of the signing process you should also be
 able to retrieve the Rekor entry for this signature:
 
@@ -115,84 +199,6 @@ $ curl --silent https://rekor.sigstore.dev/api/v1/log/entries/43553c769cd0bd99ae
 Note that the `.spec.signature.content` value matches the signature that was
 saved locally.
 
-Furthermore, you can inspect the signing certificate attached to the Rekor
-entry with the following (remember to substitute the Rekor URL with the one
-displayed when signing the artifact):
-
-```
-$ curl --silent https://rekor.sigstore.dev/api/v1/log/entries/43553c769cd0bd99aee4350d2e78ca3fb015840a2f6f4cf31b475f588fc214e6 \
-  | jq --raw-output '.[].body' \
-  | base64 --decode \
-  | jq --raw-output '.spec.signature.publicKey.content' \
-  | base64 --decode \
-  | openssl x509 -text
-
-Certificate:
-    Data:
-        Version: 3 (0x2)
-        Serial Number:
-            1a:8a:25:49:b9:86:46:1e:4a:4f:70:e8:5c:20:52:03:e6:04:ee:7b
-    Signature Algorithm: ecdsa-with-SHA384
-        Issuer: O=sigstore.dev, CN=sigstore-intermediate
-        Validity
-            Not Before: Jun 17 17:12:01 2022 GMT
-            Not After : Jun 17 17:22:01 2022 GMT
-        Subject:
-        Subject Public Key Info:
-            Public Key Algorithm: id-ecPublicKey
-                Public-Key: (256 bit)
-                pub:
-                    04:77:55:0b:20:32:67:bb:a1:eb:9a:da:18:a7:11:
-                    30:d8:b2:0b:50:90:9f:7c:ef:31:8c:c3:09:4d:b4:
-                    17:6d:f2:ed:d4:36:90:15:8e:a1:21:35:aa:88:03:
-                    09:16:fb:07:f8:25:a1:6b:ae:47:db:df:08:a0:c3:
-                    42:3a:43:14:eb
-                ASN1 OID: prime256v1
-                NIST CURVE: P-256
-        X509v3 extensions:
-            X509v3 Key Usage: critical
-                Digital Signature
-            X509v3 Extended Key Usage:
-                Code Signing
-            X509v3 Subject Key Identifier:
-                AD:4D:65:B1:5D:18:6C:E7:DA:E6:79:04:F3:83:DB:B0:AA:D8:C6:FF
-            X509v3 Authority Key Identifier:
-                keyid:DF:D3:E9:CF:56:24:11:96:F9:A8:D8:E9:28:55:A2:C6:2E:18:64:3F
-
-            X509v3 Subject Alternative Name: critical
-                email:foo@bar.com
-            1.3.6.1.4.1.57264.1.1:
-                https://github.com/login/oauth
-            1.3.6.1.4.1.11129.2.4.2:
-                .z.x.v..`..(R.hE..k'..Eg...=.8.m..".6or....r.w<.....G0E. './. S.'....s......<w..n....yUN..!..p...|......}.z1b..?..k... +
-    Signature Algorithm: ecdsa-with-SHA384
-         30:65:02:30:30:d3:7c:0e:fc:6f:0f:8e:35:4c:ae:f6:5d:37:
-         51:da:1d:36:a7:33:ba:ab:5f:1f:e1:80:fa:1c:7f:b2:44:6c:
-         cd:4e:e0:21:ec:91:de:01:95:60:17:be:88:c8:8f:9c:02:31:
-         00:ee:d6:c6:23:ff:b6:6c:66:65:82:9f:9b:ca:f0:ed:cc:4d:
-         63:5d:70:58:b4:c2:1e:55:8f:21:b3:d7:27:16:6d:cb:22:0a:
-         92:37:d6:61:38:ff:bc:43:69:eb:28:9d:af
------BEGIN CERTIFICATE-----
-MIICoDCCAiagAwIBAgIUGoolSbmGRh5KT3DoXCBSA+YE7nswCgYIKoZIzj0EAwMw
-NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
-cm1lZGlhdGUwHhcNMjIwNjE3MTcxMjAxWhcNMjIwNjE3MTcyMjAxWjAAMFkwEwYH
-KoZIzj0CAQYIKoZIzj0DAQcDQgAEd1ULIDJnu6HrmtoYpxEw2LILUJCffO8xjMMJ
-TbQXbfLt1DaQFY6hITWqiAMJFvsH+CWha65H298IoMNCOkMU66OCAUUwggFBMA4G
-A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUrU1l
-sV0YbOfa5nkE84PbsKrYxv8wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
-ZD8wHwYDVR0RAQH/BBUwE4ERYnJpYW5AZGVoYW1lci5jb20wLAYKKwYBBAGDvzAB
-AQQeaHR0cHM6Ly9naXRodWIuY29tL2xvZ2luL29hdXRoMIGKBgorBgEEAdZ5AgQC
-BHwEegB4AHYACGCS8ChS/2hF0dFrJ4ScRWcYrBY9wzjSbea8IgY2b3IAAAGBcqZ3
-PAAABAMARzBFAiAnGS+nIFONJ5Ks+Ahz3PnbnLccPHeQwG7Myh2KeVVOBQIhAP9w
-HYbxfMuisu31FgsNyaF9l3oxYtwbP+nia+4RnCArMAoGCCqGSM49BAMDA2gAMGUC
-MDDTfA78bw+ONUyu9l03UdodNqczuqtfH+GA+hx/skRszU7gIeyR3gGVYBe+iMiP
-nAIxAO7WxiP/tmxmZYKfm8rw7cxNY11wWLTCHlWPIbPXJxZtyyIKkjfWYTj/vENp
-6yidrw==
------END CERTIFICATE-----
-```
-
-The SAN in the certificate should match the identity that was used to
-authenticate with the OAuth provider.
 
 ### Verifying
 
@@ -200,16 +206,14 @@ Use the `verify` command to make sure that the saved signature matches
 the artifact:
 
 ```
-$ ./bin/sigstore.js verify sigstore-0.0.0.tgz signature
+$ ./bin/sigstore.js verify sigstore-0.0.0.tgz signature signingcert.pem
 
 Signature verified OK
 ```
 
-This will caulcuate the SHA256 digest of the package and use that
-value to look-up matching entries in the Rekor log. For each Rekor
-entry with a matching digest it will look at the signature stored in
-that entry to see if it matches the local signature. When a matching
-signature is found the associated signing certificate will be used to validate
-that the signature matches the artifact.
+This will use the signing certificate to ensure that the SHA256 digest
+encoded in the supplied signature matches the digest of the package itself.
+A future iteration of the verification logic will also find and verify
+the corresponding entry in the Rekor log.
 
 [1]: https://github.com/sigstore/rekor

--- a/src/dsse.test.ts
+++ b/src/dsse.test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 import nock from 'nock';
 import * as dsse from './dsse';
-import { base64Encode } from './util';
+import { base64Decode } from './util';
 
 describe('sign', () => {
   const fulcioBaseURL = 'http://localhost:8001';
@@ -152,112 +152,36 @@ describe('verify', () => {
   const signingCert =
     'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNvVENDQWlhZ0F3SUJBZ0lVTnRkVUhHWjZWLzRUNE9QdjE1end6NTZubUZJd0NnWUlLb1pJemowRUF3TXcKTnpFVk1CTUdBMVVFQ2hNTWMybG5jM1J2Y21VdVpHVjJNUjR3SEFZRFZRUURFeFZ6YVdkemRHOXlaUzFwYm5SbApjbTFsWkdsaGRHVXdIaGNOTWpJd056RTBNak16TURFd1doY05Nakl3TnpFME1qTTBNREV3V2pBQU1Ga3dFd1lICktvWkl6ajBDQVFZSUtvWkl6ajBEQVFjRFFnQUVOcFVMeHF3VHVUaDMxRndBTUt2Nkg1SURFZWRjUmJSL3RyVEwKc2RIOW1JMWJwSVR3OXB5S2RYZ3VuT2NoMEpaT2ZpSUR5ZlVRK2xTdDhOdG56Rzk1U3FPQ0FVVXdnZ0ZCTUE0RwpBMVVkRHdFQi93UUVBd0lIZ0RBVEJnTlZIU1VFRERBS0JnZ3JCZ0VGQlFjREF6QWRCZ05WSFE0RUZnUVVRellTCmdTTzhtbTFrdHpTSWdrVEhack1ZNXo4d0h3WURWUjBqQkJnd0ZvQVUzOVBwejFZa0VaYjVxTmpwS0ZXaXhpNFkKWkQ4d0h3WURWUjBSQVFIL0JCVXdFNEVSWW5KcFlXNUFaR1ZvWVcxbGNpNWpiMjB3TEFZS0t3WUJCQUdEdnpBQgpBUVFlYUhSMGNITTZMeTluYVhSb2RXSXVZMjl0TDJ4dloybHVMMjloZFhSb01JR0tCZ29yQmdFRUFkWjVBZ1FDCkJId0VlZ0I0QUhZQUNHQ1M4Q2hTLzJoRjBkRnJKNFNjUldjWXJCWTl3empTYmVhOElnWTJiM0lBQUFHQi93eGgKeVFBQUJBTUFSekJGQWlFQXZ1TitHVTZzdUdteWRHZ2F4RG9tQkRUSDJyS21FVm5sMzNuLy82a1NpeElDSUdxVQphTk51VFhSclBuaFg5NkxwRThwanZZRzE5dkcvbS9FSmZWMmRGQ0FJTUFvR0NDcUdTTTQ5QkFNREEya0FNR1lDCk1RRHhMNFZENVkvU3BiQU4vYlVQTTF5Zkd0NjRiZUN4NS8vYTJHQ3pxbzBza2gxeTU1NTlxNFVxd2lLTVhzdnUKVW1jQ01RQytEOEtiNVF0bXNIVnBTWjhycXhaRDlmazI0cWlmb3hKdXZyUHFjMDVaVzRIVlRJdDFOeG5CNWRiTwpOWmgybnBBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQpNSUlDR2pDQ0FhR2dBd0lCQWdJVUFMblZpVmZuVTBickphc21Sa0hybi9VbmZhUXdDZ1lJS29aSXpqMEVBd013CktqRVZNQk1HQTFVRUNoTU1jMmxuYzNSdmNtVXVaR1YyTVJFd0R3WURWUVFERXdoemFXZHpkRzl5WlRBZUZ3MHkKTWpBME1UTXlNREEyTVRWYUZ3MHpNVEV3TURVeE16VTJOVGhhTURjeEZUQVRCZ05WQkFvVERITnBaM04wYjNKbApMbVJsZGpFZU1Cd0dBMVVFQXhNVmMybG5jM1J2Y21VdGFXNTBaWEp0WldScFlYUmxNSFl3RUFZSEtvWkl6ajBDCkFRWUZLNEVFQUNJRFlnQUU4UlZTL3lzSCtOT3Z1RFp5UEladGlsZ1VGOU5sYXJZcEFkOUhQMXZCQkgxVTVDVjcKN0xTUzdzMFppSDRuRTdIdjdwdFM2THZ2Ui9TVGs3OThMVmdNekxsSjRIZUlmRjN0SFNhZXhMY1lwU0FTcjFrUwowTi9SZ0JKei85aldDaVhubzNzd2VUQU9CZ05WSFE4QkFmOEVCQU1DQVFZd0V3WURWUjBsQkF3d0NnWUlLd1lCCkJRVUhBd013RWdZRFZSMFRBUUgvQkFnd0JnRUIvd0lCQURBZEJnTlZIUTRFRmdRVTM5UHB6MVlrRVpiNXFOanAKS0ZXaXhpNFlaRDh3SHdZRFZSMGpCQmd3Rm9BVVdNQWVYNUZGcFdhcGVzeVFvWk1pMENyRnhmb3dDZ1lJS29aSQp6ajBFQXdNRFp3QXdaQUl3UENzUUs0RFlpWllEUElhRGk1SEZLbmZ4WHg2QVNTVm1FUmZzeW5ZQmlYMlg2U0pSCm5aVTg0LzlEWmRuRnZ2eG1BakJPdDZRcEJsYzRKLzBEeHZrVENxcGNsdnppTDZCQ0NQbmpkbElCM1B1M0J4c1AKbXlnVVk3SWkyemJkQ2RsaWlvdz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQotLS0tLUJFR0lOIENFUlRJRklDQVRFLS0tLS0KTUlJQjl6Q0NBWHlnQXdJQkFnSVVBTFpOQVBGZHhIUHdqZURsb0R3eVlDaEFPLzR3Q2dZSUtvWkl6ajBFQXdNdwpLakVWTUJNR0ExVUVDaE1NYzJsbmMzUnZjbVV1WkdWMk1SRXdEd1lEVlFRREV3aHphV2R6ZEc5eVpUQWVGdzB5Ck1URXdNRGN4TXpVMk5UbGFGdzB6TVRFd01EVXhNelUyTlRoYU1Db3hGVEFUQmdOVkJBb1RESE5wWjNOMGIzSmwKTG1SbGRqRVJNQThHQTFVRUF4TUljMmxuYzNSdmNtVXdkakFRQmdjcWhrak9QUUlCQmdVcmdRUUFJZ05pQUFUNwpYZUZUNHJiM1BRR3dTNElhanRMazMvT2xucGdhbmdhQmNsWXBzWUJyNWkrNHluQjA3Y2ViM0xQME9JT1pkeGV4Clg2OWM1aVZ1eUpSUStIejA1eWkrVUYzdUJXQWxIcGlTNXNoMCtIMkdIRTdTWHJrMUVDNW0xVHIxOUw5Z2c5MmoKWXpCaE1BNEdBMVVkRHdFQi93UUVBd0lCQmpBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUIwR0ExVWREZ1FXQkJSWQp3QjVma1VXbFpxbDZ6SkNoa3lMUUtzWEYrakFmQmdOVkhTTUVHREFXZ0JSWXdCNWZrVVdsWnFsNnpKQ2hreUxRCktzWEYrakFLQmdncWhrak9QUVFEQXdOcEFEQm1BakVBajFuSGVYWnArMTNOV0JOYStFRHNEUDhHMVdXZzF0Q00KV1AvV0hQcXBhVm8wamhzd2VORlpnU3MwZUU3d1lJNHFBakVBMldCOW90OThzSWtvRjN2WllkZDMvVnRXQjViOQpUTk1lYTdJeC9zdEo1VGZjTExlQUJMRTRCTkpPc1E0dm5CSEoKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==';
 
-  // Digest for the PAE struct wrapping the payload
-  const paeHash =
-    '82e6b1b8dc9151f27992e4b7c88b4b3ed26068fe73138595f013a912d62166ba';
-
-  const envelope = {
-    payloadType: 'text/plain',
-    payload: payload.toString('base64'),
-    signatures: [{ keyid: '', sig: signature }],
-  };
-
-  describe('when a matching entry is found in Rekor', () => {
-    // Rekor output
-    const uuid = 'a0b1c2d3e4f5';
-
-    const signatureBundle = {
-      spec: {
-        signature: {
-          content: signature,
-          publicKey: { content: signingCert },
-        },
-      },
+  describe('when the signature and the cert match', () => {
+    const envelope = {
+      payloadType: 'text/plain',
+      payload: payload.toString('base64'),
+      signatures: [{ keyid: '', sig: signature }],
     };
-
-    const rekorEntry = {
-      [uuid]: {
-        body: base64Encode(JSON.stringify(signatureBundle)),
-      },
-    };
-
-    beforeEach(() => {
-      // Mock the lookup of the artifact digest in Rekor
-      nock(rekorBaseURL)
-        .matchHeader('Accept', 'application/json')
-        .matchHeader('Content-Type', 'application/json')
-        .post('/api/v1/index/retrieve', {
-          hash: `sha256:${paeHash}`,
-        })
-        .reply(200, [uuid]);
-
-      // Mock the lookup of the Rekor entry
-      nock(rekorBaseURL)
-        .matchHeader('Accept', 'application/json')
-        .get(`/api/v1/log/entries/${uuid}`)
-        .reply(200, rekorEntry);
-    });
 
     it('returns true', async () => {
-      const flag = await dsse.verify(envelope, options);
+      const flag = await dsse.verify(
+        envelope,
+        base64Decode(signingCert),
+        options
+      );
       expect(flag).toBe(true);
     });
   });
 
-  describe('when artifact digest is NOT found in Rekor', () => {
-    beforeEach(() => {
-      // Mock the lookup of the artifact digest in Rekor
-      nock(rekorBaseURL)
-        .matchHeader('Accept', 'application/json')
-        .matchHeader('Content-Type', 'application/json')
-        .post('/api/v1/index/retrieve', {
-          hash: `sha256:${paeHash}`,
-        })
-        .reply(200, []);
-    });
-
-    it('returns false', async () => {
-      const flag = await dsse.verify(envelope, options);
-      expect(flag).toBe(false);
-    });
-  });
-
-  describe('when artifact signature is NOT found in Rekor', () => {
-    // Rekor output
-    const uuid = 'a0b1c2d3e4f5';
-
-    const signatureBundle = {
-      spec: {
-        signature: {
-          content: 'ABC123',
-          publicKey: { content: signingCert },
-        },
-      },
+  describe('when the signature and the do NOT cert match', () => {
+    const envelope = {
+      payloadType: 'text/plain',
+      payload: payload.toString('base64'),
+      signatures: [{ keyid: '', sig: '' }],
     };
 
-    const rekorEntry = {
-      [uuid]: {
-        body: base64Encode(JSON.stringify(signatureBundle)),
-      },
-    };
-
-    beforeEach(() => {
-      // Mock the lookup of the artifact digest in Rekor
-      nock(rekorBaseURL)
-        .matchHeader('Accept', 'application/json')
-        .matchHeader('Content-Type', 'application/json')
-        .post('/api/v1/index/retrieve', { hash: `sha256:${paeHash}` })
-        .reply(200, [uuid]);
-
-      // Mock the lookup of the Rekor entry
-      nock(rekorBaseURL)
-        .matchHeader('Accept', 'application/json')
-        .get(`/api/v1/log/entries/${uuid}`)
-        .reply(200, rekorEntry);
-    });
-
     it('returns false', async () => {
-      const flag = await dsse.verify(envelope, options);
+      const flag = await dsse.verify(
+        envelope,
+        base64Decode(signingCert),
+        options
+      );
       expect(flag).toBe(false);
     });
   });

--- a/src/dsse.ts
+++ b/src/dsse.ts
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import { KeyLike } from 'crypto';
 import * as sigstore from './sigstore';
 
 export interface Signature {
@@ -50,6 +51,7 @@ export async function sign(
 
 export async function verify(
   envelope: Envelope,
+  certificate: KeyLike,
   options: sigstore.VerifierOptions = {}
 ): Promise<boolean> {
   const payloadType = envelope.payloadType;
@@ -57,7 +59,12 @@ export async function verify(
   const signature = envelope.signatures[0].sig;
 
   const paeBuffer = pae(payloadType, payload);
-  const verified = await sigstore.verify(paeBuffer, signature, options);
+  const verified = await sigstore.verify(
+    paeBuffer,
+    signature,
+    certificate,
+    options
+  );
 
   return verified;
 }

--- a/src/sigstore.test.ts
+++ b/src/sigstore.test.ts
@@ -71,6 +71,7 @@ describe('sign', () => {
 describe('#verify', () => {
   const payload = Buffer.from('Hello, world!');
   const signature = 'a1b2c3';
+  const cert = 'cert';
 
   const mockVerify = jest.fn();
 
@@ -81,13 +82,13 @@ describe('#verify', () => {
   });
 
   it('invokes the Verifier instance with the correct params', async () => {
-    await verify(payload, signature);
+    await verify(payload, signature, cert);
 
-    expect(mockVerify).toHaveBeenCalledWith(payload, signature);
+    expect(mockVerify).toHaveBeenCalledWith(payload, signature, cert);
   });
 
   it('returns the value returned by the verifier', async () => {
-    const result = await verify(payload, signature);
+    const result = await verify(payload, signature, cert);
     expect(result).toBe(false);
   });
 });

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import { KeyLike } from 'crypto';
 import { Fulcio, Rekor } from './client';
 import identity, { Provider } from './identity';
 import { SignedPayload, Signer } from './sign';
@@ -54,11 +55,12 @@ export async function sign(
 export async function verify(
   payload: Buffer,
   signature: string,
+  certificate: KeyLike,
   options: VerifierOptions = {}
 ): Promise<boolean> {
   const rekor = new Rekor({ baseURL: options.rekorBaseURL });
 
-  return new Verifier({ rekor }).verify(payload, signature);
+  return new Verifier({ rekor }).verify(payload, signature, certificate);
 }
 
 // Translates the IdenityProviderOptions into a list of Providers which

--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -13,12 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import nock from 'nock';
-
-import { Verifier } from './verify';
-import { hash } from './crypto';
-import { base64Decode, base64Encode } from './util';
 import { Rekor } from './client';
+import { base64Decode } from './util';
+import { Verifier } from './verify';
 
 describe('Verifier', () => {
   const rekorBaseURL = 'http://localhost:8002';
@@ -34,127 +31,27 @@ describe('Verifier', () => {
     const signingCert =
       'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN1RENDQWoyZ0F3SUJBZ0lVVmV0U01RemZUbXVrTTlDSnV0KytId3AvWThzd0NnWUlLb1pJemowRUF3TXcKTnpFVk1CTUdBMVVFQ2hNTWMybG5jM1J2Y21VdVpHVjJNUjR3SEFZRFZRUURFeFZ6YVdkemRHOXlaUzFwYm5SbApjbTFsWkdsaGRHVXdIaGNOTWpJd05qQTRNVGN3TXpFeVdoY05Nakl3TmpBNE1UY3hNekV5V2pBQU1Ga3dFd1lICktvWkl6ajBDQVFZSUtvWkl6ajBEQVFjRFFnQUV0T2N5a0lMREVTVDNwN2JkZ24zMjYyS1pWSXlHL0F2SDl6ZG0KUVdDMXlpR2tVV2ZqVVF5aCtWSTVselEyQXFxdVR3QlFYZDdCcDRlaFFwYzRYaVpqQTZPQ0FWd3dnZ0ZZTUE0RwpBMVVkRHdFQi93UUVBd0lIZ0RBVEJnTlZIU1VFRERBS0JnZ3JCZ0VGQlFjREF6QWRCZ05WSFE0RUZnUVVKWi8xCmRpTEhENDNvdUhneWhrcnF6QnRFTGt3d0h3WURWUjBqQkJnd0ZvQVUzOVBwejFZa0VaYjVxTmpwS0ZXaXhpNFkKWkQ4d09RWURWUjBSQVFIL0JDOHdMWUVyWVhKMGMybG5ibVZ5UUdSbGFHRnRaWEl5TkM1cFlXMHVaM05sY25acApZMlZoWTJOdmRXNTBMbU52YlRBcEJnb3JCZ0VFQVlPL01BRUJCQnRvZEhSd2N6b3ZMMkZqWTI5MWJuUnpMbWR2CmIyZHNaUzVqYjIwd2dZb0dDaXNHQVFRQjFua0NCQUlFZkFSNkFIZ0FkZ0FJWUpMd0tGTC9hRVhSMFdzbmhKeEYKWnhpc0ZqM0RPTkp0NXJ3aUJqWnZjZ0FBQVlGRVJTak1BQUFFQXdCSE1FVUNJUURRYUNLYlhtTnBqWDExSVVhZwpoNk5DbWtsaURwR3pBTXdEY0xaWHYzVUdyd0lnY29zNGZqR1RiOGFEb2NhNk9FOEowNEJWYko1VzB1OHNyU1FjCjF6bDdhd0F3Q2dZSUtvWkl6ajBFQXdNRGFRQXdaZ0l4QUpERlc4bGJDVUhPL1Qzb0Z2TVc3WXhYQlBWdXM2UjkKN0xhY0N4aE9zbHpYWUFhMXdtWks0VXlnTHZFS3pITER1Z0l4QVBpRlI2RWtBRWtCYkJzQ2Q4aU1xZ3R0Rmp1QQpaQURrWjFiTGdaU1VPSEVyVjUvMGluZDFaSGtNcnE1ZHJDeFpvUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K';
 
-    describe('when a certificate is supplied', () => {
-      describe('when the signature and the cert match', () => {
-        it('returns true', async () => {
-          const verified = await subject.verify(
-            payload,
-            signature,
-            base64Decode(signingCert)
-          );
+    describe('when the signature and the cert match', () => {
+      it('returns true', async () => {
+        const verified = await subject.verify(
+          payload,
+          signature,
+          base64Decode(signingCert)
+        );
 
-          expect(verified).toBe(true);
-        });
-      });
-
-      describe('when the signature and the cert do NOT match', () => {
-        it('returns false', async () => {
-          const verified = await subject.verify(
-            payload,
-            '',
-            base64Decode(signingCert)
-          );
-
-          expect(verified).toBe(false);
-        });
+        expect(verified).toBe(true);
       });
     });
 
-    describe('when a certificate is NOT supplied', () => {
-      describe('when a matching entry is found in Rekor', () => {
-        // Rekor output
-        const uuid = 'a0b1c2d3e4f5';
+    describe('when the signature and the cert do NOT match', () => {
+      it('returns false', async () => {
+        const verified = await subject.verify(
+          payload,
+          '',
+          base64Decode(signingCert)
+        );
 
-        const signatureBundle = {
-          spec: {
-            signature: {
-              content: signature,
-              publicKey: { content: signingCert },
-            },
-          },
-        };
-
-        const rekorEntry = {
-          [uuid]: {
-            body: base64Encode(JSON.stringify(signatureBundle)),
-          },
-        };
-
-        beforeEach(() => {
-          // Mock the lookup of the artifact digest in Rekor
-          nock(rekorBaseURL)
-            .matchHeader('Accept', 'application/json')
-            .matchHeader('Content-Type', 'application/json')
-            .post('/api/v1/index/retrieve', { hash: `sha256:${hash(payload)}` })
-            .reply(200, [uuid]);
-
-          // Mock the lookup of the Rekor entry
-          nock(rekorBaseURL)
-            .matchHeader('Accept', 'application/json')
-            .get(`/api/v1/log/entries/${uuid}`)
-            .reply(200, rekorEntry);
-        });
-
-        it('returns true', async () => {
-          const flag = await subject.verify(payload, signature);
-          expect(flag).toBe(true);
-        });
-      });
-
-      describe('when artifact digest is NOT found in Rekor', () => {
-        beforeEach(() => {
-          // Mock the lookup of the artifact digest in Rekor
-          nock(rekorBaseURL)
-            .matchHeader('Accept', 'application/json')
-            .matchHeader('Content-Type', 'application/json')
-            .post('/api/v1/index/retrieve', { hash: `sha256:${hash(payload)}` })
-            .reply(200, []);
-        });
-
-        it('returns false', async () => {
-          const flag = await subject.verify(payload, signature);
-          expect(flag).toBe(false);
-        });
-      });
-
-      describe('when artifact signature is NOT found in Rekor', () => {
-        // Rekor output
-        const uuid = 'a0b1c2d3e4f5';
-
-        const signatureBundle = {
-          spec: {
-            signature: {
-              content: 'ABC123',
-              publicKey: { content: signingCert },
-            },
-          },
-        };
-
-        const rekorEntry = {
-          [uuid]: {
-            body: base64Encode(JSON.stringify(signatureBundle)),
-          },
-        };
-
-        beforeEach(() => {
-          // Mock the lookup of the artifact digest in Rekor
-          nock(rekorBaseURL)
-            .matchHeader('Accept', 'application/json')
-            .matchHeader('Content-Type', 'application/json')
-            .post('/api/v1/index/retrieve', { hash: `sha256:${hash(payload)}` })
-            .reply(200, [uuid]);
-
-          // Mock the lookup of the Rekor entry
-          nock(rekorBaseURL)
-            .matchHeader('Accept', 'application/json')
-            .get(`/api/v1/log/entries/${uuid}`)
-            .reply(200, rekorEntry);
-        });
-
-        it('returns false', async () => {
-          const flag = await subject.verify(payload, signature);
-          expect(flag).toBe(false);
-        });
+        expect(verified).toBe(false);
       });
     });
   });

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -32,22 +32,15 @@ export class Verifier {
   public async verify(
     payload: Buffer,
     signature: string,
-    certificate?: KeyLike
+    certificate: KeyLike
   ): Promise<boolean> {
     signature = signature.trim();
 
-    if (!certificate) {
-      certificate = await this.lookupCertificate(payload, signature);
-    }
-
-    if (certificate) {
-      return verifyBlob(certificate, payload, signature);
-    } else {
-      return false;
-    }
+    return verifyBlob(certificate, payload, signature);
   }
 
-  // Find certificate in Rekor log
+  // TODO: come back and clean this up. Currently unused but may be useful when
+  // we introduce verification against the Rekor log.
   private async lookupCertificate(
     payload: Buffer,
     signature: string


### PR DESCRIPTION
Closes #36 

**Summary**
Updates the `sigstore.verify` function to make the signing certificate a required parameter. Previously, we were searching the Rekor log to retrieve the signing certificate, but this is not the recommended approach.

There is a lot more to be done as part of the verify workflow -- currently, there is verification against the Rekor log at all (either offline or online). We'll come back and address this in a separate PR.

**Release Notes**
* `sigstore.verify` now requires the signing certificate be passed as a parameter
* `dsse.verify` now requires the signing certificate be passed as a parameter
* `Verifier.verify` no longer searches Rekor to find the signing certificate
* The `sign` CLI command now saves the Fulcio-issued signing certificate so it can be saved for verification purposes
* The `verify` CLI command now requires the path to a file containing the signing certificate be supplied
* README update with new instructions for using `sign` and `verify`.

