### PR TITLE
Re-add logging of Rekor entry index and url

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -47,6 +47,10 @@ async function sign(artifactPath: string) {
   const buffer = fs.readFileSync(artifactPath);
   const bundle = await sigstore.sign(buffer, signOptions);
   console.log(JSON.stringify(bundle));
+
+  const url = `${sigstore.getRekorBaseUrl(signOptions)}/api/v1/log/entries`;
+  console.error(`Created entry at index ${bundle.logIndex}, available at`);
+  console.error(`${url}?logIndex=${bundle.logIndex}`);
 }
 
 async function signDSSE(

--- a/src/client/rekor.ts
+++ b/src/client/rekor.ts
@@ -136,7 +136,11 @@ export class Rekor {
         'User-Agent': getUserAgent(),
       },
     });
-    this.baseUrl = options.baseURL ?? DEFAULT_BASE_URL;
+    this.baseUrl = Rekor.getBaseUrl(options.baseURL);
+  }
+
+  public static getBaseUrl(baseURL?: string) {
+    return baseURL ?? DEFAULT_BASE_URL;
   }
 
   /**

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -33,6 +33,10 @@ export interface VerifierOptions {
   rekorBaseURL?: string;
 }
 
+export function getRekorBaseUrl(options?: SignOptions) {
+  return Rekor.getBaseUrl(options?.rekorBaseURL);
+}
+
 type IdentityProviderOptions = Pick<
   SignOptions,
   'identityToken' | 'oidcIssuer' | 'oidcClientID' | 'oidcClientSecret'


### PR DESCRIPTION
#### Summary
Currently, the README.md file refers to output from the sign command:
```console
Created entry at index 2698234, available at
https://rekor.sigstore.dev/api/v1/log/entries/43553c769...
```
It looks like this output was removed in Commit bd596c0eccd6104589e596c34936a6c46a2e30ae ("proper signing/verification for attestations").

This commit suggest re-adding this output as I was not sure how to get
to this information otherwise. I'm very new to this code base but
hopefully someone can provide some feedback if there are other ways,
or if the README.md should be updated instead.


#### Release Note
N/A

#### Documentation
N/A

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>


