### PR TITLE
signed certificate timestamp parsing

### DIFF
--- a/src/__tests__/x509/sct.test.ts
+++ b/src/__tests__/x509/sct.test.ts
@@ -1,0 +1,137 @@
+import * as sigstore from '../../types/sigstore';
+import { SignedCertificateTimestamp } from '../../x509/sct';
+
+describe('SignedCertificateTimestamp', () => {
+  // These are values from a real SCT extension
+  const logID =
+    '086092f02852ff6845d1d16b27849c456718ac163dc338d26de6bc2206366f72';
+  const timestamp = '0000018227c09e9c';
+  const signature =
+    '3045022100b9ecb0b5286feea20d442a409da8c5260bd6ae76b311d71faceff1c7fc93c85c02204e35e55d629a1a84f9a885e7621d9b3af9ed8e7ffd0260679139bda764c5e7d0';
+  const sctBuffer = Buffer.from(
+    '00' + // version
+      logID + // logID
+      timestamp + // timestamp
+      '0000' + // extensionLength
+      '04' + // hashAlgorithm
+      '03' + // signatureAlgorithm
+      '0047' + // signatureLength
+      signature, // signature
+    'hex'
+  );
+
+  describe('#parse', () => {
+    describe('when the SCT is valid', () => {
+      it('parses correctly', () => {
+        const sct = SignedCertificateTimestamp.parse(sctBuffer);
+
+        expect(sct.version).toEqual(0x00);
+        expect(sct.logID).toStrictEqual(Buffer.from(logID, 'hex'));
+        expect(sct.timestamp).toStrictEqual(Buffer.from(timestamp, 'hex'));
+        expect(sct.extensions).toHaveLength(0);
+        expect(sct.hashAlgorithm).toEqual(0x04);
+        expect(sct.signatureAlgorithm).toEqual(0x03);
+        expect(sct.signature).toStrictEqual(Buffer.from(signature, 'hex'));
+      });
+    });
+
+    describe('when the SCT is invalid', () => {
+      describe('when the SCT buffer is too short', () => {
+        it('throws an error', () => {
+          expect(() =>
+            SignedCertificateTimestamp.parse(Buffer.from(''))
+          ).toThrow('request past end of buffer');
+        });
+      });
+
+      describe('when the SCT buffer is too long', () => {
+        const sctBuffer = Buffer.from(
+          '00' +
+            logID +
+            timestamp +
+            '0000' +
+            '04' +
+            '03' +
+            '0047' +
+            signature +
+            'DEADBEEF', // extra bytes
+          'hex'
+        );
+
+        it('throws an error', () => {
+          expect(() => SignedCertificateTimestamp.parse(sctBuffer)).toThrow(
+            'SCT buffer length mismatch'
+          );
+        });
+      });
+    });
+  });
+
+  describe('#datetime', () => {
+    const subject = SignedCertificateTimestamp.parse(sctBuffer);
+
+    it('returns the parsed timestamp', () => {
+      expect(subject.datetime).toEqual(new Date('2022-07-22T21:11:51.196Z'));
+    });
+  });
+
+  describe('#algorithm', () => {
+    const subject = SignedCertificateTimestamp.parse(sctBuffer);
+
+    it('returns the hash algorithm', () => {
+      expect(subject.algorithm).toEqual('sha256');
+    });
+  });
+
+  describe('#verify', () => {
+    // Real pre-certificate used to generate the SCT
+    const preCert = Buffer.from(
+      'c355ee53d69e68aade04e5c6cc202cfac11fbcaa67e9a2ba7a64ced2aec8ccd000019b30820197a0030201020214466f689fbcc3be13e63ddbd14a277c41cd56d271300a06082a8648ce3d040303303731153013060355040a130c73696773746f72652e646576311e301c0603550403131573696773746f72652d696e7465726d656469617465301e170d3232303732323231313135315a170d3232303732323231323135315a30003059301306072a8648ce3d020106082a8648ce3d0301070342000459f2ab2bc2b2f9db98e711207b1c61d9f852fba456c40a1dcdd690de9ef9c2fba6133a565ccca76afdeea6352a1b0dbcf993e74e901892bca4ff3977a4a45410a381b73081b4300e0603551d0f0101ff04040302078030130603551d25040c300a06082b06010505070303301d0603551d0e041604141ce0136e2e5cdf1b097582a9326905ffc40f557f301f0603551d23041830168014dfd3e9cf56241196f9a8d8e92855a2c62e18643f301f0603551d110101ff041530138111627269616e40646568616d65722e636f6d302c060a2b0601040183bf300101041e68747470733a2f2f6769746875622e636f6d2f6c6f67696e2f6f61757468',
+      'hex'
+    );
+
+    const subject = SignedCertificateTimestamp.parse(sctBuffer);
+
+    describe('when no key is found for the log', () => {
+      it('throws an error', () => {
+        expect(() => subject.verify(preCert, [])).toThrow(
+          /No key found for log/
+        );
+      });
+    });
+
+    describe('when the key for the log is available', () => {
+      // Real key used to sign the SCT
+      const ctfe =
+        'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbfwR+RJudXscgRBRpKX1XFDy3PyudDxz/SfnRi1fT8ekpfBd2O1uoz7jr3Z8nKzxA69EUQ+eFCFI3zeubPWU7w==';
+
+      const ctl = {
+        baseUrl: '',
+        hashAlgorithm: 'HASH_ALGORITHM_UNSPECIFIED',
+        publicKey: {
+          rawBytes: ctfe,
+          keyDetails: 'PKIX_ECDSA_P256_SHA_256',
+        },
+        logId: { keyId: Buffer.from(logID, 'hex') },
+      };
+
+      const logs: sigstore.TransparencyLogInstance[] = [
+        sigstore.TransparencyLogInstance.fromJSON(ctl),
+      ];
+
+      describe('when the signature is valid', () => {
+        it('returns true', () => {
+          expect(subject.verify(preCert, logs)).toEqual(true);
+        });
+      });
+
+      describe('when the signature is invalid', () => {
+        const preCert = Buffer.from('deadbeaf', 'hex');
+
+        it('returns false', () => {
+          expect(subject.verify(preCert, logs)).toEqual(false);
+        });
+      });
+    });
+  });
+});

--- a/src/types/sigstore/index.ts
+++ b/src/types/sigstore/index.ts
@@ -1,0 +1,2 @@
+export * from './__generated__/sigstore_common';
+export * from './__generated__/sigstore_trustroot';

--- a/src/x509/sct.ts
+++ b/src/x509/sct.ts
@@ -1,0 +1,143 @@
+import * as sigstore from '../types/sigstore';
+import { crypto } from '../util';
+import { ByteStream } from '../util/stream';
+
+interface SCTOptions {
+  version: number;
+  logID: Buffer;
+  timestamp: Buffer;
+  extensions: Buffer;
+  hashAlgorithm: number;
+  signatureAlgorithm: number;
+  signature: Buffer;
+}
+
+export class SignedCertificateTimestamp {
+  readonly version: number;
+  readonly logID: Buffer;
+  readonly timestamp: Buffer;
+  readonly extensions: Buffer;
+  readonly hashAlgorithm: number;
+  readonly signatureAlgorithm: number;
+  readonly signature: Buffer;
+
+  constructor(options: SCTOptions) {
+    this.version = options.version;
+    this.logID = options.logID;
+    this.timestamp = options.timestamp;
+    this.extensions = options.extensions;
+    this.hashAlgorithm = options.hashAlgorithm;
+    this.signatureAlgorithm = options.signatureAlgorithm;
+    this.signature = options.signature;
+  }
+
+  get datetime(): Date {
+    return new Date(Number(this.timestamp.readBigInt64BE()));
+  }
+
+  // Returns the hash algorithm used to generate the SCT's signature.
+  // https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.4.1
+  get algorithm(): string {
+    switch (this.hashAlgorithm) {
+      case 0:
+        return 'none';
+      case 1:
+        return 'md5';
+      case 2:
+        return 'sha1';
+      case 3:
+        return 'sha224';
+      case 4:
+        return 'sha256';
+      case 5:
+        return 'sha384';
+      case 6:
+        return 'sha512';
+      default:
+        return 'unknown';
+    }
+  }
+
+  public verify(
+    preCert: Buffer,
+    logs: sigstore.TransparencyLogInstance[]
+  ): boolean {
+    // Find key for the log reponsible for this signature
+    const log = logs.find((log) => log.logId?.keyId.equals(this.logID));
+
+    if (!log?.publicKey?.rawBytes) {
+      throw new Error(`No key found for log: ${this.logID.toString('base64')}`);
+    }
+
+    const publicKey = crypto.createPublicKey(log.publicKey.rawBytes);
+
+    // Assemble the digitally-signed struct (the data over which the signature
+    // was generated).
+    // https://www.rfc-editor.org/rfc/rfc6962#section-3.2
+    const stream = new ByteStream();
+    stream.appendChar(this.version);
+    stream.appendChar(0x00); // SignatureType = certificate_timestamp(0)
+    stream.appendView(this.timestamp);
+    stream.appendUint16(0x01); // LogEntryType = precert_entry(1)
+    stream.appendView(preCert);
+    stream.appendUint16(this.extensions.byteLength);
+
+    if (this.extensions.byteLength > 0) {
+      stream.appendView(this.extensions);
+    }
+
+    return crypto.verifyBlob(
+      stream.buffer,
+      publicKey,
+      this.signature,
+      this.algorithm
+    );
+  }
+
+  // Parses a SignedCertificateTimestamp from a buffer. SCTs are encoded using
+  // TLS encoding which means the fields and lengths of most fields are
+  // specified as part of the SCT and TLS specs.
+  // https://www.rfc-editor.org/rfc/rfc6962#section-3.2
+  // https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.4.1
+  public static parse(buf: Buffer): SignedCertificateTimestamp {
+    const stream = new ByteStream(buf);
+
+    // Version - enum { v1(0), (255) }
+    const version = stream.getUint8();
+
+    // Log ID  - struct { opaque key_id[32]; }
+    const logID = stream.getBlock(32);
+
+    // Timestamp - uint64
+    const timestamp = stream.getBlock(8);
+
+    // Extensions - opaque extensions<0..2^16-1>;
+    const extenstionLength = stream.getUint16();
+    const extensions = stream.getBlock(extenstionLength);
+
+    // Hash algo - enum { sha256(4), . . . (255) }
+    const hashAlgorithm = stream.getUint8();
+
+    // Signature algo - enum { anonymous(0), rsa(1), dsa(2), ecdsa(3), (255) }
+    const signatureAlgorithm = stream.getUint8();
+
+    // Signature  - opaque signature<0..2^16-1>;
+    const sigLength = stream.getUint16();
+    const signature = stream.getBlock(sigLength);
+
+    // Check that we read the entire buffer
+    if (stream.position !== buf.length) {
+      throw new Error('SCT buffer length mismatch');
+    }
+
+    return new SignedCertificateTimestamp({
+      version,
+      logID,
+      timestamp,
+      extensions,
+      hashAlgorithm,
+      signatureAlgorithm,
+      signature,
+    });
+  }
+}


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds support for parsing and verifying an encoded Signed Certificate Timestamp (SCT)