### PR TITLE
parse SCT list from cert extension

### DIFF
--- a/src/__tests__/x509/ext.test.ts
+++ b/src/__tests__/x509/ext.test.ts
@@ -1,0 +1,67 @@
+import { ASN1Obj } from '../../x509/asn1/obj';
+import { x509SCTExtension } from '../../x509/ext';
+import { SignedCertificateTimestamp } from '../../x509/sct';
+
+describe('x509SCTExtension', () => {
+  describe('constructor', () => {
+    const sctExtension = Buffer.from(
+      '3012060A2B06010401D679020402040404020000',
+      'hex'
+    );
+    const obj = ASN1Obj.parseBuffer(sctExtension);
+
+    it('parses the extension', () => {
+      const subject = new x509SCTExtension(obj);
+      expect(subject.critical).toBe(false);
+      expect(subject.oid).toBe('1.3.6.1.4.1.11129.2.4.2');
+    });
+  });
+
+  describe('#signedCertificateTimestamps', () => {
+    describe('when there are no SCTs in the extension', () => {
+      // Extension w/ zero-length array of SCTs
+      const sctExtension = Buffer.from(
+        '3012060A2B06010401D679020402040404020000',
+        'hex'
+      );
+      const subject = new x509SCTExtension(ASN1Obj.parseBuffer(sctExtension));
+
+      it('returns an empty array', () => {
+        const scts = subject.signedCertificateTimestamps;
+        expect(scts).toBeDefined();
+        expect(scts).toHaveLength(0);
+      });
+    });
+
+    describe('when there are SCTs in the extension', () => {
+      const sctExtension = Buffer.from(
+        '3043060A2B06010401D679020402043504330031002F0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+        'hex'
+      );
+      const subject = new x509SCTExtension(ASN1Obj.parseBuffer(sctExtension));
+
+      it('returns an array of SCTs', () => {
+        const scts = subject.signedCertificateTimestamps;
+        expect(scts).toBeDefined();
+        expect(scts).toHaveLength(1);
+        expect(scts[0]).toBeInstanceOf(SignedCertificateTimestamp);
+      });
+    });
+
+    describe('when the stated length of the SCT list does not match the data ', () => {
+      // Extension where length of SCT list is mismatched with the length of the constituent SCTs
+      const sctExtension = Buffer.from(
+        //                                   |--| Should be 0x0031 for a valid SCT extension
+        '3043060A2B06010401D67902040204350433002F002F0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+        'hex'
+      );
+      const subject = new x509SCTExtension(ASN1Obj.parseBuffer(sctExtension));
+
+      it('throws an error', () => {
+        expect(() => {
+          subject.signedCertificateTimestamps;
+        }).toThrow(/length does not match/);
+      });
+    });
+  });
+});

--- a/src/x509/ext.ts
+++ b/src/x509/ext.ts
@@ -1,4 +1,6 @@
+import { ByteStream } from '../util/stream';
 import { ASN1Obj } from './asn1/obj';
+import { SignedCertificateTimestamp } from './sct';
 
 // https://www.rfc-editor.org/rfc/rfc5280#section-4.1
 export class x509Extension {
@@ -113,5 +115,28 @@ export class x509SCTExtension extends x509Extension {
     super(asn1);
   }
 
-  // TODO: Parse the SCTs
+  get signedCertificateTimestamps(): SignedCertificateTimestamp[] {
+    const buf = this.extnValueObj.subs[0].value;
+    const stream = new ByteStream(buf);
+
+    // The overall list length is encoded in the first two bytes -- note this
+    // is the length of the list in bytes, NOT the number of SCTs in the list
+    const end = stream.getUint16() + 2;
+
+    const sctList = [];
+    while (stream.position < end) {
+      // Read the length of the next SCT
+      const sctLength = stream.getUint16();
+
+      // Slice out the bytes for the next SCT and parse it
+      const sct = stream.getBlock(sctLength);
+      sctList.push(SignedCertificateTimestamp.parse(sct));
+    }
+
+    if (stream.position !== end) {
+      throw new Error('SCT list length does not match actual length');
+    }
+
+    return sctList;
+  }
 }


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the `x509SCTExtension` class to add support for parsing the list of signed-certificate timestamps from the certificate extension.