### PR TITLE
Fix absolute path to rekor public key

### DIFF
--- a/src/tlog/keys.ts
+++ b/src/tlog/keys.ts
@@ -15,13 +15,17 @@ limitations under the License.
 */
 import { createPublicKey, KeyObject } from 'crypto';
 import fs from 'fs';
+import path from 'path';
 import { crypto } from '../util';
 
 // Returns the set of trusted log keys which can be used to verify the
 // Signed Entry Timestamps in the log.
 export function getKeys(): Record<string, KeyObject> {
   // TODO: This should be be loaded via TUF
-  const pem = fs.readFileSync('store/rekor.pub', 'utf-8');
+  const pem = fs.readFileSync(
+    path.resolve(__dirname, '../../store/rekor.pub'),
+    'utf-8'
+  );
   const key = createPublicKey(pem);
 
   // Calculate logID from the key


### PR DESCRIPTION
When install `sigstore` as a library the library is executed from the projects root, so reading `'store/rekor.pub'` is not found and errors: `ENOENT: no such file or directory, open 'store/rekor.pub'`

Signed-off-by: Philip Harrison <philip@mailharrison.com>
