### PR TITLE
support for public key retrieval callback

### DIFF
--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -44,7 +44,7 @@ export type SignOptions = {
 } & TLogOptions;
 
 export type VerifierOptions = {
-  findKey?: FindKeyFunc;
+  getPublicKey?: FindKeyFunc;
 } & TLogOptions;
 
 export type Bundle = SerializedBundle;
@@ -104,7 +104,11 @@ export async function verify(
 ): Promise<void> {
   const tlog = createTLogClient(options);
   const tlogKeys = getKeys();
-  const verifier = new Verifier({ tlog, tlogKeys, findKey: options.findKey });
+  const verifier = new Verifier({
+    tlog,
+    tlogKeys,
+    getPublicKey: options.getPublicKey,
+  });
 
   const b = bundleFromJSON(bundle);
   return verifier.verifyOffline(b, data);

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -24,7 +24,7 @@ import {
   SerializedBundle,
   SerializedEnvelope,
 } from './types/bundle';
-import { FindKeyFunc, Verifier } from './verify';
+import { GetPublicKeyFunc, Verifier } from './verify';
 
 export * as utils from './sigstore-utils';
 
@@ -44,7 +44,7 @@ export type SignOptions = {
 } & TLogOptions;
 
 export type VerifierOptions = {
-  getPublicKey?: FindKeyFunc;
+  getPublicKey?: GetPublicKeyFunc;
 } & TLogOptions;
 
 export type Bundle = SerializedBundle;

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -21,10 +21,10 @@ import { getKeys } from './tlog/keys';
 import {
   bundleFromJSON,
   bundleToJSON,
-  SerializedEnvelope,
   SerializedBundle,
+  SerializedEnvelope,
 } from './types/bundle';
-import { Verifier } from './verify';
+import { FindKeyFunc, Verifier } from './verify';
 
 export * as utils from './sigstore-utils';
 
@@ -43,7 +43,9 @@ export type SignOptions = {
   oidcClientSecret?: string;
 } & TLogOptions;
 
-export type VerifierOptions = TLogOptions;
+export type VerifierOptions = {
+  findKey?: FindKeyFunc;
+} & TLogOptions;
 
 export type Bundle = SerializedBundle;
 
@@ -102,7 +104,7 @@ export async function verify(
 ): Promise<void> {
   const tlog = createTLogClient(options);
   const tlogKeys = getKeys();
-  const verifier = new Verifier({ tlog, tlogKeys });
+  const verifier = new Verifier({ tlog, tlogKeys, findKey: options.findKey });
 
   const b = bundleFromJSON(bundle);
   return verifier.verifyOffline(b, data);

--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -125,8 +125,12 @@ kBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==
       });
 
       describe('when the key comes from the findKey callback', () => {
-        const findKey = () => Promise.resolve(pem.fromDER(signingCert));
-        const subject = new Verifier({ tlog, tlogKeys: keys, findKey });
+        const getPublicKey = () => Promise.resolve(pem.fromDER(signingCert));
+        const subject = new Verifier({
+          tlog,
+          tlogKeys: keys,
+          getPublicKey,
+        });
 
         const bundle: Bundle = {
           mediaType: 'application/vnd.in-toto+json',
@@ -238,8 +242,12 @@ kBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==
       });
 
       describe('when the key comes from the findKey callback', () => {
-        const findKey = () => Promise.resolve(pem.fromDER(signingCert));
-        const subject = new Verifier({ tlog, tlogKeys: keys, findKey });
+        const getPublicKey = () => Promise.resolve(pem.fromDER(signingCert));
+        const subject = new Verifier({
+          tlog,
+          tlogKeys: keys,
+          getPublicKey,
+        });
 
         const envelope: Envelope = {
           payload: payload,

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -25,18 +25,18 @@ import {
 } from './types/bundle';
 import { crypto, dsse, pem } from './util';
 
-export type FindKeyFunc = (keyId: string) => Promise<string | undefined>;
+export type GetPublicKeyFunc = (keyId: string) => Promise<string | undefined>;
 
 export interface VerifyOptions {
   tlog: TLog;
   tlogKeys: Record<string, KeyObject>;
-  getPublicKey?: FindKeyFunc;
+  getPublicKey?: GetPublicKeyFunc;
 }
 
 export class Verifier {
   private tlog: TLog;
   private tlogKeys: Record<string, KeyObject>;
-  private getExternalPublicKey: FindKeyFunc;
+  private getExternalPublicKey: GetPublicKeyFunc;
 
   constructor(options: VerifyOptions) {
     this.tlog = options.tlog;

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -30,18 +30,19 @@ export type FindKeyFunc = (keyId: string) => Promise<string | undefined>;
 export interface VerifyOptions {
   tlog: TLog;
   tlogKeys: Record<string, KeyObject>;
-  findKey?: FindKeyFunc;
+  getPublicKey?: FindKeyFunc;
 }
 
 export class Verifier {
   private tlog: TLog;
   private tlogKeys: Record<string, KeyObject>;
-  private findKey: FindKeyFunc;
+  private getExternalPublicKey: FindKeyFunc;
 
   constructor(options: VerifyOptions) {
     this.tlog = options.tlog;
     this.tlogKeys = options.tlogKeys;
-    this.findKey = options.findKey || (() => Promise.resolve(undefined));
+    this.getExternalPublicKey =
+      options.getPublicKey || (() => Promise.resolve(undefined));
   }
 
   public async verifyOffline(bundle: Bundle, data?: Buffer): Promise<void> {
@@ -62,7 +63,7 @@ export class Verifier {
         );
         break;
       case 'publicKey':
-        publicKey = await this.findKey(
+        publicKey = await this.getExternalPublicKey(
           bundle.verificationMaterial.content.publicKey.hint
         );
         break;


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the `verify` function to accept an optional `findKey` callback which can be used to retrieve the public key for verifying signatures which are not using a signing certificate (cases where verification material in the bundle specifies a public key hint instead of a certificate chain).

In a subsequent PR, the same key returned by `findKey` will also be passed-down to the tlog verification logic and used to re-create the Rekor entry for SET verification.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
* Updates the signature for the `verify` function to accept an optional `findKey` callback which will be invoked to retrieve the public key in scenarios where the signature was generated w/ a static keypair.
