### PR TITLE
subjectKeyID extension support for x509 certs

### DIFF
--- a/src/__tests__/x509/cert.test.ts
+++ b/src/__tests__/x509/cert.test.ts
@@ -38,6 +38,13 @@ describe('x509Certificate', () => {
         expect(cert.extAuthorityKeyID?.keyIdentifier).toStrictEqual(
           Buffer.from('58C01E5F9145A566A97ACC90A19322D02AC5C5FA', 'hex')
         );
+
+        expect(cert.extSubjectKeyID).toBeDefined();
+        expect(cert.extSubjectKeyID?.oid).toBe('2.5.29.14');
+        expect(cert.extSubjectKeyID?.critical).toBe(false);
+        expect(cert.extSubjectKeyID?.keyIdentifier).toStrictEqual(
+          Buffer.from('58C01E5F9145A566A97ACC90A19322D02AC5C5FA', 'hex')
+        );
       });
     });
 
@@ -72,6 +79,13 @@ describe('x509Certificate', () => {
         expect(cert.extAuthorityKeyID?.critical).toBe(false);
         expect(cert.extAuthorityKeyID?.keyIdentifier).toStrictEqual(
           Buffer.from('58C01E5F9145A566A97ACC90A19322D02AC5C5FA', 'hex')
+        );
+
+        expect(cert.extSubjectKeyID).toBeDefined();
+        expect(cert.extSubjectKeyID?.oid).toBe('2.5.29.14');
+        expect(cert.extSubjectKeyID?.critical).toBe(false);
+        expect(cert.extSubjectKeyID?.keyIdentifier).toStrictEqual(
+          Buffer.from('DFD3E9CF56241196F9A8D8E92855A2C62E18643F', 'hex')
         );
       });
     });
@@ -113,6 +127,13 @@ describe('x509Certificate', () => {
         expect(cert.extAuthorityKeyID?.critical).toBe(false);
         expect(cert.extAuthorityKeyID?.keyIdentifier).toStrictEqual(
           Buffer.from('DFD3E9CF56241196F9A8D8E92855A2C62E18643F', 'hex')
+        );
+
+        expect(cert.extSubjectKeyID).toBeDefined();
+        expect(cert.extSubjectKeyID?.oid).toBe('2.5.29.14');
+        expect(cert.extSubjectKeyID?.critical).toBe(false);
+        expect(cert.extSubjectKeyID?.keyIdentifier).toStrictEqual(
+          Buffer.from('2DFD2400F6B9B92711D5F14CFF2D1E74E5245AC0', 'hex')
         );
 
         expect(cert.extSCT).toBeDefined();

--- a/src/x509/cert.ts
+++ b/src/x509/cert.ts
@@ -7,12 +7,14 @@ import {
   x509KeyUsageExtension,
   x509SCTExtension,
   x509SubjectAlternativeNameExtension,
+  x509SubjectKeyIDExtension,
 } from './ext';
 
 const EXTENSION_OID_KEY_USAGE = '2.5.29.15';
 const EXTENSION_OID_BASIC_CONSTRAINTS = '2.5.29.19';
 const EXTENSION_OID_SUBJECT_ALT_NAME = '2.5.29.17';
 const EXTENSION_OID_AUTHORITY_KEY_ID = '2.5.29.35';
+const EXTENSION_OID_SUBJECT_KEY_ID = '2.5.29.14';
 const EXTENSION_OID_SCT = '1.3.6.1.4.1.11129.2.4.2';
 
 // List of recognized critical extensions
@@ -110,6 +112,11 @@ export class x509Certificate {
   get extAuthorityKeyID(): x509AuthorityKeyIDExtension | undefined {
     const ext = this.findExtension(EXTENSION_OID_AUTHORITY_KEY_ID);
     return ext ? new x509AuthorityKeyIDExtension(ext) : undefined;
+  }
+
+  get extSubjectKeyID(): x509SubjectKeyIDExtension | undefined {
+    const ext = this.findExtension(EXTENSION_OID_SUBJECT_KEY_ID);
+    return ext ? new x509SubjectKeyIDExtension(ext) : undefined;
   }
 
   get extSCT(): x509SCTExtension | undefined {

--- a/src/x509/ext.ts
+++ b/src/x509/ext.ts
@@ -99,6 +99,14 @@ export class x509AuthorityKeyIDExtension extends x509Extension {
     return this.extnValueObj.subs[0];
   }
 }
+
+// https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.2
+export class x509SubjectKeyIDExtension extends x509Extension {
+  get keyIdentifier(): Buffer {
+    return this.extnValueObj.subs[0].value;
+  }
+}
+
 // https://www.rfc-editor.org/rfc/rfc6962#section-3.3
 export class x509SCTExtension extends x509Extension {
   constructor(asn1: ASN1Obj) {


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the `x509Certificate` class with support for the "subjectKeyIdentifier" extension.