### PR TITLE
Set-up cert CA for generating test data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist
 node_modules
 coverage
 .tool-versions
+hack/ca/store
+hack/ca/*.crt

--- a/hack/ca/Makefile
+++ b/hack/ca/Makefile
@@ -1,0 +1,167 @@
+
+clean:
+	rm -rf store
+	rm *.crt
+
+root.crt:
+	mkdir -p store/root/ca.db.certs
+	touch store/root/ca.db.index
+	openssl ecparam -out store/root/ca.key -name secp384r1 -genkey
+	openssl req \
+	  -new \
+	  -key store/root/ca.key \
+		-sha384 \
+		-subj /organizationName=foobar.dev/commonName=foobar \
+		-addext "basicConstraints = critical, CA:true" \
+		-addext "keyUsage = critical, keyCertSign, cRLSign" \
+		-out store/root/ca.csr
+	openssl ca \
+		-notext \
+		-batch \
+		-selfsign \
+		-config ca.conf \
+		-in store/root/ca.csr \
+		-out store/root/ca.crt
+	cp store/root/ca.crt root.crt
+
+int.crt: root.crt
+	mkdir -p store/int/ca.db.certs
+	touch store/int/ca.db.index
+	openssl ecparam -out store/int/ca.key -name secp384r1 -genkey
+	openssl req \
+		-new \
+	  -key store/int/ca.key \
+		-sha384 \
+		-subj /organizationName=foobar.dev/commonName=foobar-intermediate \
+		-addext "keyUsage = critical, keyCertSign, cRLSign" \
+		-addext "basicConstraints = critical, CA:true, pathlen:0" \
+		-addext "extendedKeyUsage = codeSigning" \
+		-out store/int/ca.csr
+	openssl ca \
+		-notext \
+		-batch \
+		-config ca.conf \
+		-in store/int/ca.csr \
+		-out store/int/ca.crt
+	cp store/int/ca.crt int.crt
+
+leaf.crt: int.crt
+	mkdir -p store/leaf/ca.db.certs
+	touch store/leaf/ca.db.index
+	openssl ecparam -out store/leaf/ca.key -name prime256v1 -genkey
+	openssl req \
+		-new \
+	  -key store/leaf/ca.key \
+		-sha384 \
+		-subj / \
+		-addext "keyUsage = critical, digitalSignature" \
+		-addext "extendedKeyUsage = codeSigning" \
+		-addext "subjectAltName = URI:http://foobar.dev" \
+		-out store/leaf/leaf.csr
+	openssl ca \
+		-notext \
+		-batch \
+		-config ca.conf \
+		-name ca_int \
+		-in store/leaf/leaf.csr \
+		-out store/leaf/ca.crt
+	cp store/leaf/ca.crt leaf.crt
+
+poison.crt: int.crt
+	mkdir -p store/poison
+	openssl ecparam -out store/poison/cert.key -name prime256v1 -genkey
+	openssl req \
+		-new \
+	  -key store/poison/cert.key \
+		-sha384 \
+		-subj / \
+		-addext "keyUsage = critical, digitalSignature" \
+		-addext "extendedKeyUsage = codeSigning" \
+		-addext "1.3.6.1.4.1.11129.2.4.3 = critical, ASN1:NULL:" \
+		-out store/poison/poison.csr
+	openssl ca \
+		-notext \
+		-batch \
+		-config ca.conf \
+		-name ca_int \
+		-in store/poison/poison.csr \
+		-out poison.crt
+
+nosan.crt: int.crt
+	mkdir -p store/nosan
+	openssl ecparam -out store/nosan/cert.key -name prime256v1 -genkey
+	openssl req \
+		-new \
+	  -key store/nosan/cert.key \
+		-sha384 \
+		-subj / \
+		-addext "keyUsage = critical, digitalSignature" \
+		-addext "extendedKeyUsage = codeSigning" \
+		-out store/nosan/nosan.csr
+	openssl ca \
+		-notext \
+		-batch \
+		-config ca.conf \
+		-name ca_int \
+		-in store/nosan/nosan.csr \
+		-out nosan.crt
+
+badsan.crt: int.crt
+	mkdir -p store/badsan
+	openssl ecparam -out store/badsan/cert.key -name prime256v1 -genkey
+	openssl req \
+		-new \
+	  -key store/badsan/cert.key \
+		-sha384 \
+		-subj / \
+		-addext "keyUsage = critical, digitalSignature" \
+		-addext "extendedKeyUsage = codeSigning" \
+		-addext "subjectAltName = IP:192.168.1.1" \
+		-out store/badsan/badsan.csr
+	openssl ca \
+		-notext \
+		-batch \
+		-config ca.conf \
+		-name ca_int \
+		-in store/badsan/badsan.csr \
+		-out badsan.crt
+
+nokeyusage.crt: int.crt
+	mkdir -p store/nokeyusage
+	openssl ecparam -out store/nokeyusage/cert.key -name prime256v1 -genkey
+	openssl req \
+		-new \
+	  -key store/nokeyusage/cert.key \
+		-sha384 \
+		-subj / \
+		-addext "extendedKeyUsage = codeSigning" \
+		-addext "subjectAltName = IP:192.168.1.1" \
+		-out store/nokeyusage/nokeyusage.csr
+	openssl ca \
+		-notext \
+		-batch \
+		-config ca.conf \
+		-name ca_int \
+		-in store/nokeyusage/nokeyusage.csr \
+		-out nokeyusage.crt
+
+invalidleaf.crt: leaf.crt
+	mkdir -p store/invalidleaf
+	openssl ecparam -out store/invalidleaf/cert.key -name prime256v1 -genkey
+	openssl req \
+		-new \
+	  -key store/invalidleaf/cert.key \
+		-sha384 \
+		-subj / \
+		-addext "keyUsage = critical, digitalSignature" \
+		-addext "extendedKeyUsage = codeSigning" \
+		-addext "subjectAltName = URI:http://foobar.dev" \
+		-out store/invalidleaf/invalidleaf.csr
+	openssl ca \
+		-notext \
+		-batch \
+		-config ca.conf \
+		-name ca_leaf \
+		-in store/invalidleaf/invalidleaf.csr \
+		-out invalidleaf.crt
+

--- a/hack/ca/README.md
+++ b/hack/ca/README.md
@@ -1,0 +1,21 @@
+# Certificate Test Data
+
+The `Makefile` in this directory can be used to generate x509 certificates for
+testing certificate chain verification logic. The extensions configured for the
+various certificates are meant to mirror those used by the Fulcio CA and the
+signing certificates issued by Fulcio.
+
+The following targets are available:
+
+* `root.crt` - Root CA
+* `int.crt` - Intermediate CA signed by the root CA
+* `leaf.crt` - Valid leaf certificate signed by the intermediate CA
+* `poison.crt` - Certificate w/ the precert poison extension set (should fail parsing)
+* `nosan.crt` - Leaf certificate signed by the intermediate CA with no SAN extension
+* `badsan.crt` - Leaf certificate signed by the intermediate CA wth a SAN extension containing an unsupported type
+* `nokeyusage.crt` - Leaf certificate signed by the intermediate CA with no keyUsage extension
+* `invalidleaf.crt` - Certificate signed by the leaf certificate (even though leaf is not a valid CA)
+
+**Note:** The `Makefile` doesn't work w/ the LibreSSL version of openssl
+installed by default on macOS. You'll need to `brew install openssl@3` to generate
+certificates.

--- a/hack/ca/ca.conf
+++ b/hack/ca/ca.conf
@@ -1,0 +1,70 @@
+[ ca ]
+default_ca = ca_root
+
+[ ca_root ]
+dir = ./store/root
+certificate = $dir/ca.crt
+private_key = $dir/ca.key
+new_certs_dir = $dir/ca.db.certs
+database = $dir/ca.db.index
+rand_serial = true
+default_md = sha384
+default_startdate = 900101000000Z
+default_enddate = 400101000000Z
+default_days = 10000
+email_in_dn = no
+unique_subect = no
+copy_extensions = copy
+x509_extensions = exts_wo_authority_key_id
+policy = generic_policy
+
+[ ca_int ]
+dir = ./store/int
+certificate = $dir/ca.crt
+private_key = $dir/ca.key
+new_certs_dir = $dir/ca.db.certs
+database = $dir/ca.db.index
+rand_serial = true
+default_md = sha384
+default_startdate = 900101000000Z
+default_enddate = 400101000000Z
+default_days = 10000
+email_in_dn = no
+unique_subect = no
+copy_extensions = copy
+x509_extensions = exts_w_authority_key_id
+policy = generic_policy
+
+[ ca_leaf ]
+dir = ./store/leaf
+certificate = $dir/ca.crt
+private_key = $dir/ca.key
+new_certs_dir = $dir/ca.db.certs
+database = $dir/ca.db.index
+rand_serial = true
+default_md = sha384
+default_startdate = 900101000000Z
+default_enddate = 400101000000Z
+default_days = 10000
+email_in_dn = no
+unique_subect = no
+copy_extensions = copy
+x509_extensions = exts_w_authority_key_id
+policy = generic_policy
+
+[ generic_policy ]
+countryName = optional
+stateOrProvinceName = optional
+localityName = optional
+organizationName = optional
+organizationalUnitName = optional
+commonName = optional
+emailAddress = optional
+
+[ exts_w_authority_key_id ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+
+[ exts_wo_authority_key_id ]
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = none


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds a `Makefile` to the "hack" directory that can be used to generate different x509 certificates for testing things like ASN.1 parsing and certificate chain verification. The generated certificates are set-up specifically to mimic the root/intermediate/leaf certificates used by Fulcio.

Example Root Cert:
```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            41:21:4b:16:2f:50:72:3e:da:02:7f:c9:21:50:81:c5:e0:24:68:47
        Signature Algorithm: ecdsa-with-SHA384
        Issuer: O = foobar.dev, CN = foobar
        Validity
            Not Before: Jan  1 00:00:00 1990 GMT
            Not After : Jan  1 00:00:00 2040 GMT
        Subject: O = foobar.dev, CN = foobar
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (384 bit)
                pub:
                    04:a8:e5:d5:7a:87:5b:b2:40:a0:9d:ec:d7:47:8c:
                    14:46:34:af:66:30:69:b3:a5:9c:aa:81:8f:fb:70:
                    c3:62:11:e5:66:5c:a7:89:0d:40:ba:d4:a9:e2:87:
                    9d:18:0d:2c:7d:83:63:03:f1:5a:56:85:14:9b:44:
                    0a:89:81:30:b5:de:a8:3d:d9:13:c0:37:1c:7b:f3:
                    ea:f3:87:51:e9:cc:ff:b9:ef:09:30:d5:c4:58:4c:
                    5f:f6:d4:44:2f:1a:4b
                ASN1 OID: secp384r1
                NIST CURVE: P-384
        X509v3 extensions:
            X509v3 Subject Key Identifier: 
                5B:C9:74:93:A3:70:A6:41:A6:46:ED:8E:F5:ED:E0:81:89:64:73:CB
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Key Usage: critical
                Certificate Sign, CRL Sign
    Signature Algorithm: ecdsa-with-SHA384
    Signature Value:
        30:65:02:30:3e:35:4b:88:d6:3a:b4:b9:e3:08:60:a1:88:25:
        52:c8:c8:36:8c:11:ca:b1:6f:be:95:fd:05:25:9f:97:b9:f2:
        40:64:ea:c8:de:77:db:50:1b:ad:9a:89:a0:b7:45:40:02:31:
        00:8c:36:bb:98:b8:a5:c7:b2:71:d8:5a:12:11:57:43:25:4f:
        d1:3f:c7:6d:b7:98:54:97:81:92:06:63:ad:bf:ca:9f:5c:8d:
        3f:c8:24:82:8e:98:cc:85:b3:30:46:2c:70
-----BEGIN CERTIFICATE-----
MIIBzTCCAVOgAwIBAgIUQSFLFi9Qcj7aAn/JIVCBxeAkaEcwCgYIKoZIzj0EAwMw
JjETMBEGA1UECgwKZm9vYmFyLmRldjEPMA0GA1UEAwwGZm9vYmFyMB4XDTkwMDEw
MTAwMDAwMFoXDTQwMDEwMTAwMDAwMFowJjETMBEGA1UECgwKZm9vYmFyLmRldjEP
MA0GA1UEAwwGZm9vYmFyMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqOXVeodbskCg
nezXR4wURjSvZjBps6WcqoGP+3DDYhHlZlyniQ1AutSp4oedGA0sfYNjA/FaVoUU
m0QKiYEwtd6oPdkTwDcce/Pq84dR6cz/ue8JMNXEWExf9tRELxpLo0IwQDAdBgNV
HQ4EFgQUW8l0k6NwpkGmRu2O9e3ggYlkc8swDwYDVR0TAQH/BAUwAwEB/zAOBgNV
HQ8BAf8EBAMCAQYwCgYIKoZIzj0EAwMDaAAwZQIwPjVLiNY6tLnjCGChiCVSyMg2
jBHKsW++lf0FJZ+XufJAZOrI3nfbUButmomgt0VAAjEAjDa7mLilx7Jx2FoSEVdD
JU/RP8dtt5hUl4GSBmOtv8qfXI0/yCSCjpjMhbMwRixw
-----END CERTIFICATE-----
```

Example leaf signing certificate:
```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            64:09:ba:6a:0a:74:1a:b9:38:52:4c:05:4b:fd:02:c5:cf:c0:45:da
        Signature Algorithm: ecdsa-with-SHA384
        Issuer: O = foobar.dev, CN = foobar-intermediate
        Validity
            Not Before: Jan  1 00:00:00 1990 GMT
            Not After : Jan  1 00:00:00 2040 GMT
        Subject: 
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:b4:5e:76:8e:b5:d6:a0:6c:44:4c:00:c3:c8:17:
                    c9:65:56:83:a7:18:84:03:43:76:87:a1:8d:9c:36:
                    d2:66:a9:98:ce:51:74:d5:e0:83:a0:68:e2:89:21:
                    45:89:c5:f6:53:2a:2a:e2:34:75:5d:a5:2c:6d:80:
                    c3:b1:b0:e5:e6
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Subject Key Identifier: 
                1F:76:BE:29:98:A2:6A:19:86:EE:59:CB:5A:53:8E:49:D7:18:F3:0C
            X509v3 Authority Key Identifier: 
                56:D3:41:B1:32:E6:A3:C6:B4:2F:EF:28:20:B6:72:98:B9:55:90:CD
            X509v3 Key Usage: critical
                Digital Signature
            X509v3 Extended Key Usage: 
                Code Signing
            X509v3 Subject Alternative Name: 
                URI:http://foobar.dev
    Signature Algorithm: ecdsa-with-SHA384
    Signature Value:
        30:66:02:31:00:9d:85:92:4b:04:6f:e3:97:8a:de:46:30:a5:
        34:70:62:7d:17:9d:ba:03:a5:92:10:16:cf:e7:99:35:b3:47:
        e7:a3:53:47:ea:6a:37:e2:69:95:58:d2:f6:ad:ac:fb:a6:02:
        31:00:a4:e6:92:bb:f3:aa:ca:f8:4d:0e:94:1e:2a:66:60:8b:
        11:a1:47:ee:9e:56:26:31:9f:fb:17:9a:39:41:ea:04:16:09:
        20:51:f8:0c:00:b7:5b:2e:5b:ee:58:87:f0:a8
-----BEGIN CERTIFICATE-----
MIIB3TCCAWKgAwIBAgIUZAm6agp0Grk4UkwFS/0Cxc/ARdowCgYIKoZIzj0EAwMw
MzETMBEGA1UECgwKZm9vYmFyLmRldjEcMBoGA1UEAwwTZm9vYmFyLWludGVybWVk
aWF0ZTAeFw05MDAxMDEwMDAwMDBaFw00MDAxMDEwMDAwMDBaMAAwWTATBgcqhkjO
PQIBBggqhkjOPQMBBwNCAAS0XnaOtdagbERMAMPIF8llVoOnGIQDQ3aHoY2cNtJm
qZjOUXTV4IOgaOKJIUWJxfZTKiriNHVdpSxtgMOxsOXmo4GGMIGDMB0GA1UdDgQW
BBQfdr4pmKJqGYbuWctaU45J1xjzDDAfBgNVHSMEGDAWgBRW00GxMuajxrQv7ygg
tnKYuVWQzTAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwMwHAYD
VR0RBBUwE4YRaHR0cDovL2Zvb2Jhci5kZXYwCgYIKoZIzj0EAwMDaQAwZgIxAJ2F
kksEb+OXit5GMKU0cGJ9F526A6WSEBbP55k1s0fno1NH6mo34mmVWNL2raz7pgIx
AKTmkrvzqsr4TQ6UHipmYIsRoUfunlYmMZ/7F5o5QeoEFgkgUfgMALdbLlvuWIfw
qA==
-----END CERTIFICATE-----
```