### PR TITLE
refactor key handling for rekor SET verification

### DIFF
--- a/src/verify.ts
+++ b/src/verify.ts
@@ -49,7 +49,7 @@ export class Verifier {
     const publicKey = await this.getPublicKey(bundle);
 
     verifyArtifactSignature(bundle, publicKey, data);
-    verifyTLogSET(bundle, this.tlogKeys);
+    verifyTLogSET(bundle, publicKey, this.tlogKeys);
     verifyTLogIntegratedTime(bundle);
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Continues the work in https://github.com/sigstore/sigstore-js/pull/152 to integrate a `getPublicKey` callback option which can be used for verification when artifacts are signed w/ a static keypair. This change passes the retrieved key down into the SET verification function to ensure that the correct key value is used when re-creating the Rekor entry.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

