### PR TITLE
ASN.1 Parsing

### DIFF
--- a/src/__tests__/util/stream.test.ts
+++ b/src/__tests__/util/stream.test.ts
@@ -1,0 +1,69 @@
+import { ByteStream } from '../../util/stream';
+
+describe('ByteStream', () => {
+  const buf = Buffer.from([
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09,
+  ]);
+  const subject = new ByteStream(buf);
+
+  beforeEach(() => {
+    subject.seek(0);
+  });
+
+  describe('constructor', () => {
+    it('should create a new ByteStream', () => {
+      expect(subject).toBeTruthy();
+      expect(subject.position).toEqual(0);
+    });
+  });
+
+  describe('length', () => {
+    it('should return the length of the buffer', () => {
+      expect(subject.length).toEqual(buf.length);
+    });
+  });
+
+  describe('seek', () => {
+    it('should set the position', () => {
+      subject.seek(5);
+      expect(subject.position).toEqual(5);
+    });
+  });
+
+  describe('get', () => {
+    describe('when the position is less than the length', () => {
+      it('should return the next byte and increment cursor', () => {
+        expect(subject.get()).toEqual(buf[0]);
+        expect(subject.position).toEqual(1);
+        expect(subject.get()).toEqual(buf[1]);
+        expect(subject.position).toEqual(2);
+      });
+    });
+
+    describe('when the position is greater than the length', () => {
+      beforeEach(() => {
+        subject.seek(11);
+      });
+
+      it('should throw an error', () => {
+        expect(() => subject.get()).toThrowError('request past end of buffer');
+      });
+    });
+  });
+
+  describe('slice', () => {
+    describe('when the length is less than the buffer length', () => {
+      it('should return a slice of the buffer', () => {
+        expect(subject.slice(0, 5)).toEqual(buf.subarray(0, 5));
+      });
+    });
+
+    describe('when the length is greater than the buffer length', () => {
+      it('should throw an error', () => {
+        expect(() => subject.slice(0, 11)).toThrowError(
+          'request past end of buffer'
+        );
+      });
+    });
+  });
+});

--- a/src/__tests__/x509/asn1/length.test.ts
+++ b/src/__tests__/x509/asn1/length.test.ts
@@ -1,0 +1,49 @@
+import { ByteStream } from '../../../util/stream';
+import { decodeLength } from '../../../x509/asn1/length';
+
+describe('decodeLength', () => {
+  describe('when the encoded length is less than 128', () => {
+    const stream = streamFromBytes([0x10]);
+    it('should return the length', () => {
+      expect(decodeLength(stream)).toEqual(16);
+    });
+  });
+
+  describe('when the encoded length is equal to 128', () => {
+    const stream = streamFromBytes([0x81, 0x80]);
+    it('should return the length', () => {
+      expect(decodeLength(stream)).toEqual(128);
+    });
+  });
+
+  describe('when the encoded length is the max value', () => {
+    const stream = streamFromBytes([0x86, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+    it('should return the length', () => {
+      expect(decodeLength(stream)).toEqual(281474976710655);
+    });
+  });
+
+  describe('when the encoded length requires more than 6 bytes', () => {
+    const stream = streamFromBytes([
+      0x87, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    it('throws an error', () => {
+      expect(() => decodeLength(stream)).toThrowError(
+        'length exceeds 6 byte limit'
+      );
+    });
+  });
+
+  describe('when the encoded length is indefinite', () => {
+    const stream = streamFromBytes([0x80]);
+    it('throws an error', () => {
+      expect(() => decodeLength(stream)).toThrowError(
+        'indefinite length encoding not supported'
+      );
+    });
+  });
+});
+
+function streamFromBytes(bytes: number[]): ByteStream {
+  return new ByteStream(Buffer.from(bytes));
+}

--- a/src/__tests__/x509/asn1/obj.test.ts
+++ b/src/__tests__/x509/asn1/obj.test.ts
@@ -1,0 +1,206 @@
+import { ASN1TypeError } from '../../../x509/asn1/error';
+import { ASN1Obj } from '../../../x509/asn1/obj';
+
+describe('ASN1Obj', () => {
+  describe('parseBuffer', () => {
+    describe('when parsing a primitive', () => {
+      const buffer = Buffer.from('02021010', 'hex');
+
+      it('parses a primitive', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+
+        expect(obj).toBeInstanceOf(ASN1Obj);
+        expect(obj.tag.number).toBe(2);
+        expect(obj.value.toString('hex')).toBe('1010');
+        expect(obj.subs).toHaveLength(0);
+        expect(obj.raw).toEqual(buffer);
+      });
+    });
+
+    describe('when parsing a constructed object', () => {
+      const buffer = Buffer.from('30080202101002021111', 'hex');
+      it('parses a constructed object', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+
+        expect(obj).toBeInstanceOf(ASN1Obj);
+        expect(obj.tag.constructed).toBe(true);
+        expect(obj.tag.number).toBe(16);
+        expect(obj.value.toString('hex')).toBe('0202101002021111');
+        expect(obj.subs).toHaveLength(2);
+
+        expect(obj.subs[0].tag.constructed).toBe(false);
+        expect(obj.subs[0].tag.number).toBe(2);
+        expect(obj.subs[0].value.toString('hex')).toBe('1010');
+        expect(obj.subs[0].subs).toHaveLength(0);
+
+        expect(obj.subs[1].tag.constructed).toBe(false);
+        expect(obj.subs[1].tag.number).toBe(2);
+        expect(obj.subs[1].value.toString('hex')).toBe('1111');
+        expect(obj.subs[1].subs).toHaveLength(0);
+      });
+    });
+
+    describe('when parsing an OCTET STREAM w/ children', () => {
+      const buffer = Buffer.from('04080202101002021111', 'hex');
+      it('parses the object', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+
+        expect(obj).toBeInstanceOf(ASN1Obj);
+        expect(obj.tag.constructed).toBe(false);
+        expect(obj.tag.number).toBe(0x04);
+        expect(obj.value.toString('hex')).toBe('0202101002021111');
+        expect(obj.subs).toHaveLength(2);
+
+        expect(obj.subs[0].tag.constructed).toBe(false);
+        expect(obj.subs[0].tag.number).toBe(2);
+        expect(obj.subs[0].value.toString('hex')).toBe('1010');
+        expect(obj.subs[0].subs).toHaveLength(0);
+
+        expect(obj.subs[1].tag.constructed).toBe(false);
+        expect(obj.subs[1].tag.number).toBe(2);
+        expect(obj.subs[1].value.toString('hex')).toBe('1111');
+        expect(obj.subs[1].subs).toHaveLength(0);
+      });
+    });
+
+    describe('when parsing an OCTET STREAM w/o children', () => {
+      describe('when the OCTET STREAM value almost looks like an embedded obj', () => {
+        // OCTET STREAM looks like it could have a nested OCTET STREAM, but it
+        // doesn't -- the length of the nested OCTET STREAM is too long.
+        const buffer = Buffer.from('04020408', 'hex');
+        it('parses the OCTET STREAM as a primitive', () => {
+          const obj = ASN1Obj.parseBuffer(buffer);
+
+          expect(obj).toBeInstanceOf(ASN1Obj);
+          expect(obj.tag.constructed).toBe(false);
+          expect(obj.tag.number).toBe(0x04);
+          expect(obj.value.toString('hex')).toBe('0408');
+          expect(obj.subs).toHaveLength(0);
+        });
+      });
+
+      describe('when the OCTET STREAM value almost looks like an embedded obj', () => {
+        // OCTET STREAM looks like it could have a nested OCTET STREAM, but it
+        // doesn't -- the length of the nested OCTET STREAM is too short.
+        const buffer = Buffer.from('0406040213013131', 'hex');
+        it('parses the OCTET STREAM as a primitive', () => {
+          const obj = ASN1Obj.parseBuffer(buffer);
+
+          expect(obj).toBeInstanceOf(ASN1Obj);
+          expect(obj.tag.constructed).toBe(false);
+          expect(obj.tag.number).toBe(0x04);
+          expect(obj.value.toString('hex')).toBe('040213013131');
+          expect(obj.subs).toHaveLength(0);
+        });
+      });
+    });
+  });
+
+  describe('#toBoolean', () => {
+    describe('when the object is a BOOLEAN', () => {
+      describe('when the value is 0x00', () => {
+        const buffer = Buffer.from('010100', 'hex');
+        it('returns false', () => {
+          const obj = ASN1Obj.parseBuffer(buffer);
+          expect(obj.toBoolean()).toBe(false);
+        });
+      });
+
+      describe('when the value is 0x01', () => {
+        const buffer = Buffer.from('010101', 'hex');
+        it('returns true', () => {
+          const obj = ASN1Obj.parseBuffer(buffer);
+          expect(obj.toBoolean()).toBe(true);
+        });
+      });
+    });
+
+    describe('when the object is not a BOOLEAN', () => {
+      const buffer = Buffer.from('810102', 'hex');
+      it('throws an error', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+        expect(() => obj.toBoolean()).toThrow(ASN1TypeError);
+      });
+    });
+  });
+
+  describe('#toInteger', () => {
+    describe('when the object is an INTEGER', () => {
+      const buffer = Buffer.from('020100', 'hex');
+      it('returns the parsed integer', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+        expect(obj.toInteger()).toBe(BigInt(0));
+      });
+    });
+
+    describe('when the object is NOT an INTEGER', () => {
+      const buffer = Buffer.from('820100', 'hex');
+      it('throws an error', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+        expect(() => obj.toInteger()).toThrow(ASN1TypeError);
+      });
+    });
+  });
+
+  describe('#toOID', () => {
+    describe('when the object is an OBJECT IDENTIFIER', () => {
+      const buffer = Buffer.from('060182', 'hex');
+      it('returns parsed OID', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+        expect(obj.toOID()).toBe('3.10');
+      });
+    });
+
+    describe('when the object is NOT an OBJECT IDENTIFIER', () => {
+      const buffer = Buffer.from('020100', 'hex');
+      it('throws an error', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+        expect(() => obj.toOID()).toThrow(ASN1TypeError);
+      });
+    });
+  });
+
+  describe('#toDate', () => {
+    describe('when the object is a UTCTime', () => {
+      const buffer = Buffer.from('170D3232313132323131313131315A', 'hex');
+      it('returns the parsed date', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+        expect(obj.toDate().toISOString()).toBe('2022-11-22T11:11:11.000Z');
+      });
+    });
+
+    describe('when the object is a GeneralizedTime', () => {
+      const buffer = Buffer.from('180F32303232313132323131313131315A', 'hex');
+      it('returns the parsed date', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+        expect(obj.toDate().toISOString()).toBe('2022-11-22T11:11:11.000Z');
+      });
+    });
+
+    describe('when the object is NOT an UTCTime or GeneralizedTime', () => {
+      const buffer = Buffer.from('020100', 'hex');
+      it('throws an error', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+        expect(() => obj.toDate()).toThrow(ASN1TypeError);
+      });
+    });
+  });
+
+  describe('#toBitString', () => {
+    describe('when the object is a BITSTRING', () => {
+      const buffer = Buffer.from('030200F0', 'hex');
+      it('returns the parsed bit string', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+        expect(obj.toBitString()).toEqual([1, 1, 1, 1, 0, 0, 0, 0]);
+      });
+    });
+
+    describe('when the object is NOT a BITSTRING', () => {
+      const buffer = Buffer.from('020100', 'hex');
+      it('throws an error', () => {
+        const obj = ASN1Obj.parseBuffer(buffer);
+        expect(() => obj.toBitString()).toThrow(ASN1TypeError);
+      });
+    });
+  });
+});

--- a/src/__tests__/x509/asn1/obj.test.ts
+++ b/src/__tests__/x509/asn1/obj.test.ts
@@ -4,6 +4,7 @@ import { ASN1Obj } from '../../../x509/asn1/obj';
 describe('ASN1Obj', () => {
   describe('parseBuffer', () => {
     describe('when parsing a primitive', () => {
+      // INTEGER (2 bytes) 0x1010
       const buffer = Buffer.from('02021010', 'hex');
 
       it('parses a primitive', () => {
@@ -18,6 +19,9 @@ describe('ASN1Obj', () => {
     });
 
     describe('when parsing a constructed object', () => {
+      // SEQUENCE (8 bytes)
+      //   INTEGER (2 bytes) 0x1010
+      //   INTEGER (2 bytes) 0x1111
       const buffer = Buffer.from('30080202101002021111', 'hex');
       it('parses a constructed object', () => {
         const obj = ASN1Obj.parseBuffer(buffer);
@@ -41,6 +45,9 @@ describe('ASN1Obj', () => {
     });
 
     describe('when parsing an OCTET STREAM w/ children', () => {
+      // OCTET STRING (8 bytes)
+      //   INTEGER (2 bytes) 0x1010
+      //   INTEGER (2 bytes) 0x1010
       const buffer = Buffer.from('04080202101002021111', 'hex');
       it('parses the object', () => {
         const obj = ASN1Obj.parseBuffer(buffer);
@@ -99,6 +106,7 @@ describe('ASN1Obj', () => {
   describe('#toBoolean', () => {
     describe('when the object is a BOOLEAN', () => {
       describe('when the value is 0x00', () => {
+        // BOOLEAN (1 byte) 0x00
         const buffer = Buffer.from('010100', 'hex');
         it('returns false', () => {
           const obj = ASN1Obj.parseBuffer(buffer);
@@ -107,6 +115,7 @@ describe('ASN1Obj', () => {
       });
 
       describe('when the value is 0x01', () => {
+        // BOOLEAN (1 byte) 0x01
         const buffer = Buffer.from('010101', 'hex');
         it('returns true', () => {
           const obj = ASN1Obj.parseBuffer(buffer);
@@ -126,6 +135,7 @@ describe('ASN1Obj', () => {
 
   describe('#toInteger', () => {
     describe('when the object is an INTEGER', () => {
+      // INTEGER (1 bytes) 0x00
       const buffer = Buffer.from('020100', 'hex');
       it('returns the parsed integer', () => {
         const obj = ASN1Obj.parseBuffer(buffer);
@@ -144,6 +154,7 @@ describe('ASN1Obj', () => {
 
   describe('#toOID', () => {
     describe('when the object is an OBJECT IDENTIFIER', () => {
+      // OBJECT IDENTIFIER (1 byte) 0x82
       const buffer = Buffer.from('060182', 'hex');
       it('returns parsed OID', () => {
         const obj = ASN1Obj.parseBuffer(buffer);
@@ -162,6 +173,7 @@ describe('ASN1Obj', () => {
 
   describe('#toDate', () => {
     describe('when the object is a UTCTime', () => {
+      // UTCTime (13 bytes) 0x3232313132323131313131315A
       const buffer = Buffer.from('170D3232313132323131313131315A', 'hex');
       it('returns the parsed date', () => {
         const obj = ASN1Obj.parseBuffer(buffer);
@@ -170,6 +182,7 @@ describe('ASN1Obj', () => {
     });
 
     describe('when the object is a GeneralizedTime', () => {
+      // GeneralizedTime (15 bytes) 0x32303232313132323131313131315A
       const buffer = Buffer.from('180F32303232313132323131313131315A', 'hex');
       it('returns the parsed date', () => {
         const obj = ASN1Obj.parseBuffer(buffer);
@@ -188,6 +201,7 @@ describe('ASN1Obj', () => {
 
   describe('#toBitString', () => {
     describe('when the object is a BITSTRING', () => {
+      // BITSTRING (2 bytes) 0x00F0
       const buffer = Buffer.from('030200F0', 'hex');
       it('returns the parsed bit string', () => {
         const obj = ASN1Obj.parseBuffer(buffer);

--- a/src/__tests__/x509/asn1/parse.test.ts
+++ b/src/__tests__/x509/asn1/parse.test.ts
@@ -112,6 +112,9 @@ describe('parseBitString', () => {
     expect(parseBitString(Buffer.from([0x04, 0x57, 0xd0]))).toEqual([
       0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1,
     ]);
+
+    // Since the last four bits are ignored, the parsed bit string is
+    // identical to the example above.
     expect(parseBitString(Buffer.from([0x04, 0x57, 0xdf]))).toEqual([
       0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1,
     ]);

--- a/src/__tests__/x509/asn1/parse.test.ts
+++ b/src/__tests__/x509/asn1/parse.test.ts
@@ -1,0 +1,119 @@
+import {
+  parseBitString,
+  parseBoolean,
+  parseInteger,
+  parseOID,
+  parseStringASCII,
+  parseTime,
+} from '../../../x509/asn1/parse';
+
+describe('parseInteger', () => {
+  it('parses positive integers', () => {
+    expect(parseInteger(Buffer.from([0x00]))).toEqual(BigInt(0));
+    expect(parseInteger(Buffer.from([0x7f]))).toEqual(BigInt(127));
+    expect(parseInteger(Buffer.from([0x00, 0x80]))).toEqual(BigInt(128));
+    expect(parseInteger(Buffer.from([0x01, 0x00]))).toEqual(BigInt(256));
+  });
+
+  it('parses negative integers', () => {
+    expect(parseInteger(Buffer.from([0xff]))).toEqual(BigInt(-1));
+    expect(parseInteger(Buffer.from([0x80]))).toEqual(BigInt(-128));
+    expect(parseInteger(Buffer.from([0xff, 0x7f]))).toEqual(BigInt(-129));
+    expect(parseInteger(Buffer.from([0xff, 0x00]))).toEqual(BigInt(-256));
+  });
+});
+
+describe('parseStringASCII', () => {
+  it('parses ASCII strings', () => {
+    expect(parseStringASCII(Buffer.from([0x48, 0x69, 0x21]))).toEqual('Hi!');
+  });
+});
+
+describe('parseTime', () => {
+  describe('with short year', () => {
+    describe('when year is 50 or greater', () => {
+      it('parses the date', () => {
+        expect(parseTime(Buffer.from('740212121110Z'), true)).toEqual(
+          new Date('1974-02-12T12:11:10Z')
+        );
+      });
+    });
+
+    describe('when year is less than 50', () => {
+      it('parses the date', () => {
+        expect(parseTime(Buffer.from('180212121110Z'), true)).toEqual(
+          new Date('2018-02-12T12:11:10Z')
+        );
+      });
+    });
+  });
+
+  describe('with long year', () => {
+    it('parses the date', () => {
+      expect(parseTime(Buffer.from('19180212121110Z'), false)).toEqual(
+        new Date('1918-02-12T12:11:10Z')
+      );
+    });
+  });
+
+  describe('when the time is invalid', () => {
+    it('throws an error', () => {
+      expect(() => parseTime(Buffer.from('FOOBAR'), true)).toThrow(
+        'invalid time'
+      );
+    });
+  });
+});
+
+describe('parseOID', () => {
+  const tests = [
+    {
+      oid: '2A8648CE3D040303',
+      expected: '1.2.840.10045.4.3.3',
+    },
+    {
+      oid: '2b0601040182371514',
+      expected: '1.3.6.1.4.1.311.21.20',
+    },
+    {
+      oid: '2a8648ce3d0201',
+      expected: '1.2.840.10045.2.1',
+    },
+    {
+      oid: '2b0601040183bf300103',
+      expected: '1.3.6.1.4.1.57264.1.3',
+    },
+    {
+      oid: '2B06010401D679020402',
+      expected: '1.3.6.1.4.1.11129.2.4.2',
+    },
+    {
+      oid: '5381ab2501',
+      expected: '2.3.21925.1',
+    },
+  ];
+
+  it('parses OID strings', () => {
+    tests.forEach(({ oid, expected }) => {
+      expect(parseOID(Buffer.from(oid, 'hex'))).toEqual(expected);
+    });
+  });
+});
+
+describe('parseBoolean', () => {
+  it('parses boolean values', () => {
+    expect(parseBoolean(Buffer.from([0x00]))).toEqual(false);
+    expect(parseBoolean(Buffer.from([0xff]))).toEqual(true);
+  });
+});
+
+describe('parseBitString', () => {
+  it('parses bit strings', () => {
+    expect(parseBitString(Buffer.from([0x04, 0x57, 0xd0]))).toEqual([
+      0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1,
+    ]);
+    expect(parseBitString(Buffer.from([0x04, 0x57, 0xdf]))).toEqual([
+      0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1,
+    ]);
+  });
+});

--- a/src/__tests__/x509/asn1/tag.test.ts
+++ b/src/__tests__/x509/asn1/tag.test.ts
@@ -1,0 +1,200 @@
+import { ASN1ParseError } from '../../../x509/asn1/error';
+import { ASN1Tag } from '../../../x509/asn1/tag';
+
+describe('ASN1Tag', () => {
+  describe('when the tag is in the universal tag class', () => {
+    describe('when the tag is primitive ', () => {
+      it('should parse a tag', () => {
+        const tag = new ASN1Tag(0x02);
+        expect(tag.number).toEqual(0x02);
+        expect(tag.class).toEqual(0);
+        expect(tag.isUniversal()).toEqual(true);
+        expect(tag.constructed).toEqual(false);
+      });
+    });
+
+    describe('when the tag is constructed ', () => {
+      it('should parse a tag', () => {
+        const tag = new ASN1Tag(0x30);
+        expect(tag.number).toEqual(0x10);
+        expect(tag.class).toEqual(0);
+        expect(tag.isUniversal()).toEqual(true);
+        expect(tag.constructed).toEqual(true);
+      });
+    });
+  });
+
+  describe('when the tag is in the context-specifc tag class', () => {
+    describe('when the tag is constructed ', () => {
+      it('should parse a tag', () => {
+        const tag = new ASN1Tag(0xa3);
+        expect(tag.number).toEqual(0x03);
+        expect(tag.class).toEqual(0x02);
+        expect(tag.isUniversal()).toEqual(false);
+        expect(tag.constructed).toEqual(true);
+      });
+    });
+  });
+
+  describe('when the tag is long form', () => {
+    it('should throw an error', () => {
+      expect(() => new ASN1Tag(0x1f)).toThrowError(ASN1ParseError);
+    });
+  });
+
+  describe('when the tag is the null tag', () => {
+    it('should throw an error', () => {
+      expect(() => new ASN1Tag(0x20)).toThrowError(ASN1ParseError);
+    });
+  });
+
+  describe('#isContextSpecific', () => {
+    describe('when the tag is context-specific', () => {
+      it('should return true', () => {
+        const tag = new ASN1Tag(0xa3);
+        expect(tag.isContextSpecific()).toEqual(true);
+        expect(tag.isContextSpecific(0x03)).toEqual(true);
+      });
+    });
+
+    describe('when the tag is not context-specific', () => {
+      it('should return false', () => {
+        const tag = new ASN1Tag(0x02);
+        expect(tag.isContextSpecific()).toEqual(false);
+      });
+    });
+  });
+
+  describe('#isBoolean', () => {
+    describe('when the tag is a boolean', () => {
+      it('should return true', () => {
+        const tag = new ASN1Tag(0x01);
+        expect(tag.isBoolean()).toEqual(true);
+      });
+    });
+
+    describe('when the tag is not a boolean', () => {
+      it('should return false', () => {
+        let tag = new ASN1Tag(0x02);
+        expect(tag.isBoolean()).toEqual(false);
+
+        tag = new ASN1Tag(0x81);
+        expect(tag.isBoolean()).toEqual(false);
+      });
+    });
+  });
+
+  describe('#isInteger', () => {
+    describe('when the tag is an integer', () => {
+      it('should return true', () => {
+        const tag = new ASN1Tag(0x02);
+        expect(tag.isInteger()).toEqual(true);
+      });
+    });
+
+    describe('when the tag is not an integer', () => {
+      it('should return false', () => {
+        let tag = new ASN1Tag(0x01);
+        expect(tag.isInteger()).toEqual(false);
+
+        tag = new ASN1Tag(0x82);
+        expect(tag.isInteger()).toEqual(false);
+      });
+    });
+  });
+
+  describe('#isBitString', () => {
+    describe('when the tag is a bit string', () => {
+      it('should return true', () => {
+        const tag = new ASN1Tag(0x03);
+        expect(tag.isBitString()).toEqual(true);
+      });
+    });
+
+    describe('when the tag is not a bit string', () => {
+      it('should return false', () => {
+        let tag = new ASN1Tag(0x02);
+        expect(tag.isBitString()).toEqual(false);
+
+        tag = new ASN1Tag(0x83);
+        expect(tag.isBitString()).toEqual(false);
+      });
+    });
+  });
+
+  describe('#isOctetString', () => {
+    describe('when the tag is an octet string', () => {
+      it('should return true', () => {
+        const tag = new ASN1Tag(0x04);
+        expect(tag.isOctetString()).toEqual(true);
+      });
+    });
+
+    describe('when the tag is not an octet string', () => {
+      it('should return false', () => {
+        let tag = new ASN1Tag(0x02);
+        expect(tag.isOctetString()).toEqual(false);
+
+        tag = new ASN1Tag(0x84);
+        expect(tag.isOctetString()).toEqual(false);
+      });
+    });
+  });
+
+  describe('isOID', () => {
+    describe('when the tag is an OID', () => {
+      it('should return true', () => {
+        const tag = new ASN1Tag(0x06);
+        expect(tag.isOID()).toEqual(true);
+      });
+    });
+
+    describe('when the tag is not an OID', () => {
+      it('should return false', () => {
+        let tag = new ASN1Tag(0x02);
+        expect(tag.isOID()).toEqual(false);
+
+        tag = new ASN1Tag(0x86);
+        expect(tag.isOID()).toEqual(false);
+      });
+    });
+  });
+
+  describe('isUTCTime', () => {
+    describe('when the tag is a UTCTime', () => {
+      it('should return true', () => {
+        const tag = new ASN1Tag(0x17);
+        expect(tag.isUTCTime()).toEqual(true);
+      });
+    });
+
+    describe('when the tag is not a UTCTime', () => {
+      it('should return false', () => {
+        let tag = new ASN1Tag(0x02);
+        expect(tag.isUTCTime()).toEqual(false);
+
+        tag = new ASN1Tag(0x57);
+        expect(tag.isUTCTime()).toEqual(false);
+      });
+    });
+  });
+
+  describe('isGeneralizedTime', () => {
+    describe('when the tag is a GeneralizedTime', () => {
+      it('should return true', () => {
+        const tag = new ASN1Tag(0x18);
+        expect(tag.isGeneralizedTime()).toEqual(true);
+      });
+    });
+
+    describe('when the tag is not a UTCTime', () => {
+      it('should return false', () => {
+        let tag = new ASN1Tag(0x02);
+        expect(tag.isGeneralizedTime()).toEqual(false);
+
+        tag = new ASN1Tag(0x58);
+        expect(tag.isGeneralizedTime()).toEqual(false);
+      });
+    });
+  });
+});

--- a/src/util/stream.ts
+++ b/src/util/stream.ts
@@ -1,0 +1,49 @@
+export class StreamError extends Error {}
+
+export class ByteStream {
+  private buf: Buffer;
+  private pos: number;
+
+  constructor(buf: Buffer, pos = 0) {
+    this.buf = buf;
+    this.pos = pos;
+  }
+
+  // Returns the current stream position
+  get position(): number {
+    return this.pos;
+  }
+
+  // Returns the number of bytes in the stream
+  get length(): number {
+    return this.buf.length;
+  }
+
+  // Resets the stream to the given postion
+  public seek(pos: number): void {
+    this.pos = pos;
+  }
+
+  // Returns the next byte in the stream
+  public get(): number {
+    const pos = this.pos++;
+
+    if (pos >= this.length) {
+      throw new StreamError('request past end of buffer');
+    }
+
+    return this.buf[pos];
+  }
+
+  // Returns a Buffer containing the specified number of bytes starting at the
+  // given start position.
+  public slice(start: number, len: number): Buffer {
+    const end = start + len;
+
+    if (end > this.length) {
+      throw new StreamError('request past end of buffer');
+    }
+
+    return this.buf.subarray(start, end);
+  }
+}

--- a/src/x509/asn1/dump.ts
+++ b/src/x509/asn1/dump.ts
@@ -1,0 +1,97 @@
+import { ASN1Obj } from './obj';
+import { ASN1Tag, UNIVERSAL_TAG } from './tag';
+
+// Utility function to dump the contents of an ASN1Obj to the console.
+export function dump(obj: ASN1Obj, indent = 0): void {
+  let str = ' '.repeat(indent);
+  str += tagToString(obj.tag) + ' ';
+
+  if (obj.tag.isUniversal()) {
+    switch (obj.tag.number) {
+      case UNIVERSAL_TAG.BOOLEAN:
+        str += obj.toBoolean();
+        break;
+      case UNIVERSAL_TAG.INTEGER:
+        str += `(${obj.value.length} byte) `;
+        str += obj.toInteger();
+        break;
+      case UNIVERSAL_TAG.BIT_STRING: {
+        const bits = obj.toBitString();
+        str += `(${bits.length} bit) `;
+        str += truncate(bits.map((bit) => bit.toString()).join(''));
+        break;
+      }
+      case UNIVERSAL_TAG.OBJECT_IDENTIFIER:
+        str += obj.toOID();
+        break;
+      case UNIVERSAL_TAG.SEQUENCE:
+      case UNIVERSAL_TAG.SET:
+        str += `(${obj.subs.length} elem) `;
+        break;
+      case UNIVERSAL_TAG.PRINTABLE_STRING:
+        str += obj.value.toString('ascii');
+        break;
+      case UNIVERSAL_TAG.UTC_TIME:
+      case UNIVERSAL_TAG.GENERALIZED_TIME:
+        str += obj.toDate().toUTCString();
+        break;
+      default:
+        str += `(${obj.value.length} byte) `;
+        str += isASCII(obj.value)
+          ? obj.value.toString('ascii')
+          : truncate(obj.value.toString('hex').toUpperCase());
+    }
+  } else {
+    if (obj.tag.constructed) {
+      str += `(${obj.subs.length} elem) `;
+    } else {
+      str += `(${obj.value.length} byte) `;
+      str += isASCII(obj.value)
+        ? obj.value.toString('ascii')
+        : obj.value.toString('hex').toUpperCase();
+    }
+  }
+  console.log(str);
+
+  // Recursive call for children
+  obj.subs.forEach((sub) => dump(sub, indent + 2));
+}
+
+function tagToString(tag: ASN1Tag): string {
+  if (tag.isContextSpecific()) {
+    return `[${tag.number.toString(16)}]`;
+  } else {
+    switch (tag.number) {
+      case UNIVERSAL_TAG.BOOLEAN:
+        return 'BOOLEAN';
+      case UNIVERSAL_TAG.INTEGER:
+        return 'INTEGER';
+      case UNIVERSAL_TAG.BIT_STRING:
+        return 'BIT STRING';
+      case UNIVERSAL_TAG.OCTET_STRING:
+        return 'OCTET STRING';
+      case UNIVERSAL_TAG.OBJECT_IDENTIFIER:
+        return 'OBJECT IDENTIFIER';
+      case UNIVERSAL_TAG.SEQUENCE:
+        return 'SEQUENCE';
+      case UNIVERSAL_TAG.SET:
+        return 'SET';
+      case UNIVERSAL_TAG.PRINTABLE_STRING:
+        return 'PrintableString';
+      case UNIVERSAL_TAG.UTC_TIME:
+        return 'UTCTime';
+      case UNIVERSAL_TAG.GENERALIZED_TIME:
+        return 'GeneralizedTime';
+      default:
+        return tag.number.toString(16);
+    }
+  }
+}
+
+function isASCII(buf: Buffer) {
+  return buf.every((b) => b >= 32 && b <= 126);
+}
+
+function truncate(str: string): string {
+  return str.length > 70 ? str.substring(0, 69) + '...' : str;
+}

--- a/src/x509/asn1/error.ts
+++ b/src/x509/asn1/error.ts
@@ -1,0 +1,3 @@
+export class ASN1ParseError extends Error {}
+
+export class ASN1TypeError extends Error {}

--- a/src/x509/asn1/length.ts
+++ b/src/x509/asn1/length.ts
@@ -8,8 +8,9 @@ import { ASN1ParseError } from './error';
 export function decodeLength(stream: ByteStream): number {
   const buf = stream.get();
 
-  // If the first bit is unset the length is just the value of the byte.
-  if (buf < 0x80) {
+  // If the most significant bit is UNSET the length is just the value of the
+  // byte.
+  if ((buf & 0x80) === 0x00) {
     return buf;
   }
 

--- a/src/x509/asn1/length.ts
+++ b/src/x509/asn1/length.ts
@@ -1,0 +1,37 @@
+// Decodes the length of an ANS.1 element.
+
+import { ByteStream } from '../../util/stream';
+import { ASN1ParseError } from './error';
+
+// Decodes the length of a DER-encoded ANS.1 element from the supplied stream.
+// https://learn.microsoft.com/en-us/windows/win32/seccertenroll/about-encoded-length-and-value-bytes
+export function decodeLength(stream: ByteStream): number {
+  const buf = stream.get();
+
+  // If the first bit is unset the length is just the value of the byte.
+  if (buf < 0x80) {
+    return buf;
+  }
+
+  // Otherwise, the lower 7 bits of the first byte indicate the number of bytes
+  // that follow to encode the length.
+  const byteCount = buf & 0x7f;
+
+  // Ensure the encoded length can safely fit in a JS number.
+  if (byteCount > 6) {
+    throw new ASN1ParseError('length exceeds 6 byte limit');
+  }
+
+  // Iterate over the bytes that encode the length.
+  let len = 0;
+  for (let i = 0; i < byteCount; i++) {
+    len = len * 256 + stream.get();
+  }
+
+  // This is a valid ASN.1 length encoding, but we don't support it.
+  if (len === 0) {
+    throw new ASN1ParseError('indefinite length encoding not supported');
+  }
+
+  return len;
+}

--- a/src/x509/asn1/obj.ts
+++ b/src/x509/asn1/obj.ts
@@ -1,0 +1,170 @@
+import { ByteStream } from '../../util/stream';
+import { ASN1ParseError, ASN1TypeError } from './error';
+import { decodeLength } from './length';
+import {
+  parseBitString,
+  parseBoolean,
+  parseInteger,
+  parseOID,
+  parseTime,
+} from './parse';
+import { ASN1Tag } from './tag';
+
+export class ASN1Obj {
+  readonly tag: ASN1Tag;
+  readonly subs: ASN1Obj[];
+  private buf: Buffer;
+  private headerLength: number;
+
+  constructor(
+    tag: ASN1Tag,
+    headerLength: number,
+    buf: Buffer,
+    subs: ASN1Obj[]
+  ) {
+    this.tag = tag;
+    this.headerLength = headerLength;
+    this.buf = buf;
+    this.subs = subs;
+  }
+
+  // Constructs an ASN.1 object from a Buffer of DER-encoded bytes.
+  public static parseBuffer(buf: Buffer): ASN1Obj {
+    return parseStream(new ByteStream(buf));
+  }
+
+  // Returns the raw bytes of the ASN.1 object's value. For constructed objects,
+  // this is the concatenation of the raw bytes of the values of its children.
+  // For primitive objects, this is the raw bytes of the object's value.
+  // Use the various to* methods to parse the value into a specific type.
+  get value(): Buffer {
+    return this.buf.subarray(this.headerLength);
+  }
+
+  // Returns the raw bytes of the entire ASN.1 object (including tag, length,
+  // and value)
+  get raw(): Buffer {
+    return this.buf;
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Convenience methods for parsing ASN.1 primitives into JS types
+
+  // Returns the ASN.1 object's value as a boolean. Throws an error if the
+  // object is not a boolean.
+  public toBoolean(): boolean {
+    if (!this.tag.isBoolean()) {
+      throw new ASN1TypeError('not a boolean');
+    }
+
+    return parseBoolean(this.value);
+  }
+
+  // Returns the ASN.1 object's value as a BigInt. Throws an error if the
+  // object is not an integer.
+  public toInteger(): bigint {
+    if (!this.tag.isInteger()) {
+      throw new ASN1TypeError('not an integer');
+    }
+
+    return parseInteger(this.value);
+  }
+
+  // Returns the ASN.1 object's value as an OID string. Throws an error if the
+  // object is not an OID.
+  public toOID(): string {
+    if (!this.tag.isOID()) {
+      throw new ASN1TypeError('not an OID');
+    }
+
+    return parseOID(this.value);
+  }
+
+  // Returns the ASN.1 object's value as a Date. Throws an error if the object
+  // is not either a UTCTime or a GeneralizedTime.
+  public toDate(): Date {
+    switch (true) {
+      case this.tag.isUTCTime():
+        return parseTime(this.value, true);
+      case this.tag.isGeneralizedTime():
+        return parseTime(this.value, false);
+      default:
+        throw new ASN1TypeError('not a date');
+    }
+  }
+
+  // Returns the ASN.1 object's value as a number[] where each number is the
+  // value of a bit in the bit string. Throws an error if the object is not a
+  // bit string.
+  public toBitString(): number[] {
+    if (!this.tag.isBitString()) {
+      throw new ASN1TypeError('not a bit string');
+    }
+
+    return parseBitString(this.value);
+  }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Internal stream parsing functions
+
+function parseStream(stream: ByteStream): ASN1Obj {
+  // Capture current stream position so we know where this object starts
+  const startPos = stream.position;
+
+  // Parse tag and length from stream
+  const tag = new ASN1Tag(stream.get());
+  const len = decodeLength(stream);
+
+  // Calculate length of header (tag + length)
+  const header = stream.position - startPos;
+
+  let subs: ASN1Obj[] = [];
+  // If the object is constructed, parse its children. Sometimes, children
+  // are embedded in OCTESTRING objects, so we need to check those
+  // for children as well.
+  if (tag.constructed) {
+    subs = collectSubs(stream, len);
+  } else if (tag.isOctetString()) {
+    // Attempt to parse children of OCTETSTRING objects. If anything fails,
+    // assume the object is not constructed and treat as primitive.
+    try {
+      subs = collectSubs(stream, len);
+    } catch (e) {
+      // Fail silently and treat as primitive
+    }
+  }
+
+  // If there are no children, move stream cursor to the end of the object
+  if (subs.length === 0) {
+    stream.seek(startPos + header + len);
+  }
+
+  // Capture the raw bytes of the object (including tag, length, and value)
+  const buf = stream.slice(startPos, header + len);
+
+  return new ASN1Obj(tag, header, buf, subs);
+}
+
+function collectSubs(stream: ByteStream, len: number): ASN1Obj[] {
+  // Calculate end of object content
+  const end = stream.position + len;
+
+  // Make sure there are enough bytes left in the stream
+  if (end > stream.length) {
+    throw new ASN1ParseError('invalid length');
+  }
+
+  // Parse all children
+  const subs: ASN1Obj[] = [];
+  while (stream.position < end) {
+    subs.push(parseStream(stream));
+  }
+
+  // When we're done parsing children, we should be at the end of the object
+  if (stream.position !== end) {
+    throw new ASN1ParseError('invalid length');
+  }
+
+  return subs;
+}

--- a/src/x509/asn1/parse.ts
+++ b/src/x509/asn1/parse.ts
@@ -52,7 +52,7 @@ export function parseTime(buf: Buffer, shortYear: boolean): Date {
     throw new Error('invalid time');
   }
 
-  // Normalize to 4-digit year
+  // Translate dates with a 2-digit year to 4 digits per the spec
   if (shortYear) {
     let year = Number(m[1]);
     year += year >= 50 ? 1900 : 2000;

--- a/src/x509/asn1/parse.ts
+++ b/src/x509/asn1/parse.ts
@@ -1,0 +1,126 @@
+const RE_TIME_SHORT_YEAR = /^(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})Z$/;
+const RE_TIME_LONG_YEAR = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})Z$/;
+
+// Parse a BigInt from the DER-encoded buffer
+// https://learn.microsoft.com/en-us/windows/win32/seccertenroll/about-integer
+export function parseInteger(buf: Buffer): bigint {
+  let pos = 0;
+  const end = buf.length;
+  let val = buf[pos];
+  const neg = val > 0x7f;
+
+  // Consume any padding bytes
+  const pad = neg ? 0xff : 0x00;
+  while (val == pad && ++pos < end) {
+    val = buf[pos];
+  }
+
+  // Calculate remaining bytes to read
+  const len = end - pos;
+
+  if (len === 0) return BigInt(neg ? -1 : 0);
+
+  // Handle two's complement for negative numbers
+  val = neg ? val - 256 : val;
+
+  // Parse remaining bytes
+  let n = BigInt(val);
+  for (let i = pos + 1; i < end; ++i) {
+    n = n * BigInt(256) + BigInt(buf[i]);
+  }
+
+  return n;
+}
+
+// Parse an ASCII string from the DER-encoded buffer
+// https://learn.microsoft.com/en-us/windows/win32/seccertenroll/about-basic-types#boolean
+export function parseStringASCII(buf: Buffer): string {
+  return buf.toString('ascii');
+}
+
+// Parse a Date from the DER-encoded buffer
+// https://www.rfc-editor.org/rfc/rfc5280#section-4.1.2.5.1
+export function parseTime(buf: Buffer, shortYear: boolean): Date {
+  const timeStr = parseStringASCII(buf);
+
+  // Parse the time string into matches - captured groups start at index 1
+  const m = shortYear
+    ? RE_TIME_SHORT_YEAR.exec(timeStr)
+    : RE_TIME_LONG_YEAR.exec(timeStr);
+
+  if (!m) {
+    throw new Error('invalid time');
+  }
+
+  // Normalize to 4-digit year
+  if (shortYear) {
+    let year = Number(m[1]);
+    year += year >= 50 ? 1900 : 2000;
+    m[1] = year.toString();
+  }
+
+  // Translate to ISO8601 format and parse
+  return new Date(`${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}Z`);
+}
+
+// Parse an OID from the DER-encoded buffer
+// https://learn.microsoft.com/en-us/windows/win32/seccertenroll/about-object-identifier
+export function parseOID(buf: Buffer): string {
+  let pos = 0;
+  const end = buf.length;
+
+  // Consume first byte which encodes the first two OID components
+  let n = buf[pos++];
+  const first = Math.floor(n / 40);
+  const second = n % 40;
+
+  let oid = `${first}.${second}`;
+
+  // Consume remaining bytes
+  let val = 0;
+  for (; pos < end; ++pos) {
+    n = buf[pos];
+    val = (val << 7) + (n & 0x7f);
+
+    // If the left-most bit is NOT set, then this is the last byte in the
+    // sequence and we can add the value to the OID and reset the accumulator
+    if ((n & 0x80) === 0) {
+      oid += `.${val}`;
+      val = 0;
+    }
+  }
+
+  return oid;
+}
+
+// Parse a boolean from the DER-encoded buffer
+// https://learn.microsoft.com/en-us/windows/win32/seccertenroll/about-basic-types#boolean
+export function parseBoolean(buf: Buffer): boolean {
+  return buf[0] !== 0;
+}
+
+// Parse a bit string from the DER-encoded buffer
+// https://learn.microsoft.com/en-us/windows/win32/seccertenroll/about-bit-string
+export function parseBitString(buf: Buffer): number[] {
+  // First byte tell us how many unused bits are in the last byte
+  const unused = buf[0];
+
+  const start = 1;
+  const end = buf.length;
+  const bits = [];
+
+  for (let i = start; i < end; ++i) {
+    const byte = buf[i];
+
+    // The skip value is only used for the last byte
+    const skip = i === end - 1 ? unused : 0;
+
+    // Iterate over each bit in the byte (most significant first)
+    for (let j = 7; j >= skip; --j) {
+      // Read the bit and add it to the bit string
+      bits.push((byte >> j) & 0x01);
+    }
+  }
+
+  return bits;
+}

--- a/src/x509/asn1/tag.ts
+++ b/src/x509/asn1/tag.ts
@@ -1,0 +1,86 @@
+import { ASN1ParseError } from './error';
+
+export const UNIVERSAL_TAG = {
+  BOOLEAN: 0x01,
+  INTEGER: 0x02,
+  BIT_STRING: 0x03,
+  OCTET_STRING: 0x04,
+  OBJECT_IDENTIFIER: 0x06,
+  SEQUENCE: 0x10,
+  SET: 0x11,
+  PRINTABLE_STRING: 0x13,
+  UTC_TIME: 0x17,
+  GENERALIZED_TIME: 0x18,
+};
+
+const TAG_CLASS = {
+  UNIVERSAL: 0x00,
+  APPLICATION: 0x01,
+  CONTEXT_SPECIFIC: 0x02,
+  PRIVATE: 0x03,
+};
+
+// https://learn.microsoft.com/en-us/windows/win32/seccertenroll/about-encoded-tag-bytes
+export class ASN1Tag {
+  readonly number: number;
+  readonly constructed: boolean;
+  readonly class: number;
+
+  constructor(enc: number) {
+    // Bits 0 through 4 are the tag number
+    this.number = enc & 0x1f;
+
+    // Bit 5 is the constructed bit
+    this.constructed = (enc & 0x20) === 0x20;
+
+    // Bit 6 & 7 are the class
+    this.class = enc >> 6;
+
+    if (this.number === 0x1f) {
+      throw new ASN1ParseError('long form tags not supported');
+    }
+
+    if (this.class === TAG_CLASS.UNIVERSAL && this.number === 0x00) {
+      throw new ASN1ParseError('unsupported tag 0x00');
+    }
+  }
+
+  public isUniversal(): boolean {
+    return this.class === TAG_CLASS.UNIVERSAL;
+  }
+
+  public isContextSpecific(num?: number): boolean {
+    const res = this.class === TAG_CLASS.CONTEXT_SPECIFIC;
+    return num ? res && this.number === num : res;
+  }
+
+  public isBoolean(): boolean {
+    return this.isUniversal() && this.number === UNIVERSAL_TAG.BOOLEAN;
+  }
+
+  public isInteger(): boolean {
+    return this.isUniversal() && this.number === UNIVERSAL_TAG.INTEGER;
+  }
+
+  public isBitString(): boolean {
+    return this.isUniversal() && this.number === UNIVERSAL_TAG.BIT_STRING;
+  }
+
+  public isOctetString(): boolean {
+    return this.isUniversal() && this.number === UNIVERSAL_TAG.OCTET_STRING;
+  }
+
+  public isOID(): boolean {
+    return (
+      this.isUniversal() && this.number === UNIVERSAL_TAG.OBJECT_IDENTIFIER
+    );
+  }
+
+  public isUTCTime(): boolean {
+    return this.isUniversal() && this.number === UNIVERSAL_TAG.UTC_TIME;
+  }
+
+  public isGeneralizedTime(): boolean {
+    return this.isUniversal() && this.number === UNIVERSAL_TAG.GENERALIZED_TIME;
+  }
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds support for basic parsing of DER-encoded ASN.1 objects. This lays the groundwork for adding full x509 certificate support so that we can do verification of the Fulcio certificate chain.

This implementation does not support the complete set of ANS.1 datatypes or encoding options. For now, it is focused exclusively on the ASN.1 types commonly used in x509 certificates using DER encoding:

* `BOOLEAN`
* `INTEGER`
* `BIT STRING`
* `OCTET STRING`
* `OBJECT IDENTIFER`
* `SEQUENCE`
* `SET`  
* `PrintableString`
* `UTCTime`

Following is the structure resulting from parsing a Fulcio-issued x509 signing certificate:
```
SEQUENCE (3 elem) 
  SEQUENCE (8 elem) 
    [0] (1 elem) 
      INTEGER (1 byte) 2
    INTEGER (20 byte) 651968271402900508168874304870743208745138152437
    SEQUENCE (1 elem) 
      OBJECT IDENTIFIER 1.2.840.10045.4.3.3
    SEQUENCE (2 elem) 
      SET (1 elem) 
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 2.5.4.10
          PrintableString sigstore.dev
      SET (1 elem) 
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 2.5.4.3
          PrintableString sigstore-intermediate
    SEQUENCE (2 elem) 
      UTCTime Wed, 21 Sep 2022 19:25:15 GMT
      UTCTime Wed, 21 Sep 2022 19:35:15 GMT
    SEQUENCE (0 elem) 
    SEQUENCE (2 elem) 
      SEQUENCE (2 elem) 
        OBJECT IDENTIFIER 1.2.840.10045.2.1
        OBJECT IDENTIFIER 1.2.840.10045.3.1.7
      BIT STRING (520 bit) 000001001111000010101100000011010000101001001000101000100011001010001...
    [3] (1 elem) 
      SEQUENCE (12 elem) 
        SEQUENCE (3 elem) 
          OBJECT IDENTIFIER 2.5.29.15
          BOOLEAN true
          OCTET STRING (4 byte) 03020780
            BIT STRING (1 bit) 1
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 2.5.29.37
          OCTET STRING (12 byte) 300A06082B06010505070303
            SEQUENCE (1 elem) 
              OBJECT IDENTIFIER 1.3.6.1.5.5.7.3.3
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 2.5.29.14
          OCTET STRING (22 byte) 041476639CDB701727D02F5E5EBD5AAB63D98CFEAE5E
            OCTET STRING (20 byte) 76639CDB701727D02F5E5EBD5AAB63D98CFEAE5E
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 2.5.29.35
          OCTET STRING (24 byte) 30168014DFD3E9CF56241196F9A8D8E92855A2C62E18643F
            SEQUENCE (1 elem) 
              [0] (20 byte) DFD3E9CF56241196F9A8D8E92855A2C62E18643F
        SEQUENCE (3 elem) 
          OBJECT IDENTIFIER 2.5.29.17
          BOOLEAN true
          OCTET STRING (100 byte) 3062866068747470733A2F2F6769746875622E636F6D2F6769746875622F747275737...
            SEQUENCE (1 elem) 
              [6] (96 byte) https://github.com/github/trust-metadata-demo/.github/workflows/npm-demo.yml@refs/heads/npm-demo
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 1.3.6.1.4.1.57264.1.1
          OCTET STRING (43 byte) https://token.actions.githubusercontent.com
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 1.3.6.1.4.1.57264.1.2
          OCTET STRING (4 byte) push
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 1.3.6.1.4.1.57264.1.3
          OCTET STRING (40 byte) 221b26650574313a4207ae9262c6ce0707859a39
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 1.3.6.1.4.1.57264.1.4
          OCTET STRING (8 byte) npm-demo
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 1.3.6.1.4.1.57264.1.5
          OCTET STRING (26 byte) github/trust-metadata-demo
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 1.3.6.1.4.1.57264.1.6
          OCTET STRING (19 byte) refs/heads/npm-demo
        SEQUENCE (2 elem) 
          OBJECT IDENTIFIER 1.3.6.1.4.1.11129.2.4.2
          OCTET STRING (123 byte) 04790077007500086092F02852FF6845D1D16B27849C456718AC163DC338D26DE6BC2...
            OCTET STRING (121 byte) 0077007500086092F02852FF6845D1D16B27849C456718AC163DC338D26DE6BC22063...
  SEQUENCE (1 elem) 
    OBJECT IDENTIFIER 1.2.840.10045.4.3.3
  BIT STRING (824 bit) 001100000110010100000010001100000000010111000111111011100010010111000...
```