### PR TITLE
add verify method to x509Certificate class

### DIFF
--- a/src/__tests__/x509/cert.test.ts
+++ b/src/__tests__/x509/cert.test.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import { pem } from '../../util';
 import { x509Certificate } from '../../x509/cert';
 import { certificates } from '../__fixtures__/certs';
@@ -95,43 +94,44 @@ describe('x509Certificate', () => {
     });
   });
 
-  describe('verification', () => {
+  describe('#verify', () => {
     const leafCert = x509Certificate.fromDER(pem.toDER(certificates.leaf));
     const intCert = x509Certificate.fromDER(
       pem.toDER(certificates.intermediate)
     );
     const rootCert = x509Certificate.fromDER(pem.toDER(certificates.root));
 
-    it('properly extracts keys and signatures', () => {
-      // Self-signed root certificate
-      expect(
-        crypto.verify(
-          rootCert.signatureAlgorithm,
-          rootCert.tbsCertificate,
-          rootCert.publicKey,
-          rootCert.signatureValue
-        )
-      ).toBe(true);
+    describe('when the issuer is provided', () => {
+      describe('when the issuer is a parent certificate', () => {
+        it('returns true', () => {
+          expect(leafCert.verify(intCert)).toBe(true);
+          expect(intCert.verify(rootCert)).toBe(true);
+        });
+      });
 
-      // Intermediate certificate signed by root
-      expect(
-        crypto.verify(
-          intCert.signatureAlgorithm,
-          intCert.tbsCertificate,
-          rootCert.publicKey,
-          intCert.signatureValue
-        )
-      ).toBe(true);
+      describe('when the issuer is NOT a parent', () => {
+        it('returns false', () => {
+          expect(leafCert.verify(rootCert)).toBe(false);
+          expect(intCert.verify(leafCert)).toBe(false);
+          expect(rootCert.verify(leafCert)).toBe(false);
+          expect(rootCert.verify(intCert)).toBe(false);
+        });
+      });
+    });
 
-      // Leaf certificate signed by intermediate
-      expect(
-        crypto.verify(
-          leafCert.signatureAlgorithm,
-          leafCert.tbsCertificate,
-          intCert.publicKey,
-          leafCert.signatureValue
-        )
-      ).toBe(true);
+    describe('when the issuer is NOT provided', () => {
+      describe('when the certificate is self-signed', () => {
+        it('returns true', () => {
+          expect(rootCert.verify()).toBe(true);
+        });
+      });
+
+      describe('when the certificate is NOT self-signed', () => {
+        it('returns false', () => {
+          expect(intCert.verify()).toBe(false);
+          expect(leafCert.verify()).toBe(false);
+        });
+      });
     });
   });
 });

--- a/src/x509/cert.ts
+++ b/src/x509/cert.ts
@@ -90,6 +90,17 @@ export class x509Certificate {
     return ext ? new x509SCTExtension(ext) : undefined;
   }
 
+  public verify(issuerCertificate?: x509Certificate): boolean {
+    // Use the issuer's public key if provided, otherwise use the subject's
+    const publicKey = issuerCertificate?.publicKey || this.publicKey;
+
+    return crypto.verify(
+      this.signatureAlgorithm,
+      this.tbsCertificate,
+      publicKey,
+      this.signatureValue
+    );
+  }
   private findExtension(oid: string): ASN1Obj | undefined {
     // The extension list is the first (and only) element of the extensions
     // context specific tag


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Add's a `verify` method to the `x509Certificate` class which can be used to verify the certificate's signature against the public key of its issuer.