### PR TITLE
add intoto support to rekor client

### DIFF
--- a/src/client/rekor.test.ts
+++ b/src/client/rekor.test.ts
@@ -180,7 +180,7 @@ describe('Rekor', () => {
         .reply(201, responseBody);
     });
 
-    it('submits a new hashedrekor entry', async () => {
+    it('submits a new intoto entry', async () => {
       const result = await subject.createIntoEntry({ envelope, publicKey });
       expect(result.uuid).toBe(uuid);
     });

--- a/src/client/rekor.test.ts
+++ b/src/client/rekor.test.ts
@@ -143,7 +143,7 @@ describe('Rekor', () => {
         .reply(201, responseBody);
     });
 
-    it('submits a new intoto entry', async () => {
+    it('submits a new hashedrekor entry', async () => {
       const result = await subject.createHashedRekordEntry({
         artifactDigest,
         artifactSignature,

--- a/src/client/rekor.test.ts
+++ b/src/client/rekor.test.ts
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { ProposedEntry, Rekor } from './rekor';
 import nock from 'nock';
+import { HashedRekordKind, Rekor } from './rekor';
 
 describe('Rekor', () => {
   const baseURL = 'http://localhost:8080';
@@ -25,13 +25,26 @@ describe('Rekor', () => {
   });
 
   describe('#createEntry', () => {
-    const proposedEntry: ProposedEntry = {
-      artifactSignature:
-        'MEUCIDB2SWDabztSC8RrlfRCWUf04LBN0E2CEwiDZJLacDS8AiEA3bQHMBpodxA3dvJ+JK1SALkuzju/w4oCg3S89c8CtN8=',
-      artifactDigest:
-        '1c025a6e48ceb8bf10e01b367089732326eabe3541d03d348724c79040382c65',
-      certificate:
-        'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K',
+    const proposedEntry: HashedRekordKind = {
+      apiVersion: '0.0.1',
+      kind: 'hashedrekord',
+      spec: {
+        data: {
+          hash: {
+            algorithm: 'sha256',
+            value:
+              '1c025a6e48ceb8bf10e01b367089732326eabe3541d03d348724c79040382c65',
+          },
+        },
+        signature: {
+          content:
+            'MEUCIDB2SWDabztSC8RrlfRCWUf04LBN0E2CEwiDZJLacDS8AiEA3bQHMBpodxA3dvJ+JK1SALkuzju/w4oCg3S89c8CtN8=',
+          publicKey: {
+            content:
+              'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K',
+          },
+        },
+      },
     };
 
     describe('when the entry is successfully added', () => {
@@ -86,6 +99,90 @@ describe('Rekor', () => {
           'HTTP Error: 409 Conflict'
         );
       });
+    });
+  });
+
+  describe('#createIntoEntry', () => {
+    const artifactDigest =
+      '1c025a6e48ceb8bf10e01b367089732326eabe3541d03d348724c79040382c65';
+    const artifactSignature =
+      'MEUCIDB2SWDabztSC8RrlfRCWUf04LBN0E2CEwiDZJLacDS8AiEA3bQHMBpodxA3dvJ+JK1SALkuzju/w4oCg3S89c8CtN8=';
+    const publicKey =
+      'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K';
+
+    const proposedEntry = {
+      apiVersion: '0.0.1',
+      kind: 'hashedrekord',
+      spec: {
+        data: {
+          hash: {
+            algorithm: 'sha256',
+            value: artifactDigest,
+          },
+        },
+        signature: {
+          content: artifactSignature,
+          publicKey: {
+            content: publicKey,
+          },
+        },
+      },
+    };
+
+    const uuid =
+      '69e5a0c1663ee4452674a5c9d5050d866c2ee31e2faaf79913aea7cc27293cf6';
+    const responseBody = {
+      [uuid]: {},
+    };
+
+    beforeEach(() => {
+      nock(baseURL)
+        .matchHeader('Accept', 'application/json')
+        .matchHeader('Content-Type', 'application/json')
+        .post('/api/v1/log/entries', proposedEntry)
+        .reply(201, responseBody);
+    });
+
+    it('submits a new intoto entry', async () => {
+      const result = await subject.createHashedRekordEntry({
+        artifactDigest,
+        artifactSignature,
+        publicKey,
+      });
+      expect(result.uuid).toBe(uuid);
+    });
+  });
+
+  describe('#createHashedRekordEntry', () => {
+    const envelope = 'some envelope';
+    const publicKey = 'a1b2c3';
+
+    const proposedEntry = {
+      apiVersion: '0.0.1',
+      kind: 'intoto',
+      spec: {
+        content: { envelope },
+        publicKey,
+      },
+    };
+
+    const uuid =
+      '69e5a0c1663ee4452674a5c9d5050d866c2ee31e2faaf79913aea7cc27293cf6';
+    const responseBody = {
+      [uuid]: {},
+    };
+
+    beforeEach(() => {
+      nock(baseURL)
+        .matchHeader('Accept', 'application/json')
+        .matchHeader('Content-Type', 'application/json')
+        .post('/api/v1/log/entries', proposedEntry)
+        .reply(201, responseBody);
+    });
+
+    it('submits a new hashedrekor entry', async () => {
+      const result = await subject.createIntoEntry({ envelope, publicKey });
+      expect(result.uuid).toBe(uuid);
     });
   });
 
@@ -164,7 +261,7 @@ describe('Rekor', () => {
     });
   });
 
-  describe('#search', () => {
+  describe('#searchIndex', () => {
     describe('when matching entries exist', () => {
       const sha =
         'sha256:04c0c13721a28c60f38daf09a05326c301a2cf57ad2beb953eb29d61383db47e';
@@ -179,7 +276,7 @@ describe('Rekor', () => {
       });
 
       it('returns matching entries', async () => {
-        const response = await subject.searchLog({ hash: sha });
+        const response = await subject.searchIndex({ hash: sha });
         expect(response).toEqual(responseBody);
       });
     });
@@ -195,7 +292,7 @@ describe('Rekor', () => {
         const sha =
           'sha256:04c0c13721a28c60f38daf09a05326c301a2cf57ad2beb953eb29d61383db47e';
 
-        const response = await subject.searchLog({ hash: sha });
+        const response = await subject.searchIndex({ hash: sha });
 
         expect(response).toEqual([]);
       });

--- a/src/client/rekor.test.ts
+++ b/src/client/rekor.test.ts
@@ -102,7 +102,7 @@ describe('Rekor', () => {
     });
   });
 
-  describe('#createIntoEntry', () => {
+  describe('#createHashedRekordEntry', () => {
     const artifactDigest =
       '1c025a6e48ceb8bf10e01b367089732326eabe3541d03d348724c79040382c65';
     const artifactSignature =
@@ -153,7 +153,7 @@ describe('Rekor', () => {
     });
   });
 
-  describe('#createHashedRekordEntry', () => {
+  describe('#createIntoEntry', () => {
     const envelope = 'some envelope';
     const publicKey = 'a1b2c3';
 

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -87,10 +87,10 @@ export class Signer {
     const digest = hash(payload);
 
     // Create Rekor entry
-    const entry = await this.rekor.createEntry({
+    const entry = await this.rekor.createHashedRekordEntry({
       artifactDigest: digest,
       artifactSignature: signature,
-      certificate: b64Certificate,
+      publicKey: b64Certificate,
     });
 
     console.error(`Created entry at index ${entry.logIndex}, available at`);

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -56,7 +56,7 @@ export class Verifier {
     const digest = hash(payload);
 
     // Look-up Rekor entries by artifact digest
-    const uuids = await this.rekor.searchLog({ hash: `sha256:${digest}` });
+    const uuids = await this.rekor.searchIndex({ hash: `sha256:${digest}` });
 
     let b64Cert;
     // Find Rekor entry with matching artifact signature


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the `Rekor` client to support "intoto" entry uploads. Previously, the only entry kind that the client knew how to deal with was "hashrekord". The changes here lay the groundwork for supporting all of the various entry kinds in the future but is primarily focused on the "hashrekord" and "intoto" kinds for now.

#### Release Note

* Updates the `Rekor.createEntry` function to support creating entries of any kind.
* Adds a new `Rekor.createIntotoEntry` convenience function.
* Adds a new `Rekor.createHashedRekordEntry` convenience function.
* Renames the `Rekor.searchLog` function to `Rekor.searchIndex` to better reflect which API is being wrapped.
