### PR TITLE
verify tlog integrated time against signing cert

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -16,8 +16,9 @@ limitations under the License.
 export * as crypto from './crypto';
 export * as dsse from './dsse';
 export * as encoding from './encoding';
+export * as json from './json';
 export * as oidc from './oidc';
 export * as pem from './pem';
 export * as promise from './promise';
 export * as ua from './ua';
-export * as json from './json';
+export * as x509 from './x509';

--- a/src/util/x509.test.ts
+++ b/src/util/x509.test.ts
@@ -1,0 +1,46 @@
+import { toDER } from './pem';
+import { parseCertificate } from './x509';
+
+describe('parseX509Certificate', () => {
+  const pem = `-----BEGIN CERTIFICATE-----
+MIICnjCCAiWgAwIBAgIUZMcoh64XV4XCcSQYwJrXU22UjlUwCgYIKoZIzj0EAwMw
+NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
+cm1lZGlhdGUwHhcNMjIxMDI0MTk1MDQ3WhcNMjIxMDI0MjAwMDQ3WjAAMFkwEwYH
+KoZIzj0CAQYIKoZIzj0DAQcDQgAEtP3jL42xsHewiWX1E9x3rENlhbVgTj/qdJWZ
+fpe3KSW3/tNHkRC/YMJMqsbemTCXdq7gIbyqa28srcEdP8XV2aOCAUQwggFAMA4G
+A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUoIYY
+Fvfwa166e3JmMQJ2bQUHQ3MwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
+ZD8wHwYDVR0RAQH/BBUwE4ERYnJpYW5AZGVoYW1lci5jb20wLAYKKwYBBAGDvzAB
+AQQeaHR0cHM6Ly9naXRodWIuY29tL2xvZ2luL29hdXRoMIGJBgorBgEEAdZ5AgQC
+BHsEeQB3AHUACGCS8ChS/2hF0dFrJ4ScRWcYrBY9wzjSbea8IgY2b3IAAAGEC4wx
+kgAABAMARjBEAiBwdXYiWwZ4VvuEOxStLYhFgX6FsG+3D8kn0kyJrvhBGQIgNxUT
++I+qhBoCGS24ai1YvDfcnZcsBLFPwRNNBcDXm7gwCgYIKoZIzj0EAwMDZwAwZAIw
+PO5vrCtwROzycizQctYdGQ1a5iVutbxFg2UrEXW5O+2gtHTrcc4EGITevo8ILPDn
+AjAgQz8q59ZTMKwJ0pGFQ3x3jg+Ib2SVVcNhB2kSKTfllnASyT9kgX7MHw/NU1Ow
+GMI=
+-----END CERTIFICATE-----`;
+
+  describe('when passed a PEM string', () => {
+    it('parses a certificate', () => {
+      const x = parseCertificate(pem);
+      expect(x.serialNumber).toEqual(
+        '64C72887AE175785C2712418C09AD7536D948E55'
+      );
+      expect(x.validFrom).toEqual(new Date('Oct 24 19:50:47 2022 GMT'));
+      expect(x.validTo).toEqual(new Date('Oct 24 20:00:47 2022 GMT'));
+    });
+  });
+
+  describe('when passed a DER byte buffer', () => {
+    const der = toDER(pem);
+
+    it('parses a certificate', () => {
+      const x = parseCertificate(der);
+      expect(x.serialNumber).toEqual(
+        '64C72887AE175785C2712418C09AD7536D948E55'
+      );
+      expect(x.validFrom).toEqual(new Date('Oct 24 19:50:47 2022 GMT'));
+      expect(x.validTo).toEqual(new Date('Oct 24 20:00:47 2022 GMT'));
+    });
+  });
+});

--- a/src/util/x509.ts
+++ b/src/util/x509.ts
@@ -1,0 +1,29 @@
+import net from 'net';
+import tls, { PeerCertificate } from 'tls';
+import { fromDER } from './pem';
+
+interface x509Certificate {
+  serialNumber: string;
+  validFrom: Date;
+  validTo: Date;
+}
+
+// Returns the parsed form of an X.509 certificate. Until we have a better
+// solution, this is a very simple implementation that only parses the
+// serial number and validity period. We're taking advantage of the
+// fact that the TLSSocket class exposes a getPeerCertificate() method which
+// returns basic information about its associated certificate.
+export function parseCertificate(cert: string | Buffer): x509Certificate {
+  const pem = typeof cert === 'string' ? cert : fromDER(cert);
+
+  const secureContext = tls.createSecureContext({ cert: pem });
+  const secureSocket = new tls.TLSSocket(new net.Socket(), { secureContext });
+  const certFields = secureSocket.getCertificate() as PeerCertificate;
+  secureSocket.destroy();
+
+  return {
+    serialNumber: certFields.serialNumber,
+    validFrom: new Date(certFields.valid_from),
+    validTo: new Date(certFields.valid_to),
+  };
+}

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -16,7 +16,7 @@ limitations under the License.
 import { KeyObject } from 'crypto';
 import { VerificationError } from './error';
 import { TLog } from './tlog';
-import { verifyTLogSET } from './tlog/verify';
+import { verifyTLogIntegratedTime, verifyTLogSET } from './tlog/verify';
 import { Bundle } from './types/bundle';
 import { crypto, dsse, pem } from './util';
 
@@ -37,6 +37,7 @@ export class Verifier {
   public verifyOffline(bundle: Bundle, data?: Buffer): void {
     verifyArtifactSignature(bundle, data);
     verifyTLogSET(bundle, this.tlogKeys);
+    verifyTLogIntegratedTime(bundle);
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the verification logic with a check which will compare the `integratedTime` of all tlog entries against the validity period of the signing certificate. 

If the `integratedTime` occurs before the certificate's "Not Before" time or after the certificate's "Not After" time the bundle will be considered invalid.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

