### PR TITLE
Reduce Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  versioning-strategy: auto
+  versioning-strategy: increase-if-necessary
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"


### PR DESCRIPTION
This should reduce the number of Dependabot PRs but no longer submitting PRs that only change the lockfile.

Signed-off-by: Philip Harrison <philip@mailharrison.com>
