### PR TITLE
refactor tlog verification

### DIFF
--- a/src/tlog/types/index.ts
+++ b/src/tlog/types/index.ts
@@ -60,10 +60,3 @@ export interface InclusionProof {
   rootHash: string;
   treeSize: number;
 }
-
-export interface VerificationPayload {
-  body: string;
-  integratedTime: number;
-  logIndex: number;
-  logID: string;
-}

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -16,11 +16,7 @@ limitations under the License.
 import { KeyObject } from 'crypto';
 import { InvalidBundleError, VerificationError } from './error';
 import { TLog } from './tlog';
-import {
-  verifyTLogBodies,
-  verifyTLogIntegratedTime,
-  verifyTLogSET,
-} from './tlog/verify';
+import { verifyTLogEntries } from './tlog/verify';
 import {
   Bundle,
   Envelope,
@@ -53,9 +49,7 @@ export class Verifier {
     const publicKey = await this.getPublicKey(bundle);
 
     verifyArtifactSignature(bundle, publicKey, data);
-    verifyTLogSET(bundle, this.tlogKeys);
-    verifyTLogBodies(bundle);
-    verifyTLogIntegratedTime(bundle);
+    verifyTLogEntries(bundle, this.tlogKeys);
   }
 
   public async getPublicKey(bundle: Bundle): Promise<string> {


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Internal refactoring of the transparency log verification logic to improve efficiency.

Previously, there were three separate transparency log verification steps which were exposed as separate functions:

* Verification of the canonicalized transparency log body
* Verification of the transparency log SET
* Verification of the transparency log integrated time.

With this refactor, all three of these checks are rolled into a single `verifyTLogEntries` function which performs these operations across all transparency log entries in the bundle.
