### PR TITLE
add statusCode property to HTTPError

### DIFF
--- a/src/__tests__/client/error.test.ts
+++ b/src/__tests__/client/error.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import fetch from 'make-fetch-happen';
-import { checkStatus } from '../../client/error';
+import { checkStatus, HTTPError } from '../../client/error';
 
 type Response = Awaited<ReturnType<typeof fetch>>;
 
@@ -39,7 +39,14 @@ describe('checkStatus', () => {
     } as Response;
 
     it('throws an error', () => {
-      expect(() => checkStatus(response)).toThrow('HTTP Error: 404 Not Found');
+      try {
+        checkStatus(response);
+        fail('Expected an error to be thrown');
+      } catch (e) {
+        if (!(e instanceof HTTPError)) fail('Expected an HTTPError');
+        expect(e.message).toEqual('HTTP Error: 404 Not Found');
+        expect(e.statusCode).toEqual(404);
+      }
     });
   });
 });

--- a/src/client/error.ts
+++ b/src/client/error.ts
@@ -20,9 +20,11 @@ type Response = Awaited<ReturnType<typeof fetch>>;
 
 export class HTTPError extends Error {
   public response: Response;
+  public statusCode: number;
   constructor(response: Response) {
     super(`HTTP Error: ${response.status} ${response.statusText}`);
     this.response = response;
+    this.statusCode = response.status;
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the `HTTPError` class to include a `statusCode` property which is populated with the HTTP status code of the response in error.