### PR TITLE
Expose new addEnvelopToTransparencyLog function

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -63,13 +63,14 @@ function printUsage() {
 const signOptions = {
   oidcClientID: 'sigstore',
   oidcIssuer: 'https://oauth2.sigstore.dev/auth',
+  rekorBaseURL: sigstore.DEFAULT_REKOR_BASE_URL,
 };
 
 async function sign(artifactPath: string) {
   const buffer = fs.readFileSync(artifactPath);
   const bundle = await sigstore.sign(buffer, signOptions);
 
-  const url = `${sigstore.getRekorBaseUrl(signOptions)}/api/v1/log/entries`;
+  const url = `${signOptions.rekorBaseURL}/api/v1/log/entries`;
   const logIndex = bundle.verificationData?.tlogEntries[0].logIndex;
   console.error(`Created entry at index ${logIndex}, available at`);
   console.error(`${url}?logIndex=${logIndex}`);

--- a/src/client/rekor.ts
+++ b/src/client/rekor.ts
@@ -18,11 +18,9 @@ import { Entry, EntryKind } from '../types/rekor';
 import { ua } from '../util';
 import { checkStatus } from './error';
 
-const DEFAULT_BASE_URL = 'https://rekor.sigstore.dev';
-
 // Client options
 export interface RekorOptions {
-  baseURL?: string;
+  baseURL: string;
 }
 
 export interface SearchIndex {
@@ -52,11 +50,8 @@ export class Rekor {
         'User-Agent': ua.getUserAgent(),
       },
     });
-    this.baseUrl = Rekor.getBaseUrl(options.baseURL);
-  }
 
-  public static getBaseUrl(baseURL?: string) {
-    return baseURL ?? DEFAULT_BASE_URL;
+    this.baseUrl = options.baseURL;
   }
 
   /**

--- a/src/sign.test.ts
+++ b/src/sign.test.ts
@@ -14,8 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import nock from 'nock';
-import { Fulcio, Rekor } from './client';
+import { Fulcio } from './client';
 import { Signer } from './sign';
+import { TLogClient } from './tlog';
 import { HashAlgorithm } from './types/bundle';
 import { SignatureMaterial, SignerFunc } from './types/signature';
 import { pem } from './util';
@@ -30,12 +31,12 @@ describe('Signer', () => {
   const jwt = `.${Buffer.from(JSON.stringify(jwtPayload)).toString('base64')}.`;
 
   const fulcio = new Fulcio({ baseURL: fulcioBaseURL });
-  const rekor = new Rekor({ baseURL: rekorBaseURL });
+  const tlog = new TLogClient({ rekorBaseURL });
   const idp = { getToken: () => Promise.resolve(jwt) };
 
   const subject = new Signer({
     fulcio,
-    rekor,
+    tlog,
     identityProviders: [idp],
   });
 
@@ -51,7 +52,7 @@ describe('Signer', () => {
       describe('when no identity provider returns a token', () => {
         const noIDTokenSubject = new Signer({
           fulcio,
-          rekor,
+          tlog,
           identityProviders: [],
         });
 
@@ -250,7 +251,7 @@ describe('Signer', () => {
       it('invokes the custom signer', async () => {
         const s = new Signer({
           fulcio,
-          rekor,
+          tlog,
           identityProviders: [],
           signer,
         });

--- a/src/sigstore.test.ts
+++ b/src/sigstore.test.ts
@@ -110,7 +110,7 @@ describe('sign', () => {
 
     // Signer was constructed with the correct options
     expect(options).toHaveProperty('fulcio', expect.anything());
-    expect(options).toHaveProperty('rekor', expect.anything());
+    expect(options).toHaveProperty('tlog', expect.anything());
     expect(options.identityProviders).toHaveLength(1);
   });
 
@@ -182,7 +182,7 @@ describe('signAttestation', () => {
 
     // Signer was constructed with the correct options
     expect(options).toHaveProperty('fulcio', expect.anything());
-    expect(options).toHaveProperty('rekor', expect.anything());
+    expect(options).toHaveProperty('tlog', expect.anything());
     expect(options.identityProviders).toHaveLength(1);
   });
 

--- a/src/tlog/index.test.ts
+++ b/src/tlog/index.test.ts
@@ -1,0 +1,325 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import nock from 'nock';
+import { Envelope, HashAlgorithm } from '../types/bundle';
+import { rekor } from '../types/rekor';
+import { SignatureMaterial } from '../types/signature';
+import { pem } from '../util';
+import { TLogClient } from './index';
+
+describe('TLogClient', () => {
+  const baseURL = 'http://localhost:8080';
+
+  describe('constructor', () => {
+    it('should create a new instance', () => {
+      const client = new TLogClient({ rekorBaseURL: baseURL });
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe('createMessageSignatureEntry', () => {
+    const subject = new TLogClient({ rekorBaseURL: baseURL });
+
+    const digest = Buffer.from('digest');
+
+    const leafCertificate = `-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----`;
+    const rootCertificate = `-----BEGIN CERTIFICATE-----\nxyz\n-----END CERTIFICATE-----`;
+
+    const sigMaterial: SignatureMaterial = {
+      signature: Buffer.from('signature'),
+      certificates: [leafCertificate, rootCertificate],
+      key: undefined,
+    };
+
+    // Rekor input
+    const proposedEntry = JSON.stringify(
+      rekor.toProposedHashedRekordEntry(digest, sigMaterial)
+    );
+
+    describe('when Rekor returns an error', () => {
+      beforeEach(() => {
+        nock(baseURL)
+          .matchHeader('Accept', 'application/json')
+          .matchHeader('Content-Type', 'application/json')
+          .post('/api/v1/log/entries', proposedEntry)
+          .reply(500, {});
+      });
+
+      it('returns an error', async () => {
+        await expect(
+          subject.createMessageSignatureEntry(digest, sigMaterial)
+        ).rejects.toThrow('HTTP Error: 500 Internal Server Error');
+      });
+    });
+
+    describe('when Rekor returns a valid response', () => {
+      // Rekor output
+      const b64Cert = Buffer.from(leafCertificate).toString('base64');
+      const uuid =
+        '69e5a0c1663ee4452674a5c9d5050d866c2ee31e2faaf79913aea7cc27293cf6';
+
+      const signatureBundle = {
+        kind: 'hashedrekord',
+        apiVersion: '0.0.1',
+        spec: {
+          signature: {
+            content: sigMaterial.signature.toString('hex'),
+            publicKey: { content: b64Cert },
+          },
+        },
+      };
+
+      const rekorEntry = {
+        [uuid]: {
+          body: Buffer.from(JSON.stringify(signatureBundle)).toString('base64'),
+          integratedTime: 1654015743,
+          logID:
+            'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d',
+          logIndex: 2513258,
+          verification: {
+            signedEntryTimestamp:
+              'MEUCIQD6CD7ZNLUipFoxzmSL/L8Ewic4SRkXN77UjfJZ7d/wAAIgatokSuX9Rg0iWxAgSfHMtcsagtDCQalU5IvXdQ+yLEA=',
+          },
+        },
+      };
+
+      beforeEach(() => {
+        // Mock Rekor request
+        nock(baseURL)
+          .matchHeader('Accept', 'application/json')
+          .matchHeader('Content-Type', 'application/json')
+          .post('/api/v1/log/entries', proposedEntry)
+          .reply(201, rekorEntry);
+      });
+
+      it('returns a signature bundle', async () => {
+        const bundle = await subject.createMessageSignatureEntry(
+          digest,
+          sigMaterial
+        );
+
+        expect(bundle).toBeTruthy();
+        expect(bundle.mediaType).toEqual(
+          'application/vnd.dev.sigstore.bundle+json;version=0.1'
+        );
+
+        if (bundle.content?.$case === 'messageSignature') {
+          const ms = bundle.content.messageSignature;
+          expect(ms.messageDigest).toBeTruthy();
+          expect(ms.messageDigest?.algorithm).toEqual(HashAlgorithm.SHA2_256);
+          expect(ms.messageDigest?.digest).toBeTruthy();
+          expect(ms.signature).toBeTruthy();
+        } else {
+          fail('Expected messageSignature');
+        }
+
+        // Verification material
+        if (
+          bundle.verificationMaterial?.content?.$case === 'x509CertificateChain'
+        ) {
+          const chain =
+            bundle.verificationMaterial.content.x509CertificateChain;
+          expect(chain).toBeTruthy();
+          expect(chain.certificates).toHaveLength(2);
+          expect(chain.certificates[0].derBytes).toEqual(
+            pem.toDER(leafCertificate)
+          );
+          expect(chain.certificates[1].derBytes).toEqual(
+            pem.toDER(rootCertificate)
+          );
+        } else {
+          fail('Expected x509CertificateChain');
+        }
+
+        // Timestamp verification data
+        expect(bundle.verificationData).toBeTruthy();
+        expect(bundle.verificationData?.timestampVerificationData).toBeTruthy();
+        expect(
+          bundle.verificationData?.timestampVerificationData?.rfc3161Timestamps
+        ).toHaveLength(0);
+        expect(bundle.verificationData?.tlogEntries).toHaveLength(1);
+
+        const tlog = bundle.verificationData?.tlogEntries[0];
+        expect(tlog?.inclusionPromise).toBeTruthy();
+        expect(tlog?.inclusionPromise?.signedEntryTimestamp).toBeTruthy();
+        expect(
+          tlog?.inclusionPromise?.signedEntryTimestamp.toString('base64')
+        ).toEqual(rekorEntry[uuid].verification.signedEntryTimestamp);
+        expect(tlog?.integratedTime).toEqual(
+          rekorEntry[uuid].integratedTime.toString()
+        );
+        expect(tlog?.logId).toBeTruthy();
+        expect(tlog?.logId?.keyId).toBeTruthy();
+        expect(tlog?.logId?.keyId.toString('hex')).toEqual(
+          rekorEntry[uuid].logID
+        );
+        expect(tlog?.logIndex).toEqual(rekorEntry[uuid].logIndex.toString());
+        expect(tlog?.inclusionProof).toBeFalsy();
+        expect(tlog?.kindVersion?.kind).toEqual('hashedrekord');
+        expect(tlog?.kindVersion?.version).toEqual('0.0.1');
+      });
+    });
+  });
+
+  describe('createDSSEEntry', () => {
+    const subject = new TLogClient({ rekorBaseURL: baseURL });
+
+    // Input
+    const payload = Buffer.from('Hello, world!');
+    const payloadType = 'text/plain';
+    const signature = Buffer.from('signature');
+
+    const dsse: Envelope = {
+      payload,
+      payloadType,
+      signatures: [{ keyid: '', sig: signature }],
+    };
+    const leafCertificate = `-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----`;
+    const rootCertificate = `-----BEGIN CERTIFICATE-----\nxyz\n-----END CERTIFICATE-----`;
+
+    const sigMaterial: SignatureMaterial = {
+      signature,
+      certificates: [leafCertificate, rootCertificate],
+      key: undefined,
+    };
+
+    // Rekor input
+    const proposedEntry = JSON.stringify(
+      rekor.toProposedIntotoEntry(dsse, sigMaterial)
+    );
+
+    describe('when Rekor returns an error', () => {
+      beforeEach(() => {
+        nock(baseURL)
+          .matchHeader('Accept', 'application/json')
+          .matchHeader('Content-Type', 'application/json')
+          .post('/api/v1/log/entries', proposedEntry)
+          .reply(500, {});
+      });
+
+      it('returns an error', async () => {
+        await expect(
+          subject.createDSSEEntry(dsse, sigMaterial)
+        ).rejects.toThrow('HTTP Error: 500 Internal Server Error');
+      });
+    });
+
+    describe('when Rekor returns a valid response', () => {
+      const uuid =
+        '69e5a0c1663ee4452674a5c9d5050d866c2ee31e2faaf79913aea7cc27293cf6';
+
+      const signatureBundle = {
+        kind: 'intoto',
+        apiVersion: '0.0.2',
+        spec: {
+          signature: {
+            content: signature,
+            publicKey: { content: leafCertificate },
+          },
+        },
+      };
+
+      const rekorEntry = {
+        [uuid]: {
+          body: Buffer.from(JSON.stringify(signatureBundle)).toString('base64'),
+          integratedTime: 1654015743,
+          logID:
+            'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d',
+          logIndex: 2513258,
+          verification: {
+            signedEntryTimestamp:
+              'MEUCIQD6CD7ZNLUipFoxzmSL/L8Ewic4SRkXN77UjfJZ7d/wAAIgatokSuX9Rg0iWxAgSfHMtcsagtDCQalU5IvXdQ+yLEA=',
+          },
+        },
+      };
+
+      beforeEach(() => {
+        // Mock Rekor request
+        nock(baseURL)
+          .matchHeader('Accept', 'application/json')
+          .matchHeader('Content-Type', 'application/json')
+          .post('/api/v1/log/entries', proposedEntry)
+          .reply(201, rekorEntry);
+      });
+
+      it('returns a signature bundle', async () => {
+        const bundle = await subject.createDSSEEntry(dsse, sigMaterial);
+
+        expect(bundle).toBeTruthy();
+        expect(bundle.mediaType).toEqual(
+          'application/vnd.dev.sigstore.bundle+json;version=0.1'
+        );
+
+        if (bundle.content?.$case === 'dsseEnvelope') {
+          const env = bundle.content.dsseEnvelope;
+          expect(env.payloadType).toEqual(payloadType);
+          expect(env.payload.toString('base64')).toEqual(
+            payload.toString('base64')
+          );
+          expect(env.signatures).toHaveLength(1);
+          expect(env.signatures[0].keyid).toEqual('');
+        } else {
+          fail('Expected dsseEnvelope');
+        }
+
+        // Verification material
+        if (
+          bundle.verificationMaterial?.content?.$case === 'x509CertificateChain'
+        ) {
+          const chain =
+            bundle.verificationMaterial.content.x509CertificateChain;
+          expect(chain).toBeTruthy();
+          expect(chain.certificates).toHaveLength(2);
+          expect(chain.certificates[0].derBytes).toEqual(
+            pem.toDER(leafCertificate)
+          );
+          expect(chain.certificates[1].derBytes).toEqual(
+            pem.toDER(rootCertificate)
+          );
+        } else {
+          fail('Expected x509CertificateChain');
+        }
+
+        // Timestamp verification data
+        expect(bundle.verificationData).toBeTruthy();
+        expect(bundle.verificationData?.timestampVerificationData).toBeTruthy();
+        expect(
+          bundle.verificationData?.timestampVerificationData?.rfc3161Timestamps
+        ).toHaveLength(0);
+        expect(bundle.verificationData?.tlogEntries).toHaveLength(1);
+
+        const tlog = bundle.verificationData?.tlogEntries[0];
+        expect(tlog?.inclusionPromise).toBeTruthy();
+        expect(tlog?.inclusionPromise?.signedEntryTimestamp).toBeTruthy();
+        expect(
+          tlog?.inclusionPromise?.signedEntryTimestamp.toString('base64')
+        ).toEqual(rekorEntry[uuid].verification.signedEntryTimestamp);
+        expect(tlog?.integratedTime).toEqual(
+          rekorEntry[uuid].integratedTime.toString()
+        );
+        expect(tlog?.logId).toBeTruthy();
+        expect(tlog?.logId?.keyId).toBeTruthy();
+        expect(tlog?.logId?.keyId.toString('hex')).toEqual(
+          rekorEntry[uuid].logID
+        );
+        expect(tlog?.logIndex).toEqual(rekorEntry[uuid].logIndex.toString());
+        expect(tlog?.inclusionProof).toBeFalsy();
+        expect(tlog?.kindVersion?.kind).toEqual('intoto');
+        expect(tlog?.kindVersion?.version).toEqual('0.0.2');
+      });
+    });
+  });
+});

--- a/src/tlog/index.ts
+++ b/src/tlog/index.ts
@@ -26,7 +26,7 @@ export interface TLog {
 
   createDSSEEntry: (
     envelope: Envelope,
-    sigMaterial: SignatureMaterial | string
+    sigMaterial: SignatureMaterial
   ) => Promise<Bundle>;
 }
 
@@ -56,21 +56,8 @@ export class TLogClient implements TLog {
 
   async createDSSEEntry(
     envelope: Envelope,
-    sigMaterial: SignatureMaterial | string
+    sigMaterial: SignatureMaterial
   ): Promise<Bundle> {
-    // If sigMaterial is a string, assume it's a PEM-encoded public key
-    // and create a new SignatureMaterial object from data in envelope
-    if (typeof sigMaterial === 'string') {
-      sigMaterial = {
-        signature: envelope.signatures[0].sig,
-        key: {
-          id: envelope.signatures[0].keyid,
-          value: sigMaterial,
-        },
-        certificates: undefined,
-      };
-    }
-
     const proposedEntry = rekor.toProposedIntotoEntry(envelope, sigMaterial);
     const entry = await this.rekor.createEntry(proposedEntry);
     return bundle.toDSSEBundle(envelope, sigMaterial, entry);

--- a/src/tlog/index.ts
+++ b/src/tlog/index.ts
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { Rekor } from '../client';
+import { bundle, Bundle, Envelope } from '../types/bundle';
+import { rekor } from '../types/rekor';
+import { SignatureMaterial } from '../types/signature';
+
+export interface TLog {
+  createMessageSignatureEntry: (
+    digest: Buffer,
+    sigMaterial: SignatureMaterial
+  ) => Promise<Bundle>;
+
+  createDSSEEntry: (
+    envelope: Envelope,
+    sigMaterial: SignatureMaterial | string
+  ) => Promise<Bundle>;
+}
+
+export interface TLogClientOptions {
+  rekorBaseURL: string;
+}
+
+export class TLogClient implements TLog {
+  private rekor: Rekor;
+
+  constructor(options: TLogClientOptions) {
+    this.rekor = new Rekor({ baseURL: options.rekorBaseURL });
+  }
+
+  async createMessageSignatureEntry(
+    digest: Buffer,
+    sigMaterial: SignatureMaterial
+  ): Promise<Bundle> {
+    const proposedEntry = rekor.toProposedHashedRekordEntry(
+      digest,
+      sigMaterial
+    );
+
+    const entry = await this.rekor.createEntry(proposedEntry);
+    return bundle.toMessageSignatureBundle(digest, sigMaterial, entry);
+  }
+
+  async createDSSEEntry(
+    envelope: Envelope,
+    sigMaterial: SignatureMaterial | string
+  ): Promise<Bundle> {
+    // If sigMaterial is a string, assume it's a PEM-encoded public key
+    // and create a new SignatureMaterial object from data in envelope
+    if (typeof sigMaterial === 'string') {
+      sigMaterial = {
+        signature: envelope.signatures[0].sig,
+        key: {
+          id: envelope.signatures[0].keyid,
+          value: sigMaterial,
+        },
+        certificates: undefined,
+      };
+    }
+
+    const proposedEntry = rekor.toProposedIntotoEntry(envelope, sigMaterial);
+    const entry = await this.rekor.createEntry(proposedEntry);
+    return bundle.toDSSEBundle(envelope, sigMaterial, entry);
+  }
+}

--- a/src/types/bundle/index.ts
+++ b/src/types/bundle/index.ts
@@ -29,6 +29,9 @@ export * from './__generated__/envelope';
 export * from './__generated__/sigstore_bundle';
 export * from './__generated__/sigstore_common';
 
+export const bundleToJSON = Bundle.toJSON;
+export const bundleFromJSON = Bundle.fromJSON;
+
 const BUNDLE_MEDIA_TYPE =
   'application/vnd.dev.sigstore.bundle+json;version=0.1';
 

--- a/src/types/signature.test.ts
+++ b/src/types/signature.test.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { Envelope } from './bundle';
+import { extractSignatureMaterial } from './signature';
+
+describe('extractSignatureMaterial', () => {
+  const envelope: Envelope = {
+    payload: Buffer.from('Hello, world!'),
+    payloadType: 'text/plain',
+    signatures: [
+      {
+        keyid: 'keyid',
+        sig: Buffer.from('signature'),
+      },
+    ],
+  };
+
+  const publicKey = '-----BEGIN PUBLIC KEY-----\nABC\n-----END PUBLIC KEY-----';
+
+  it('returns the correct signature material', () => {
+    const sigMaterial = extractSignatureMaterial(envelope, publicKey);
+
+    expect(sigMaterial.key).toBeDefined();
+    expect(sigMaterial.signature).toEqual(envelope.signatures[0].sig);
+    expect(sigMaterial.key?.id).toEqual(envelope.signatures[0].keyid);
+    expect(sigMaterial.key?.value).toEqual(publicKey);
+    expect(sigMaterial.certificates).toBeUndefined();
+  });
+});

--- a/src/types/signature.ts
+++ b/src/types/signature.ts
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { Envelope } from './bundle';
 import { OneOf } from './utility';
 
 interface VerificationMaterial {
@@ -15,3 +31,19 @@ export type SignatureMaterial = {
 } & OneOf<VerificationMaterial>;
 
 export type SignerFunc = (payload: Buffer) => Promise<SignatureMaterial>;
+
+export function extractSignatureMaterial(
+  dsseEnvelope: Envelope,
+  publicKey: string
+): SignatureMaterial {
+  const signature = dsseEnvelope.signatures[0];
+
+  return {
+    signature: signature.sig,
+    key: {
+      id: signature.keyid,
+      value: publicKey,
+    },
+    certificates: undefined,
+  };
+}

--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -13,15 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { Rekor } from './client';
+import { TLogClient } from './tlog';
 import { Bundle, Envelope, HashAlgorithm } from './types/bundle';
 import { crypto } from './util';
 import { Verifier } from './verify';
 
 describe('Verifier', () => {
   const rekorBaseURL = 'http://localhost:8002';
-  const rekor = new Rekor({ baseURL: rekorBaseURL });
-  const subject = new Verifier({ rekor });
+  const tlog = new TLogClient({ rekorBaseURL });
+  const subject = new Verifier({ tlog });
 
   describe('#verify', () => {
     describe('when bundle type is messageSignature', () => {

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -13,19 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { Rekor } from './client';
+import { TLog } from './tlog';
 import { Bundle } from './types/bundle';
 import { crypto, dsse, pem } from './util';
 
 export interface VerifyOptions {
-  rekor: Rekor;
+  tlog: TLog;
 }
 
 export class Verifier {
-  private rekor: Rekor;
+  private tlog: TLog;
 
   constructor(options: VerifyOptions) {
-    this.rekor = options.rekor;
+    this.tlog = options.tlog;
   }
 
   public async verify(bundle: Bundle, data?: Buffer): Promise<boolean> {


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Exposes a new public `addEnvelopeToTransparencyLog` function which allows a user with an existing, signed DSSE envelope to post that envelope to Rekor and receive a Sigstore bundle in return.

```typescript
function addEnvelopeToTransparencyLog(envelope: Envelope, key: string): Promise<Bundle> { }
```

As part of exposing this function, I introduced a new `TLog` class which sits atop the `Rekor` class. Whereas `Rekor` provided direct access to the Rekor REST API, the new `TLog` class encapsulates the logic necessary to marshal data to/from the Rekor request/response formats. Ultimately, I'd like to do something similar on top of the `Fulcio` client, but I'll save that for another refactor.
#### Release Note

* Adds new `addEnvelopeToTransparencyLog` to public interface.
