### PR TITLE
authorityKeyID extension support for x509 certs

### DIFF
--- a/src/__tests__/x509/cert.test.ts
+++ b/src/__tests__/x509/cert.test.ts
@@ -32,6 +32,13 @@ describe('x509Certificate', () => {
         expect(cert.extKeyUsage?.digitalSignature).toBe(false);
         expect(cert.extKeyUsage?.keyCertSign).toBe(true);
         expect(cert.extKeyUsage?.crlSign).toBe(true);
+
+        expect(cert.extAuthorityKeyID).toBeDefined();
+        expect(cert.extAuthorityKeyID?.oid).toBe('2.5.29.35');
+        expect(cert.extAuthorityKeyID?.critical).toBe(false);
+        expect(cert.extAuthorityKeyID?.keyIdentifier).toStrictEqual(
+          Buffer.from('58C01E5F9145A566A97ACC90A19322D02AC5C5FA', 'hex')
+        );
       });
     });
 
@@ -60,6 +67,13 @@ describe('x509Certificate', () => {
         expect(cert.extKeyUsage?.digitalSignature).toBe(false);
         expect(cert.extKeyUsage?.keyCertSign).toBe(true);
         expect(cert.extKeyUsage?.crlSign).toBe(true);
+
+        expect(cert.extAuthorityKeyID).toBeDefined();
+        expect(cert.extAuthorityKeyID?.oid).toBe('2.5.29.35');
+        expect(cert.extAuthorityKeyID?.critical).toBe(false);
+        expect(cert.extAuthorityKeyID?.keyIdentifier).toStrictEqual(
+          Buffer.from('58C01E5F9145A566A97ACC90A19322D02AC5C5FA', 'hex')
+        );
       });
     });
 
@@ -93,6 +107,13 @@ describe('x509Certificate', () => {
         expect(cert.extSubjectAltName?.rfc822Name).toBeUndefined();
         expect(cert.extSubjectAltName?.uri).toBe(
           'https://github.com/sigstore/sigstore-js/.github/workflows/publish.yml@refs/tags/v0.2.0'
+        );
+
+        expect(cert.extAuthorityKeyID).toBeDefined();
+        expect(cert.extAuthorityKeyID?.oid).toBe('2.5.29.35');
+        expect(cert.extAuthorityKeyID?.critical).toBe(false);
+        expect(cert.extAuthorityKeyID?.keyIdentifier).toStrictEqual(
+          Buffer.from('DFD3E9CF56241196F9A8D8E92855A2C62E18643F', 'hex')
         );
 
         expect(cert.extSCT).toBeDefined();

--- a/src/x509/cert.ts
+++ b/src/x509/cert.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { ASN1Obj } from './asn1/obj';
 import {
+  x509AuthorityKeyIDExtension,
   x509BasicConstraintsExtension,
   x509Extension,
   x509KeyUsageExtension,
@@ -11,6 +12,7 @@ import {
 const EXTENSION_OID_KEY_USAGE = '2.5.29.15';
 const EXTENSION_OID_BASIC_CONSTRAINTS = '2.5.29.19';
 const EXTENSION_OID_SUBJECT_ALT_NAME = '2.5.29.17';
+const EXTENSION_OID_AUTHORITY_KEY_ID = '2.5.29.35';
 const EXTENSION_OID_SCT = '1.3.6.1.4.1.11129.2.4.2';
 
 // List of recognized critical extensions
@@ -103,6 +105,11 @@ export class x509Certificate {
   get extSubjectAltName(): x509SubjectAlternativeNameExtension | undefined {
     const ext = this.findExtension(EXTENSION_OID_SUBJECT_ALT_NAME);
     return ext ? new x509SubjectAlternativeNameExtension(ext) : undefined;
+  }
+
+  get extAuthorityKeyID(): x509AuthorityKeyIDExtension | undefined {
+    const ext = this.findExtension(EXTENSION_OID_AUTHORITY_KEY_ID);
+    return ext ? new x509AuthorityKeyIDExtension(ext) : undefined;
   }
 
   get extSCT(): x509SCTExtension | undefined {

--- a/src/x509/ext.ts
+++ b/src/x509/ext.ts
@@ -84,6 +84,21 @@ export class x509SubjectAlternativeNameExtension extends x509Extension {
   }
 }
 
+// https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.1
+export class x509AuthorityKeyIDExtension extends x509Extension {
+  get keyIdentifier(): Buffer | undefined {
+    return this.findSequenceMember(0x00)?.value;
+  }
+
+  private findSequenceMember(tag: number): ASN1Obj | undefined {
+    return this.sequence.subs.find((el) => el.tag.isContextSpecific(tag));
+  }
+
+  // The extnValue field contains a single sequence wrapping the keyIdentifier
+  private get sequence(): ASN1Obj {
+    return this.extnValueObj.subs[0];
+  }
+}
 // https://www.rfc-editor.org/rfc/rfc6962#section-3.3
 export class x509SCTExtension extends x509Extension {
   constructor(asn1: ASN1Obj) {


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the `x509Certificate` class with support for the "authorityKeyIdentifier" extension.