### PR TITLE
Support custom signer callback

### DIFF
--- a/src/sign.test.ts
+++ b/src/sign.test.ts
@@ -17,6 +17,7 @@ import nock from 'nock';
 import { Fulcio, Rekor } from './client';
 import { Signer } from './sign';
 import { HashAlgorithm } from './types/bundle';
+import { SignatureMaterial, SignerFunc } from './types/signature';
 import { pem } from './util';
 
 describe('Signer', () => {
@@ -46,170 +47,24 @@ describe('Signer', () => {
     // Input
     const payload = Buffer.from('Hello, world!');
 
-    describe('when no identity provider returns a token', () => {
-      const noIDTokenSubject = new Signer({
-        fulcio,
-        rekor,
-        identityProviders: [],
-      });
-
-      it('throws an error', async () => {
-        await expect(noIDTokenSubject.signBlob(payload)).rejects.toThrow(
-          'Identity token providers failed: '
-        );
-      });
-    });
-
-    describe('when Fulcio returns an error', () => {
-      beforeEach(() => {
-        nock(fulcioBaseURL).post('/api/v1/signingCert').reply(500, {});
-      });
-
-      it('returns an error', async () => {
-        await expect(subject.signBlob(payload)).rejects.toThrow(
-          'HTTP Error: 500 Internal Server Error'
-        );
-      });
-    });
-
-    describe('when Fulcio returns successfully', () => {
-      // Fulcio output
-      const leafCertificate = `-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----`;
-      const rootCertificate = `-----BEGIN CERTIFICATE-----\nxyz\n-----END CERTIFICATE-----`;
-      const certificate = [leafCertificate, rootCertificate].join('\n');
-
-      beforeEach(() => {
-        // Mock Fulcio request
-        nock(fulcioBaseURL)
-          .matchHeader('Accept', 'application/pem-certificate-chain')
-          .matchHeader('Content-Type', 'application/json')
-          .matchHeader('Authorization', `Bearer ${jwt}`)
-          .post('/api/v1/signingCert', {
-            publicKey: { content: /.+/i },
-            signedEmailAddress: /.+/i,
-          })
-          .reply(200, certificate);
-      });
-
-      describe('when Rekor returns successfully', () => {
-        // Rekor output
-        const signature = 'ABC123';
-        const b64Cert = Buffer.from(certificate).toString('base64');
-        const uuid =
-          '69e5a0c1663ee4452674a5c9d5050d866c2ee31e2faaf79913aea7cc27293cf6';
-
-        const signatureBundle = {
-          kind: 'hashedrekord',
-          apiVersion: '0.0.1',
-          spec: {
-            signature: {
-              content: signature,
-              publicKey: { content: b64Cert },
-            },
-          },
-        };
-
-        const rekorEntry = {
-          [uuid]: {
-            body: Buffer.from(JSON.stringify(signatureBundle)).toString(
-              'base64'
-            ),
-            integratedTime: 1654015743,
-            logID:
-              'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d',
-            logIndex: 2513258,
-            verification: {
-              signedEntryTimestamp:
-                'MEUCIQD6CD7ZNLUipFoxzmSL/L8Ewic4SRkXN77UjfJZ7d/wAAIgatokSuX9Rg0iWxAgSfHMtcsagtDCQalU5IvXdQ+yLEA=',
-            },
-          },
-        };
-
-        beforeEach(() => {
-          // Mock Rekor request
-          nock(rekorBaseURL)
-            .matchHeader('Accept', 'application/json')
-            .matchHeader('Content-Type', 'application/json')
-            .post('/api/v1/log/entries')
-            .reply(201, rekorEntry);
+    describe('when using the default signer', () => {
+      describe('when no identity provider returns a token', () => {
+        const noIDTokenSubject = new Signer({
+          fulcio,
+          rekor,
+          identityProviders: [],
         });
 
-        it('returns a signature bundle', async () => {
-          const bundle = await subject.signBlob(payload);
-
-          expect(bundle).toBeTruthy();
-          expect(bundle.mediaType).toEqual(
-            'application/vnd.dev.sigstore.bundle+json;version=0.1'
+        it('throws an error', async () => {
+          await expect(noIDTokenSubject.signBlob(payload)).rejects.toThrow(
+            'Identity token providers failed: '
           );
-
-          if (bundle.content?.$case === 'messageSignature') {
-            const ms = bundle.content.messageSignature;
-            expect(ms.messageDigest).toBeTruthy();
-            expect(ms.messageDigest?.algorithm).toEqual(HashAlgorithm.SHA2_256);
-            expect(ms.messageDigest?.digest).toBeTruthy();
-            expect(ms.signature).toBeTruthy();
-          } else {
-            fail('Expected messageSignature');
-          }
-
-          // Verification material
-          if (
-            bundle.verificationMaterial?.content?.$case ===
-            'x509CertificateChain'
-          ) {
-            const chain =
-              bundle.verificationMaterial.content.x509CertificateChain;
-            expect(chain).toBeTruthy();
-            expect(chain.certificates).toHaveLength(2);
-            expect(chain.certificates[0].derBytes).toEqual(
-              pem.toDER(leafCertificate)
-            );
-            expect(chain.certificates[1].derBytes).toEqual(
-              pem.toDER(rootCertificate)
-            );
-          } else {
-            fail('Expected x509CertificateChain');
-          }
-
-          // Timestamp verification data
-          expect(bundle.verificationData).toBeTruthy();
-          expect(
-            bundle.verificationData?.timestampVerificationData
-          ).toBeTruthy();
-          expect(
-            bundle.verificationData?.timestampVerificationData
-              ?.rfc3161Timestamps
-          ).toHaveLength(0);
-          expect(bundle.verificationData?.tlogEntries).toHaveLength(1);
-
-          const tlog = bundle.verificationData?.tlogEntries[0];
-          expect(tlog?.inclusionPromise).toBeTruthy();
-          expect(tlog?.inclusionPromise?.signedEntryTimestamp).toBeTruthy();
-          expect(
-            tlog?.inclusionPromise?.signedEntryTimestamp.toString('base64')
-          ).toEqual(rekorEntry[uuid].verification.signedEntryTimestamp);
-          expect(tlog?.integratedTime).toEqual(
-            rekorEntry[uuid].integratedTime.toString()
-          );
-          expect(tlog?.logId).toBeTruthy();
-          expect(tlog?.logId?.keyId).toBeTruthy();
-          expect(tlog?.logId?.keyId.toString('hex')).toEqual(
-            rekorEntry[uuid].logID
-          );
-          expect(tlog?.logIndex).toEqual(rekorEntry[uuid].logIndex.toString());
-          expect(tlog?.inclusionProof).toBeFalsy();
-          expect(tlog?.kindVersion?.kind).toEqual('hashedrekord');
-          expect(tlog?.kindVersion?.version).toEqual('0.0.1');
         });
       });
 
-      describe('when Rekor returns an error', () => {
+      describe('when Fulcio returns an error', () => {
         beforeEach(() => {
-          nock(rekorBaseURL)
-            .matchHeader('Accept', 'application/json')
-            .matchHeader('Content-Type', 'application/json')
-            .post('/api/v1/log/entries')
-            .reply(500, {});
+          nock(fulcioBaseURL).post('/api/v1/signingCert').reply(500, {});
         });
 
         it('returns an error', async () => {
@@ -217,6 +72,192 @@ describe('Signer', () => {
             'HTTP Error: 500 Internal Server Error'
           );
         });
+      });
+
+      describe('when Fulcio returns successfully', () => {
+        // Fulcio output
+        const leafCertificate = `-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----`;
+        const rootCertificate = `-----BEGIN CERTIFICATE-----\nxyz\n-----END CERTIFICATE-----`;
+        const certificate = [leafCertificate, rootCertificate].join('\n');
+
+        beforeEach(() => {
+          // Mock Fulcio request
+          nock(fulcioBaseURL)
+            .matchHeader('Accept', 'application/pem-certificate-chain')
+            .matchHeader('Content-Type', 'application/json')
+            .matchHeader('Authorization', `Bearer ${jwt}`)
+            .post('/api/v1/signingCert', {
+              publicKey: { content: /.+/i },
+              signedEmailAddress: /.+/i,
+            })
+            .reply(200, certificate);
+        });
+
+        describe('when Rekor returns successfully', () => {
+          // Rekor output
+          const signature = 'ABC123';
+          const b64Cert = Buffer.from(certificate).toString('base64');
+          const uuid =
+            '69e5a0c1663ee4452674a5c9d5050d866c2ee31e2faaf79913aea7cc27293cf6';
+
+          const signatureBundle = {
+            kind: 'hashedrekord',
+            apiVersion: '0.0.1',
+            spec: {
+              signature: {
+                content: signature,
+                publicKey: { content: b64Cert },
+              },
+            },
+          };
+
+          const rekorEntry = {
+            [uuid]: {
+              body: Buffer.from(JSON.stringify(signatureBundle)).toString(
+                'base64'
+              ),
+              integratedTime: 1654015743,
+              logID:
+                'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d',
+              logIndex: 2513258,
+              verification: {
+                signedEntryTimestamp:
+                  'MEUCIQD6CD7ZNLUipFoxzmSL/L8Ewic4SRkXN77UjfJZ7d/wAAIgatokSuX9Rg0iWxAgSfHMtcsagtDCQalU5IvXdQ+yLEA=',
+              },
+            },
+          };
+
+          beforeEach(() => {
+            // Mock Rekor request
+            nock(rekorBaseURL)
+              .matchHeader('Accept', 'application/json')
+              .matchHeader('Content-Type', 'application/json')
+              .post('/api/v1/log/entries')
+              .reply(201, rekorEntry);
+          });
+
+          it('returns a signature bundle', async () => {
+            const bundle = await subject.signBlob(payload);
+
+            expect(bundle).toBeTruthy();
+            expect(bundle.mediaType).toEqual(
+              'application/vnd.dev.sigstore.bundle+json;version=0.1'
+            );
+
+            if (bundle.content?.$case === 'messageSignature') {
+              const ms = bundle.content.messageSignature;
+              expect(ms.messageDigest).toBeTruthy();
+              expect(ms.messageDigest?.algorithm).toEqual(
+                HashAlgorithm.SHA2_256
+              );
+              expect(ms.messageDigest?.digest).toBeTruthy();
+              expect(ms.signature).toBeTruthy();
+            } else {
+              fail('Expected messageSignature');
+            }
+
+            // Verification material
+            if (
+              bundle.verificationMaterial?.content?.$case ===
+              'x509CertificateChain'
+            ) {
+              const chain =
+                bundle.verificationMaterial.content.x509CertificateChain;
+              expect(chain).toBeTruthy();
+              expect(chain.certificates).toHaveLength(2);
+              expect(chain.certificates[0].derBytes).toEqual(
+                pem.toDER(leafCertificate)
+              );
+              expect(chain.certificates[1].derBytes).toEqual(
+                pem.toDER(rootCertificate)
+              );
+            } else {
+              fail('Expected x509CertificateChain');
+            }
+
+            // Timestamp verification data
+            expect(bundle.verificationData).toBeTruthy();
+            expect(
+              bundle.verificationData?.timestampVerificationData
+            ).toBeTruthy();
+            expect(
+              bundle.verificationData?.timestampVerificationData
+                ?.rfc3161Timestamps
+            ).toHaveLength(0);
+            expect(bundle.verificationData?.tlogEntries).toHaveLength(1);
+
+            const tlog = bundle.verificationData?.tlogEntries[0];
+            expect(tlog?.inclusionPromise).toBeTruthy();
+            expect(tlog?.inclusionPromise?.signedEntryTimestamp).toBeTruthy();
+            expect(
+              tlog?.inclusionPromise?.signedEntryTimestamp.toString('base64')
+            ).toEqual(rekorEntry[uuid].verification.signedEntryTimestamp);
+            expect(tlog?.integratedTime).toEqual(
+              rekorEntry[uuid].integratedTime.toString()
+            );
+            expect(tlog?.logId).toBeTruthy();
+            expect(tlog?.logId?.keyId).toBeTruthy();
+            expect(tlog?.logId?.keyId.toString('hex')).toEqual(
+              rekorEntry[uuid].logID
+            );
+            expect(tlog?.logIndex).toEqual(
+              rekorEntry[uuid].logIndex.toString()
+            );
+            expect(tlog?.inclusionProof).toBeFalsy();
+            expect(tlog?.kindVersion?.kind).toEqual('hashedrekord');
+            expect(tlog?.kindVersion?.version).toEqual('0.0.1');
+          });
+        });
+
+        describe('when Rekor returns an error', () => {
+          beforeEach(() => {
+            nock(rekorBaseURL)
+              .matchHeader('Accept', 'application/json')
+              .matchHeader('Content-Type', 'application/json')
+              .post('/api/v1/log/entries')
+              .reply(500, {});
+          });
+
+          it('returns an error', async () => {
+            await expect(subject.signBlob(payload)).rejects.toThrow(
+              'HTTP Error: 500 Internal Server Error'
+            );
+          });
+        });
+      });
+    });
+
+    describe('when using a custom signer', () => {
+      const sigMaterial: SignatureMaterial = {
+        signature: Buffer.from('ABC123'),
+        certificates: undefined,
+        key: {
+          id: 'key-id',
+          value: 'key-value',
+        },
+      };
+
+      const signer = jest.fn().mockResolvedValueOnce(sigMaterial) as SignerFunc;
+
+      beforeEach(() => {
+        nock(rekorBaseURL)
+          .matchHeader('Accept', 'application/json')
+          .matchHeader('Content-Type', 'application/json')
+          .post('/api/v1/log/entries')
+          .reply(500, {});
+      });
+
+      it('invokes the custom signer', async () => {
+        const s = new Signer({
+          fulcio,
+          rekor,
+          identityProviders: [],
+          signer,
+        });
+
+        // await expect(s.signBlob(payload)).rejects.toThrow();
+        await expect(s.signBlob(payload)).rejects.toThrow();
+        expect(signer).toHaveBeenCalledWith(payload);
       });
     });
   });

--- a/src/types/bundle/index.test.ts
+++ b/src/types/bundle/index.test.ts
@@ -16,10 +16,18 @@ limitations under the License.
 import { encoding as enc, pem } from '../../util';
 import { Envelope, HashAlgorithm } from '../bundle';
 import { Entry } from '../rekor';
+import { SignatureMaterial } from '../signature';
 import { bundle } from './index';
 
 describe('bundle', () => {
+  const signature = Buffer.from('signature');
   const certificate = `-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----`;
+
+  const sigMaterial: SignatureMaterial = {
+    signature,
+    certificates: [certificate],
+    key: undefined,
+  };
 
   describe('toDSSEBundle', () => {
     const envelope: Envelope = {
@@ -28,7 +36,7 @@ describe('bundle', () => {
       signatures: [
         {
           keyid: '',
-          sig: Buffer.from('signature'),
+          sig: signature,
         },
       ],
     };
@@ -56,7 +64,7 @@ describe('bundle', () => {
     };
 
     it('returns a valid DSSE bundle', () => {
-      const b = bundle.toDSSEBundle(envelope, [certificate], rekorEntry);
+      const b = bundle.toDSSEBundle(envelope, sigMaterial, rekorEntry);
 
       expect(b).toBeTruthy();
       expect(b.mediaType).toEqual(
@@ -106,7 +114,6 @@ describe('bundle', () => {
 
   describe('toMessageSignatureBundle', () => {
     const digest = Buffer.from('digest');
-    const signature = Buffer.from('signature');
 
     const entryKind = {
       kind: 'hashedrekord',
@@ -133,8 +140,7 @@ describe('bundle', () => {
     it('returns a valid message signature bundle', () => {
       const b = bundle.toMessageSignatureBundle(
         digest,
-        signature,
-        [certificate],
+        sigMaterial,
         rekorEntry
       );
 

--- a/src/types/rekor/index.test.ts
+++ b/src/types/rekor/index.test.ts
@@ -15,10 +15,17 @@ limitations under the License.
 */
 import { crypto, encoding as enc } from '../../util';
 import { Envelope } from '../bundle';
+import { SignatureMaterial } from '../signature';
 import { rekor } from './index';
 
 describe('request', () => {
   const cert = '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----';
+  const signature = Buffer.from('signature');
+  const sigMaterial: SignatureMaterial = {
+    signature: signature,
+    certificates: [cert],
+    key: undefined,
+  };
 
   describe('toProposedIntotoEntry', () => {
     const envelope: Envelope = {
@@ -27,13 +34,13 @@ describe('request', () => {
       signatures: [
         {
           keyid: '',
-          sig: Buffer.from('signature'),
+          sig: signature,
         },
       ],
     };
 
     it('returns a valid intoto entry', () => {
-      const entry = rekor.toProposedIntotoEntry(envelope, cert);
+      const entry = rekor.toProposedIntotoEntry(envelope, sigMaterial);
 
       expect(entry.apiVersion).toEqual('0.0.2');
       expect(entry.kind).toEqual('intoto');
@@ -70,7 +77,7 @@ describe('request', () => {
     const signature = Buffer.from('signature');
 
     it('returns a valid hashedrekord entry', () => {
-      const entry = rekor.toProposedHashedRekordEntry(digest, signature, cert);
+      const entry = rekor.toProposedHashedRekordEntry(digest, sigMaterial);
 
       expect(entry.apiVersion).toEqual('0.0.1');
       expect(entry.kind).toEqual('hashedrekord');

--- a/src/types/signature.ts
+++ b/src/types/signature.ts
@@ -1,0 +1,17 @@
+import { OneOf } from './utility';
+
+interface VerificationMaterial {
+  certificates: string[];
+  key: {
+    id?: string;
+    value: string;
+  };
+}
+
+// Result of signing some artifact. Containing the signature and either the
+// signing certificate chain or the public key.
+export type SignatureMaterial = {
+  signature: Buffer;
+} & OneOf<VerificationMaterial>;
+
+export type SignerFunc = (payload: Buffer) => Promise<SignatureMaterial>;


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Updates the `Signer` class to support a user-provided `SignerFunc` which is responsible for generating and returning an artifact signature. If no `SignerFunc` is provided, it defaults to using the standard ephemeral keypair w/ Fulcio certificate signing scheme.

Allowing for a a custom signing function allows us to support scenarios where a user may want to use something like a KMS key to generate a signature which still utilizing the rest of the Sigstore workflow (upload to Rekor, bundle creation, etc).

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note

Lays the foundation for user-supplied signing functions. Note that this isn't yet exposed as part of the package's public interface. Will add that in a subsequent commit.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

