### PR TITLE
add createPublicKey to crypto utility module

### DIFF
--- a/src/__tests__/util/crypto.test.ts
+++ b/src/__tests__/util/crypto.test.ts
@@ -13,7 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import { KeyObject } from 'crypto';
 import {
+  createPublicKey,
   generateKeyPair,
   hash,
   randomBytes,
@@ -30,6 +32,34 @@ describe('generateKeyPair', () => {
 
     expect(keypair.publicKey).toBeDefined();
     expect(keypair.publicKey.asymmetricKeyType).toBe('ec');
+  });
+});
+
+describe('createPublicKey', () => {
+  describe('when the input in a PEM-encoded key', () => {
+    const pem = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtZO/hiYFB3WveI+iYoN4I6w17rSA
+tbn02XdfIl+ZhQqUZv88dgDB86bfKyoOokA7fagAEOulkquhKKoOxdOySQ==
+-----END PUBLIC KEY-----`;
+
+    it('creates a public key', () => {
+      const key = createPublicKey(pem);
+      expect(key).toBeDefined();
+      expect((key as KeyObject).asymmetricKeyType).toBe('ec');
+    });
+  });
+
+  describe('when the input is a DER-encoded key', () => {
+    const der = Buffer.from(
+      'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtZO/hiYFB3WveI+iYoN4I6w17rSAtbn02XdfIl+ZhQqUZv88dgDB86bfKyoOokA7fagAEOulkquhKKoOxdOySQ==',
+      'base64'
+    );
+
+    it('creates a public key', () => {
+      const key = createPublicKey(der);
+      expect(key).toBeDefined();
+      expect((key as KeyObject).asymmetricKeyType).toBe('ec');
+    });
   });
 });
 

--- a/src/util/crypto.ts
+++ b/src/util/crypto.ts
@@ -25,6 +25,14 @@ export function generateKeyPair(): KeyPairKeyObjectResult {
   });
 }
 
+export function createPublicKey(key: string | Buffer): KeyLike {
+  if (typeof key === 'string') {
+    return crypto.createPublicKey(key);
+  } else {
+    return crypto.createPublicKey({ key, format: 'der', type: 'spki' });
+  }
+}
+
 export function signBlob(
   data: NodeJS.ArrayBufferView,
   privateKey: KeyLike
@@ -35,12 +43,13 @@ export function signBlob(
 export function verifyBlob(
   data: Buffer,
   key: KeyLike,
-  signature: Buffer
+  signature: Buffer,
+  algorithm?: string
 ): boolean {
   // The try/catch is to work around an issue in Node 14.x where verify throws
   // an error in some scenarios if the signature is invalid.
   try {
-    return crypto.verify(null, data, key, signature);
+    return crypto.verify(algorithm, data, key, signature);
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds a `createPublicKey` function to the crypto utility module which can be used to parse either PEM- or DER-encoded keys and turn them into `KeyLike` objects which can be passed to the sign and verify functions.

Also updates the `verifyBlob` function signature to accept an optional algorithm param which can be used to identify the hash algorithm which should be used when verifying the signature of an artifact.