### PR TITLE
Update supported node engines

### DIFF
--- a/.github/workflows/build-sign-verify.yml
+++ b/.github/workflows/build-sign-verify.yml
@@ -30,12 +30,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 12.13.0
-          - 12.x
-          - 14.15.0
+          - 14.17.0
           - 14.x
-          - 16.0.0
+          - 16.13.0
           - 16.x
+          - 18.0.0
+          - 18.x
         platform:
           - os: ubuntu-latest
             shell: bash


### PR DESCRIPTION
Update supported node versions to match npm/cli v9: `^14.17.0 || ^16.0.0 || >=18.0.0`

## References
- [BREAKING CHANGE(engines): engines support for npm 9.0.0](https://github.com/npm/statusboard/issues/519)
- [Related npm/cli change](https://github.com/npm/cli/commit/457d388c9a70b4bc6c2421f576c79fb7524ff259)

Signed-off-by: Philip Harrison <philip@mailharrison.com>
