### PR TITLE
Accept serialized envelope in createRekorEntry

### DIFF
--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -20,7 +20,8 @@ import { TLog, TLogClient } from './tlog';
 import {
   bundleFromJSON,
   bundleToJSON,
-  Envelope,
+  envelopeFromJSON,
+  SerializedEnvelope,
   SerializedBundle,
 } from './types/bundle';
 import { extractSignatureMaterial } from './types/signature';
@@ -44,6 +45,8 @@ export type SignOptions = {
 export type VerifierOptions = TLogOptions;
 
 export type Bundle = SerializedBundle;
+
+export type Envelope = SerializedEnvelope;
 
 type IdentityProviderOptions = Pick<
   SignOptions,
@@ -110,10 +113,11 @@ export async function createRekorEntry(
   publicKey: string,
   options: SignOptions = {}
 ): Promise<Bundle> {
+  const envelope = envelopeFromJSON(dsseEnvelope);
   const tlog = createTLogClient(options);
 
-  const sigMaterial = extractSignatureMaterial(dsseEnvelope, publicKey);
-  const bundle = await tlog.createDSSEEntry(dsseEnvelope, sigMaterial);
+  const sigMaterial = extractSignatureMaterial(envelope, publicKey);
+  const bundle = await tlog.createDSSEEntry(envelope, sigMaterial);
   return bundleToJSON(bundle) as Bundle;
 }
 

--- a/src/types/bundle/index.ts
+++ b/src/types/bundle/index.ts
@@ -31,6 +31,7 @@ export * from './__generated__/sigstore_common';
 
 export const bundleToJSON = Bundle.toJSON;
 export const bundleFromJSON = Bundle.fromJSON;
+export const envelopeFromJSON = Envelope.fromJSON;
 
 const BUNDLE_MEDIA_TYPE =
   'application/vnd.dev.sigstore.bundle+json;version=0.1';

--- a/src/types/bundle/serialized.ts
+++ b/src/types/bundle/serialized.ts
@@ -83,3 +83,15 @@ export type SerializedBundle = {
   dsseEnvelope: SerializedDSSEEnvelope;
   messageSignature: SerializedMessageSignature;
 }>;
+
+interface SerializedSignature {
+  sig: string;
+  keyid: string;
+}
+
+// Serialized form of the DSSE Envelope
+export type SerializedEnvelope = {
+  payload: string;
+  payloadType: string;
+  signatures: SerializedSignature[];
+};


### PR DESCRIPTION
Modifies the interface of `createRekorEntry` to take a "serialized dsse envelope" which is a JSON representation and de-serialize it internally.

Signed-off-by: Philip Harrison <philip@mailharrison.com>
