### PR TITLE
Update sign/verify to take the bundle as json

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-node_modules
-dist
-**/__generated__

--- a/.lintignore
+++ b/.lintignore
@@ -1,0 +1,4 @@
+**/__generated__
+dist
+node_modules
+src/__snapshots__

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:ci": "jest --maxWorkers=2 --coverage",
-    "lint": "eslint --fix --ext .ts src/**",
-    "lint:check": "eslint --max-warnings 0 --ext .ts src/**",
-    "format": "prettier --write \"src/**/*\"",
+    "lint": "eslint --fix --ignore-path .lintignore --ext .ts src",
+    "lint:check": "eslint --ignore-path .lintignore --max-warnings 0 --ext .ts src",
+    "format": "prettier --write --ignore-path .lintignore \"src\"",
     "codegen:bundle": "./hack/generate-bundle-types",
     "codegen:rekor": "./hack/generate-rekor-types"
   },

--- a/src/__snapshots__/sigstore.test.ts.snap
+++ b/src/__snapshots__/sigstore.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sign returns the correct envelope 1`] = `"{\\"mediaType\\":\\"application/vnd.dev.sigstore.bundle+json;version=0.1\\",\\"timestampVerificationData\\":{\\"tlogEntries\\":[],\\"rfc3161Timestamps\\":[]},\\"verificationMaterial\\":{\\"x509CertificateChain\\":{\\"certificates\\":[]}},\\"messageSignature\\":{\\"messageDigest\\":{\\"algorithm\\":\\"SHA2_256\\",\\"digest\\":\\"\\"},\\"signature\\":\\"\\"}}"`;
+
+exports[`signAttestation returns the correct envelope 1`] = `"{\\"mediaType\\":\\"application/vnd.dev.sigstore.bundle+json;version=0.1\\",\\"timestampVerificationData\\":{\\"tlogEntries\\":[],\\"rfc3161Timestamps\\":[]},\\"verificationMaterial\\":{\\"x509CertificateChain\\":{\\"certificates\\":[]}},\\"dsseEnvelope\\":{\\"payload\\":\\"\\",\\"payloadType\\":\\"text/json\\",\\"signatures\\":[{\\"sig\\":\\"\\",\\"keyid\\":\\"key-123\\"}]}}"`;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import fs from 'fs';
-import { Bundle } from '../types/bundle';
 import { sigstore } from '../index';
 
 const INTOTO_PAYLOAD_TYPE = 'application/vnd.in-toto+json';
@@ -42,15 +41,14 @@ const signOptions = {
 
 async function sign(artifactPath: string) {
   const buffer = fs.readFileSync(artifactPath);
-  const bundleJson = await sigstore.sign(buffer, signOptions);
+  const bundle: any = await sigstore.sign(buffer, signOptions); //eslint-disable-line @typescript-eslint/no-explicit-any
 
   const url = `${sigstore.getRekorBaseUrl(signOptions)}/api/v1/log/entries`;
-  const bundle = Bundle.fromJSON(JSON.parse(bundleJson));
   const logIndex = bundle.timestampVerificationData?.tlogEntries[0].logIndex;
   console.error(`Created entry at index ${logIndex}, available at`);
   console.error(`${url}?logIndex=${logIndex}`);
 
-  console.log(bundleJson);
+  console.log(JSON.stringify(bundle));
 }
 
 async function signDSSE(
@@ -74,7 +72,10 @@ async function verify(bundlePath: string, artifactPath: string) {
   }
 
   const bundleFile = fs.readFileSync(bundlePath);
-  const result = await sigstore.verify(bundleFile.toString('utf-8'), payload);
+  const result = await sigstore.verify(
+    JSON.parse(bundleFile.toString('utf-8')),
+    payload
+  );
 
   if (result) {
     console.error('Verified OK');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -42,14 +42,15 @@ const signOptions = {
 
 async function sign(artifactPath: string) {
   const buffer = fs.readFileSync(artifactPath);
-  const bundle = await sigstore.sign(buffer, signOptions);
+  const bundleJson = await sigstore.sign(buffer, signOptions);
 
   const url = `${sigstore.getRekorBaseUrl(signOptions)}/api/v1/log/entries`;
+  const bundle = Bundle.fromJSON(JSON.parse(bundleJson));
   const logIndex = bundle.timestampVerificationData?.tlogEntries[0].logIndex;
   console.error(`Created entry at index ${logIndex}, available at`);
   console.error(`${url}?logIndex=${logIndex}`);
 
-  console.log(JSON.stringify(Bundle.toJSON(bundle)));
+  console.log(bundleJson);
 }
 
 async function signDSSE(
@@ -57,12 +58,12 @@ async function signDSSE(
   payloadType = INTOTO_PAYLOAD_TYPE
 ) {
   const buffer = fs.readFileSync(artifactPath);
-  const bundle = await sigstore.signAttestation(
+  const bundleJson = await sigstore.signAttestation(
     buffer,
     payloadType,
     signOptions
   );
-  console.log(JSON.stringify(Bundle.toJSON(bundle)));
+  console.log(bundleJson);
 }
 
 async function verify(bundlePath: string, artifactPath: string) {
@@ -73,9 +74,7 @@ async function verify(bundlePath: string, artifactPath: string) {
   }
 
   const bundleFile = fs.readFileSync(bundlePath);
-  const bundle = Bundle.fromJSON(JSON.parse(bundleFile.toString('utf-8')));
-
-  const result = await sigstore.verify(bundle, payload);
+  const result = await sigstore.verify(bundleFile.toString('utf-8'), payload);
 
   if (result) {
     console.error('Verified OK');

--- a/src/sigstore.test.ts
+++ b/src/sigstore.test.ts
@@ -24,9 +24,30 @@ describe('sign', () => {
   const payload = Buffer.from('Hello, world!');
 
   // Signer output
-  const signedPayload = {
-    base64Signature: 'signature',
-    cert: 'cert',
+  const signedPayload: Bundle = {
+    mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.1',
+    content: {
+      $case: 'messageSignature',
+      messageSignature: {
+        messageDigest: {
+          algorithm: HashAlgorithm.SHA2_256,
+          digest: Buffer.from(''),
+        },
+        signature: Buffer.from(''),
+      },
+    },
+    timestampVerificationData: {
+      rfc3161Timestamps: [],
+      tlogEntries: [],
+    },
+    verificationMaterial: {
+      content: {
+        $case: 'x509CertificateChain',
+        x509CertificateChain: {
+          certificates: [],
+        },
+      },
+    },
   };
 
   const mockSigner = jest.mocked(Signer);
@@ -65,8 +86,7 @@ describe('sign', () => {
 
   it('returns the correct envelope', async () => {
     const sig = await sign(payload);
-
-    expect(sig).toEqual(signedPayload);
+    expect(sig).toMatchSnapshot();
   });
 });
 
@@ -76,8 +96,32 @@ describe('signAttestation', () => {
 
   // Signer output
   const signedPayload = {
-    base64Signature: 'signature',
-    cert: 'cert',
+    mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.1',
+    content: {
+      $case: 'dsseEnvelope',
+      dsseEnvelope: {
+        payload: Buffer.from(''),
+        payloadType: 'text/json',
+        signatures: [
+          {
+            sig: Buffer.from(''),
+            keyid: 'key-123',
+          },
+        ],
+      },
+    },
+    timestampVerificationData: {
+      rfc3161Timestamps: [],
+      tlogEntries: [],
+    },
+    verificationMaterial: {
+      content: {
+        $case: 'x509CertificateChain',
+        x509CertificateChain: {
+          certificates: [],
+        },
+      },
+    },
   };
 
   const mockSigner = jest.mocked(Signer);
@@ -118,8 +162,7 @@ describe('signAttestation', () => {
 
   it('returns the correct envelope', async () => {
     const sig = await signAttestation(payload, payloadType);
-
-    expect(sig).toEqual(signedPayload);
+    expect(sig).toMatchSnapshot();
   });
 });
 
@@ -149,6 +192,7 @@ describe('#verify', () => {
       },
     },
   };
+  const bundleJson = JSON.stringify(Bundle.toJSON(bundle));
 
   const mockVerify = jest.fn();
 
@@ -159,12 +203,12 @@ describe('#verify', () => {
   });
 
   it('invokes the Verifier instance with the correct params', async () => {
-    await verify(bundle);
+    await verify(bundleJson);
     expect(mockVerify).toHaveBeenCalledWith(bundle, undefined);
   });
 
   it('returns the value returned by the verifier', async () => {
-    const result = await verify(bundle);
+    const result = await verify(bundleJson);
     expect(result).toBe(false);
   });
 });

--- a/src/sigstore.test.ts
+++ b/src/sigstore.test.ts
@@ -86,7 +86,7 @@ describe('sign', () => {
 
   it('returns the correct envelope', async () => {
     const sig = await sign(payload);
-    expect(sig).toMatchSnapshot();
+    expect(JSON.stringify(sig)).toMatchSnapshot();
   });
 });
 
@@ -162,7 +162,7 @@ describe('signAttestation', () => {
 
   it('returns the correct envelope', async () => {
     const sig = await signAttestation(payload, payloadType);
-    expect(sig).toMatchSnapshot();
+    expect(JSON.stringify(sig)).toMatchSnapshot();
   });
 });
 
@@ -192,7 +192,6 @@ describe('#verify', () => {
       },
     },
   };
-  const bundleJson = JSON.stringify(Bundle.toJSON(bundle));
 
   const mockVerify = jest.fn();
 
@@ -203,12 +202,13 @@ describe('#verify', () => {
   });
 
   it('invokes the Verifier instance with the correct params', async () => {
-    await verify(bundleJson);
+    const b = Bundle.toJSON(bundle);
+    await verify(b);
     expect(mockVerify).toHaveBeenCalledWith(bundle, undefined);
   });
 
   it('returns the value returned by the verifier', async () => {
-    const result = await verify(bundleJson);
+    const result = await verify(Bundle.toJSON(bundle));
     expect(result).toBe(false);
   });
 });

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -44,41 +44,49 @@ type IdentityProviderOptions = Pick<
 export async function sign(
   payload: Buffer,
   options: SignOptions = {}
-): Promise<Bundle> {
+): Promise<string> {
   const fulcio = new Fulcio({ baseURL: options.fulcioBaseURL });
   const rekor = new Rekor({ baseURL: options.rekorBaseURL });
   const idps = configureIdentityProviders(options);
+  console.log('Signed payload: ', payload);
 
-  return new Signer({
-    fulcio,
-    rekor,
-    identityProviders: idps,
-  }).signBlob(payload);
+  return new Signer({ fulcio, rekor, identityProviders: idps })
+    .signBlob(payload)
+    .then((bundle: Bundle) => {
+      console.log('Signed bundle: ', bundle);
+
+      return JSON.stringify(Bundle.toJSON(bundle))
+    });
 }
 
 export async function signAttestation(
   payload: Buffer,
   payloadType: string,
   options: SignOptions = {}
-): Promise<Bundle> {
+): Promise<string> {
   const fulcio = new Fulcio({ baseURL: options.fulcioBaseURL });
   const rekor = new Rekor({ baseURL: options.rekorBaseURL });
   const idps = configureIdentityProviders(options);
 
-  return new Signer({
-    fulcio,
-    rekor,
-    identityProviders: idps,
-  }).signAttestation(payload, payloadType);
+  return new Signer({ fulcio, rekor, identityProviders: idps })
+    .signAttestation(payload, payloadType)
+    .then((bundle: Bundle) => {
+      console.log('Signed bundle: ', JSON.stringify(Bundle.toJSON(bundle)));
+
+      return JSON.stringify(Bundle.toJSON(bundle))
+    });
 }
 
 export async function verify(
-  bundle: Bundle,
+  bundle: string,
   data?: Buffer,
   options: VerifierOptions = {}
 ): Promise<boolean> {
   const rekor = new Rekor({ baseURL: options.rekorBaseURL });
-  return new Verifier({ rekor }).verify(bundle, data);
+  return new Verifier({ rekor }).verify(
+    Bundle.fromJSON(JSON.parse(bundle)),
+    data
+  );
 }
 
 // Translates the IdenityProviderOptions into a list of Providers which

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -44,40 +44,37 @@ type IdentityProviderOptions = Pick<
 export async function sign(
   payload: Buffer,
   options: SignOptions = {}
-): Promise<string> {
+): Promise<unknown> {
   const fulcio = new Fulcio({ baseURL: options.fulcioBaseURL });
   const rekor = new Rekor({ baseURL: options.rekorBaseURL });
   const idps = configureIdentityProviders(options);
 
   return new Signer({ fulcio, rekor, identityProviders: idps })
     .signBlob(payload)
-    .then((bundle: Bundle) => JSON.stringify(Bundle.toJSON(bundle)));
+    .then((bundle: Bundle) => Bundle.toJSON(bundle));
 }
 
 export async function signAttestation(
   payload: Buffer,
   payloadType: string,
   options: SignOptions = {}
-): Promise<string> {
+): Promise<unknown> {
   const fulcio = new Fulcio({ baseURL: options.fulcioBaseURL });
   const rekor = new Rekor({ baseURL: options.rekorBaseURL });
   const idps = configureIdentityProviders(options);
 
   return new Signer({ fulcio, rekor, identityProviders: idps })
     .signAttestation(payload, payloadType)
-    .then((bundle: Bundle) => JSON.stringify(Bundle.toJSON(bundle)));
+    .then((bundle: Bundle) => Bundle.toJSON(bundle));
 }
 
 export async function verify(
-  bundle: string,
+  bundle: unknown,
   data?: Buffer,
   options: VerifierOptions = {}
 ): Promise<boolean> {
   const rekor = new Rekor({ baseURL: options.rekorBaseURL });
-  return new Verifier({ rekor }).verify(
-    Bundle.fromJSON(JSON.parse(bundle)),
-    data
-  );
+  return new Verifier({ rekor }).verify(Bundle.fromJSON(bundle), data);
 }
 
 // Translates the IdenityProviderOptions into a list of Providers which

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -48,7 +48,6 @@ export async function sign(
   const fulcio = new Fulcio({ baseURL: options.fulcioBaseURL });
   const rekor = new Rekor({ baseURL: options.rekorBaseURL });
   const idps = configureIdentityProviders(options);
-  console.log('Signed payload: ', payload);
 
   return new Signer({ fulcio, rekor, identityProviders: idps })
     .signBlob(payload)

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -52,11 +52,7 @@ export async function sign(
 
   return new Signer({ fulcio, rekor, identityProviders: idps })
     .signBlob(payload)
-    .then((bundle: Bundle) => {
-      console.log('Signed bundle: ', bundle);
-
-      return JSON.stringify(Bundle.toJSON(bundle))
-    });
+    .then((bundle: Bundle) => JSON.stringify(Bundle.toJSON(bundle)));
 }
 
 export async function signAttestation(
@@ -70,11 +66,7 @@ export async function signAttestation(
 
   return new Signer({ fulcio, rekor, identityProviders: idps })
     .signAttestation(payload, payloadType)
-    .then((bundle: Bundle) => {
-      console.log('Signed bundle: ', JSON.stringify(Bundle.toJSON(bundle)));
-
-      return JSON.stringify(Bundle.toJSON(bundle))
-    });
+    .then((bundle: Bundle) => JSON.stringify(Bundle.toJSON(bundle)));
 }
 
 export async function verify(


### PR DESCRIPTION
#### Summary

Updated the `sign/signAttestation/verify` library methods to take and return the bundle file as json to match the format on disk.

With the current interface a caller would be forced to convert the json to the Bundle object format which seems like an implementation detail. I ran into this implementing bundle verification in npm where we want to use the `Sigstore.verify` method to verify the bundle.

Opening up for comments/feedback.

#### Release Note

* **BREAKING CHANGES**
  * `sigstore.sign(...): Promise<Bundle> > sigstore.sign(...): Promise<object>`: Promise returns a json object where it previously returned a Bundle object
  * `sigstore.signAttestation(...): Promise<Bundle> > sigstore.signAttestation(...): Promise<object>`: Promise returns a json object where it previously returned a Bundle object
  * `sigstore.verify(bundle: Bundle, data?: Buffer, options: {}) > sigstore.verify(bundle: object, data?: Buffer, options: {})`: Verify now takes a the bundle as json object instead of a Bundle object

Signed-off-by: Philip Harrison <philip@mailharrison.com>
