### PR TITLE
simplify workflow for publishing w/ provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,20 +21,9 @@ jobs:
         node-version: 16
         registry-url: 'https://registry.npmjs.org'
         cache: npm
-    - name: Clone npm
-      uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
-      with:
-        repository: npm/cli
-        ref: provenance
-        path: npm
-    - name: Link npm
-      run: |
-        cd npm
-        node . link
-        cd ..
     - name: Install dependencies and build
       run: npm ci && npm run build
     - name: Publish package
-      run: npm publish --provenance
+      run: npm exec npm@npm/cli#provenance -- publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Simplifies the set-up for publishing the package w/ provenance using the pre-release version of the npm CLI