### PR TITLE
refactor ByteStream utility class

### DIFF
--- a/src/__tests__/util/stream.test.ts
+++ b/src/__tests__/util/stream.test.ts
@@ -17,41 +17,74 @@ describe('ByteStream', () => {
     });
   });
 
-  describe('length', () => {
+  describe('#length', () => {
     it('should return the length of the buffer', () => {
       expect(subject.length).toEqual(buf.length);
     });
   });
 
-  describe('seek', () => {
+  describe('#seek', () => {
     it('should set the position', () => {
       subject.seek(5);
       expect(subject.position).toEqual(5);
     });
   });
 
-  describe('get', () => {
+  describe('#getBlock', () => {
+    describe('when the block size is 0', () => {
+      it('should return an empty buffer', () => {
+        expect(subject.getBlock(0)).toHaveLength(0);
+      });
+    });
+  });
+
+  describe('#getUint8', () => {
     describe('when the position is less than the length', () => {
       it('should return the next byte and increment cursor', () => {
-        expect(subject.get()).toEqual(buf[0]);
+        expect(subject.getUint8()).toEqual(buf[0]);
         expect(subject.position).toEqual(1);
-        expect(subject.get()).toEqual(buf[1]);
+        expect(subject.getUint8()).toEqual(buf[1]);
         expect(subject.position).toEqual(2);
       });
     });
 
     describe('when the position is greater than the length', () => {
       beforeEach(() => {
-        subject.seek(11);
+        subject.seek(10);
       });
 
       it('should throw an error', () => {
-        expect(() => subject.get()).toThrowError('request past end of buffer');
+        expect(() => subject.getUint8()).toThrowError(
+          'request past end of buffer'
+        );
       });
     });
   });
 
-  describe('slice', () => {
+  describe('#getUint16', () => {
+    describe('when the position is less than the length', () => {
+      it('should return the next uint16 and increment cursor', () => {
+        expect(subject.getUint16()).toEqual(0x0001);
+        expect(subject.position).toEqual(2);
+        expect(subject.getUint16()).toEqual(0x0203);
+        expect(subject.position).toEqual(4);
+      });
+    });
+
+    describe('when the position is greater than the length', () => {
+      beforeEach(() => {
+        subject.seek(10);
+      });
+
+      it('should throw an error', () => {
+        expect(() => subject.getUint16()).toThrowError(
+          'request past end of buffer'
+        );
+      });
+    });
+  });
+
+  describe('#slice', () => {
     describe('when the length is less than the buffer length', () => {
       it('should return a slice of the buffer', () => {
         expect(subject.slice(0, 5)).toEqual(buf.subarray(0, 5));
@@ -64,6 +97,46 @@ describe('ByteStream', () => {
           'request past end of buffer'
         );
       });
+    });
+  });
+
+  describe('#appendChar', () => {
+    const subject = new ByteStream();
+
+    it('should append a character to the buffer', () => {
+      subject.appendChar(0x0a);
+      expect(subject.buffer).toEqual(Buffer.from([0x0a]));
+      expect(subject.position).toEqual(1);
+    });
+  });
+
+  describe('#appendUint16', () => {
+    const subject = new ByteStream();
+
+    it('should append a uint16 to the buffer', () => {
+      subject.appendUint16(0x0a0b);
+      expect(subject.buffer).toEqual(Buffer.from([0x0a, 0x0b]));
+      expect(subject.position).toEqual(2);
+    });
+  });
+
+  describe('#appendUint24', () => {
+    const subject = new ByteStream();
+
+    it('should append a uint24 to the buffer', () => {
+      subject.appendUint24(0x0a0b0c);
+      expect(subject.buffer).toEqual(Buffer.from([0x0a, 0x0b, 0x0c]));
+      expect(subject.position).toEqual(3);
+    });
+  });
+
+  describe('appendView', () => {
+    const subject = new ByteStream();
+
+    it('should append a view to the buffer', () => {
+      subject.appendView(buf);
+      expect(subject.buffer).toEqual(buf);
+      expect(subject.position).toEqual(buf.length);
     });
   });
 });

--- a/src/util/stream.ts
+++ b/src/util/stream.ts
@@ -1,38 +1,36 @@
 export class StreamError extends Error {}
 
 export class ByteStream {
-  private buf: Buffer;
-  private pos: number;
+  private static BLOCK_SIZE = 1024;
 
-  constructor(buf: Buffer, pos = 0) {
-    this.buf = buf;
-    this.pos = pos;
-  }
+  private buf: ArrayBuffer;
+  private view: Buffer;
+  private start = 0;
 
-  // Returns the current stream position
-  get position(): number {
-    return this.pos;
-  }
-
-  // Returns the number of bytes in the stream
-  get length(): number {
-    return this.buf.length;
-  }
-
-  // Resets the stream to the given postion
-  public seek(pos: number): void {
-    this.pos = pos;
-  }
-
-  // Returns the next byte in the stream
-  public get(): number {
-    const pos = this.pos++;
-
-    if (pos >= this.length) {
-      throw new StreamError('request past end of buffer');
+  constructor(buffer?: ArrayBuffer) {
+    if (buffer) {
+      this.buf = buffer;
+      this.view = Buffer.from(buffer);
+    } else {
+      this.buf = new ArrayBuffer(0);
+      this.view = Buffer.from(this.buf);
     }
+  }
 
-    return this.buf[pos];
+  get buffer(): Buffer {
+    return this.view.subarray(0, this.start);
+  }
+
+  get length(): number {
+    return this.view.byteLength;
+  }
+
+  get position(): number {
+    return this.start;
+  }
+
+  public seek(position: number) {
+    this.start = position;
   }
 
   // Returns a Buffer containing the specified number of bytes starting at the
@@ -44,6 +42,85 @@ export class ByteStream {
       throw new StreamError('request past end of buffer');
     }
 
-    return this.buf.subarray(start, end);
+    return this.view.subarray(start, end);
+  }
+
+  public appendChar(char: number) {
+    this.ensureCapacity(1);
+    this.view[this.start] = char;
+    this.start += 1;
+  }
+
+  public appendUint16(num: number) {
+    this.ensureCapacity(2);
+
+    const value = new Uint16Array([num]);
+    const view = new Uint8Array(value.buffer);
+
+    this.view[this.start] = view[1];
+    this.view[this.start + 1] = view[0];
+    this.start += 2;
+  }
+
+  public appendUint24(num: number) {
+    this.ensureCapacity(3);
+
+    const value = new Uint32Array([num]);
+    const view = new Uint8Array(value.buffer);
+
+    this.view[this.start] = view[2];
+    this.view[this.start + 1] = view[1];
+    this.view[this.start + 2] = view[0];
+    this.start += 3;
+  }
+
+  public appendView(view: Uint8Array) {
+    this.ensureCapacity(view.length);
+    this.view.set(view, this.start);
+    this.start += view.length;
+  }
+
+  public getBlock(size: number): Buffer {
+    if (size <= 0) {
+      return Buffer.alloc(0);
+    }
+
+    if (this.start + size > this.view.length) {
+      throw new Error('request past end of buffer');
+    }
+
+    const result = this.view.subarray(this.start, this.start + size);
+    this.start += size;
+
+    return result;
+  }
+
+  public getUint8(): number {
+    return this.getBlock(1)[0];
+  }
+
+  public getUint16(): number {
+    const block = this.getBlock(2);
+
+    return (block[0] << 8) | block[1];
+  }
+
+  private ensureCapacity(size: number) {
+    if (this.start + size > this.view.byteLength) {
+      const blockSize =
+        ByteStream.BLOCK_SIZE + (size > ByteStream.BLOCK_SIZE ? size : 0);
+      this.realloc(this.view.byteLength + blockSize);
+    }
+  }
+
+  private realloc(size: number) {
+    const newArray = new ArrayBuffer(size);
+    const newView = Buffer.from(newArray);
+
+    // Copy the old buffer into the new one
+    newView.set(this.view);
+
+    this.buf = newArray;
+    this.view = newView;
   }
 }

--- a/src/x509/asn1/length.ts
+++ b/src/x509/asn1/length.ts
@@ -6,7 +6,7 @@ import { ASN1ParseError } from './error';
 // Decodes the length of a DER-encoded ANS.1 element from the supplied stream.
 // https://learn.microsoft.com/en-us/windows/win32/seccertenroll/about-encoded-length-and-value-bytes
 export function decodeLength(stream: ByteStream): number {
-  const buf = stream.get();
+  const buf = stream.getUint8();
 
   // If the most significant bit is UNSET the length is just the value of the
   // byte.
@@ -26,7 +26,7 @@ export function decodeLength(stream: ByteStream): number {
   // Iterate over the bytes that encode the length.
   let len = 0;
   for (let i = 0; i < byteCount; i++) {
-    len = len * 256 + stream.get();
+    len = len * 256 + stream.getUint8();
   }
 
   // This is a valid ASN.1 length encoding, but we don't support it.


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Refactors the `ByteStream` utility class to support both reading-from and writing-to a stream. Since we need to both decode and encode x509 certificates its handy to have a data structure which allows us to either read-from or write-to an array of bytes in discrete chunks. 