### PR TITLE
Add basic help and version command line option

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,9 +30,35 @@ async function cli(args: string[]) {
     case 'verify':
       await verify(args[1], args[2]);
       break;
+    case 'version':
+    case '-version':
+    case '--version':
+    case '-v':
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      console.log(require('../../package.json').version);
+      break;
+    case 'help':
+    case '--help':
+    case '-h':
+    case '-?':
+      printUsage();
+      break;
     default:
       throw 'Unknown command';
   }
+}
+
+function printUsage() {
+  console.log(`sigstore <command> <artifact>
+
+  Usage:
+
+  sigstore sign         sign an artifact
+  sigstore sign-dsse    sign an artifact using dsse (Dead Simple Signing Envelope)
+  sigstore verify       verify an artifact
+  sigstore version      print version information
+  sigstore help         print help information
+  `);
 }
 
 const signOptions = {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
This commit adds very basic command line `help` and `version` command line options.

The motivation for this that I tried running sigstore --help out of habit but that returned `Unknown command`. Perhaps others will do this same and this commit could be a start of adding more options/details.
This can be tested using the following commands:
```console
$ npm run build
$ ./bin/sigstore.js --help
sigstore <command> <artifact>

  Usage:

  sigstore sign         sign an artifact
  sigstore sign-dsse    sign an artifact using dsse (Dead Simple Signing Envelope)
  sigstore verify       verify an artifact
  
```
Perhaps this can be expanded upon and cleaned up by using a module like yargs, but I was not sure if adding a dependency would be considered ok, and if there might be preferences of which module to use in that case.


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
None

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
None