### PR TITLE
Fetch existing Rekor entry on create conflict

### DIFF
--- a/src/client/error.ts
+++ b/src/client/error.ts
@@ -21,10 +21,13 @@ type Response = Awaited<ReturnType<typeof fetch>>;
 export class HTTPError extends Error {
   public response: Response;
   public statusCode: number;
+  public location?: string;
+
   constructor(response: Response) {
     super(`HTTP Error: ${response.status} ${response.statusText}`);
     this.response = response;
     this.statusCode = response.status;
+    this.location = response.headers?.get('Location') || undefined;
   }
 }
 

--- a/src/sigstore-utils.ts
+++ b/src/sigstore-utils.ts
@@ -73,6 +73,9 @@ export async function createRekorEntry(
   const tlog = createTLogClient(options);
 
   const sigMaterial = extractSignatureMaterial(envelope, publicKey);
-  const bundle = await tlog.createDSSEEntry(envelope, sigMaterial);
+  const bundle = await tlog.createDSSEEntry(envelope, sigMaterial, {
+    fetchOnConflict: true,
+  });
+
   return bundleToJSON(bundle) as Bundle;
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds a `fetchOnConflict` option to `tlog.createDSSEEntry` which allows it to retrieve/return an existing Rekor entry in the event that the entry being creating matches an existing record. The default behavior is still to throw an error in the event of a conflict (HTTP status code 409), but the `fetchOnConflict` flag  can be enabled to override this behavior.