### PR TITLE
Add createDSSEEnvelope method

### DIFF
--- a/src/sigstore-utils.test.ts
+++ b/src/sigstore-utils.test.ts
@@ -1,0 +1,67 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { dsse } from './util';
+import { createDSSEEnvelope } from './sigstore-utils';
+
+describe('createDSSEEnvelope', () => {
+  const payload = Buffer.from('Hello, world!');
+  const payloadType = 'text/plain';
+  const sigMaterial = {
+    key: {
+      id: 'sha256-1234',
+    },
+    signature: Buffer.from('abc'),
+  };
+
+  const mockSign = jest.fn();
+  const options = {
+    signer: mockSign,
+  };
+
+  beforeEach(() => {
+    mockSign.mockClear();
+    mockSign.mockResolvedValueOnce(sigMaterial);
+  });
+
+  it('calls the signer with the correct payload', async () => {
+    await createDSSEEnvelope(payload, payloadType, options);
+
+    // Signer func was called
+    expect(mockSign).toHaveBeenCalledTimes(1);
+    const args = mockSign.mock.calls[0];
+
+    expect(args).toHaveLength(1);
+    const signerArg = args[0];
+
+    // Signer was constructed with the correct options
+    expect(signerArg).toEqual(dsse.preAuthEncoding(payloadType, payload));
+  });
+
+  it('returns a serialized envelope', async () => {
+    const envelope = await createDSSEEnvelope(payload, payloadType, options);
+
+    expect(envelope).toEqual({
+      payloadType: 'text/plain',
+      payload: 'SGVsbG8sIHdvcmxkIQ==',
+      signatures: [
+        {
+          keyid: 'sha256-1234',
+          sig: 'YWJj',
+        },
+      ],
+    });
+  });
+});

--- a/src/sigstore-utils.ts
+++ b/src/sigstore-utils.ts
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { TLog, TLogClient } from './tlog';
+import {
+  bundleToJSON,
+  envelopeFromJSON,
+  envelopeToJSON,
+  Envelope as DSSEEnvelope,
+} from './types/bundle';
+import { extractSignatureMaterial, SignerFunc } from './types/signature';
+import { dsse } from './util';
+import {
+  Bundle,
+  Envelope,
+  SignOptions,
+  DEFAULT_REKOR_BASE_URL,
+} from './sigstore';
+
+function createTLogClient(options: { rekorBaseURL?: string }): TLog {
+  return new TLogClient({
+    rekorBaseURL: options.rekorBaseURL || DEFAULT_REKOR_BASE_URL,
+  });
+}
+
+export async function createDSSEEnvelope(
+  payload: Buffer,
+  payloadType: string,
+  options: {
+    signer: SignerFunc;
+  }
+): Promise<Envelope> {
+  // Pre-authentication encoding to be signed
+  const paeBuffer = dsse.preAuthEncoding(payloadType, payload);
+
+  // Get signature and verification material for pae
+  const sigMaterial = await options.signer(paeBuffer);
+
+  const envelope: DSSEEnvelope = {
+    payloadType,
+    payload,
+    signatures: [
+      {
+        keyid: sigMaterial.key?.id || '',
+        sig: sigMaterial.signature,
+      },
+    ],
+  };
+
+  return envelopeToJSON(envelope) as Envelope;
+}
+
+// Accepts a signed DSSE envelope and a PEM-encoded public key to be added to the
+// transparency log. Returns a Sigstore bundle suitable for offline verification.
+export async function createRekorEntry(
+  dsseEnvelope: Envelope,
+  publicKey: string,
+  options: SignOptions = {}
+): Promise<Bundle> {
+  const envelope = envelopeFromJSON(dsseEnvelope);
+  const tlog = createTLogClient(options);
+
+  const sigMaterial = extractSignatureMaterial(envelope, publicKey);
+  const bundle = await tlog.createDSSEEntry(envelope, sigMaterial);
+  return bundleToJSON(bundle) as Bundle;
+}

--- a/src/sigstore.test.ts
+++ b/src/sigstore.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { Signer } from './sign';
-import { sign, signAttestation, verify } from './sigstore';
+import { sign, signAttestation, createDSSEEnvelope, verify } from './sigstore';
 import {
   Bundle,
   HashAlgorithm,
@@ -23,6 +23,7 @@ import {
   X509CertificateChain,
 } from './types/bundle';
 import { Verifier } from './verify';
+import { dsse } from './util';
 
 jest.mock('./sign');
 
@@ -196,6 +197,56 @@ describe('signAttestation', () => {
     const sig = await signAttestation(payload, payloadType);
 
     expect(sig).toEqual(Bundle.toJSON(bundle));
+  });
+});
+
+describe('createDSSEEnvelope', () => {
+  const payload = Buffer.from('Hello, world!');
+  const payloadType = 'text/plain';
+  const sigMaterial = {
+    key: {
+      id: 'sha256-1234',
+    },
+    signature: Buffer.from('abc'),
+  };
+
+  const mockSign = jest.fn();
+  const options = {
+    signer: mockSign,
+  };
+
+  beforeEach(() => {
+    mockSign.mockClear();
+    mockSign.mockResolvedValueOnce(sigMaterial);
+  });
+
+  it('calls the signer with the correct payload', async () => {
+    await createDSSEEnvelope(payload, payloadType, options);
+
+    // Signer func was called
+    expect(mockSign).toHaveBeenCalledTimes(1);
+    const args = mockSign.mock.calls[0];
+
+    expect(args).toHaveLength(1);
+    const signerArg = args[0];
+
+    // Signer was constructed with the correct options
+    expect(signerArg).toEqual(dsse.preAuthEncoding(payloadType, payload));
+  });
+
+  it('returns a serialized envelope', async () => {
+    const envelope = await createDSSEEnvelope(payload, payloadType, options);
+
+    expect(envelope).toEqual({
+      payloadType: 'text/plain',
+      payload: 'SGVsbG8sIHdvcmxkIQ==',
+      signatures: [
+        {
+          keyid: 'sha256-1234',
+          sig: 'YWJj',
+        },
+      ],
+    });
   });
 });
 

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -21,11 +21,14 @@ import {
   bundleFromJSON,
   bundleToJSON,
   envelopeFromJSON,
+  envelopeToJSON,
+  Envelope as DSSEEnvelope,
   SerializedEnvelope,
   SerializedBundle,
 } from './types/bundle';
-import { extractSignatureMaterial } from './types/signature';
+import { extractSignatureMaterial, SignerFunc } from './types/signature';
 import { Verifier } from './verify';
+import { dsse } from './util';
 
 export const DEFAULT_REKOR_BASE_URL = 'https://rekor.sigstore.dev';
 
@@ -104,6 +107,33 @@ export async function verify(
 
   const b = bundleFromJSON(bundle);
   return verifier.verify(b, data);
+}
+
+export async function createDSSEEnvelope(
+  payload: Buffer,
+  payloadType: string,
+  options: {
+    signer: SignerFunc;
+  }
+): Promise<Envelope> {
+  // Pre-authentication encoding to be signed
+  const paeBuffer = dsse.preAuthEncoding(payloadType, payload);
+
+  // Get signature and verification material for pae
+  const sigMaterial = await options.signer(paeBuffer);
+
+  const envelope: DSSEEnvelope = {
+    payloadType,
+    payload,
+    signatures: [
+      {
+        keyid: sigMaterial.key?.id || '',
+        sig: sigMaterial.signature,
+      },
+    ],
+  };
+
+  return envelopeToJSON(envelope) as Envelope;
 }
 
 // Accepts a signed DSSE envelope and a PEM-encoded public key to be added to the

--- a/src/types/bundle/index.ts
+++ b/src/types/bundle/index.ts
@@ -31,6 +31,7 @@ export * from './__generated__/sigstore_common';
 
 export const bundleToJSON = Bundle.toJSON;
 export const bundleFromJSON = Bundle.fromJSON;
+export const envelopeToJSON = Envelope.toJSON;
 export const envelopeFromJSON = Envelope.fromJSON;
 
 const BUNDLE_MEDIA_TYPE =


### PR DESCRIPTION
Creates a dsse envelope using a custom signer. The output of this function can be passed to `createRekorEntry` along with a public key in order to separate signing and the Rekor upload.

Signed-off-by: Philip Harrison <philip@mailharrison.com>
