### PR TITLE
verification of cert-embedded SCTs

### DIFF
--- a/src/x509/cert.ts
+++ b/src/x509/cert.ts
@@ -1,5 +1,6 @@
-import crypto from 'crypto';
-import { pem } from '../util';
+import * as sigstore from '../types/sigstore';
+import { crypto, pem } from '../util';
+import { ByteStream } from '../util/stream';
 import { ASN1Obj } from './asn1/obj';
 import {
   x509AuthorityKeyIDExtension,
@@ -11,11 +12,11 @@ import {
   x509SubjectKeyIDExtension,
 } from './ext';
 
-const EXTENSION_OID_KEY_USAGE = '2.5.29.15';
-const EXTENSION_OID_BASIC_CONSTRAINTS = '2.5.29.19';
-const EXTENSION_OID_SUBJECT_ALT_NAME = '2.5.29.17';
-const EXTENSION_OID_AUTHORITY_KEY_ID = '2.5.29.35';
 const EXTENSION_OID_SUBJECT_KEY_ID = '2.5.29.14';
+const EXTENSION_OID_KEY_USAGE = '2.5.29.15';
+const EXTENSION_OID_SUBJECT_ALT_NAME = '2.5.29.17';
+const EXTENSION_OID_BASIC_CONSTRAINTS = '2.5.29.19';
+const EXTENSION_OID_AUTHORITY_KEY_ID = '2.5.29.35';
 const EXTENSION_OID_SCT = '1.3.6.1.4.1.11129.2.4.2';
 
 // List of recognized critical extensions
@@ -50,8 +51,8 @@ export class x509Certificate {
     return new x509Certificate(asn1);
   }
 
-  get tbsCertificate(): Buffer {
-    return this.tbsCertificateObj.raw;
+  get tbsCertificate(): ASN1Obj {
+    return this.tbsCertificateObj;
   }
 
   get version(): string {
@@ -78,12 +79,8 @@ export class x509Certificate {
     return this.subjectObj.value;
   }
 
-  get publicKey(): crypto.KeyObject {
-    return crypto.createPublicKey({
-      key: this.subjectPublicKeyInfoObj.raw,
-      format: 'der',
-      type: 'spki',
-    });
+  get publicKey(): Buffer {
+    return this.subjectPublicKeyInfoObj.raw;
   }
 
   get signatureAlgorithm(): string {
@@ -94,6 +91,13 @@ export class x509Certificate {
   get signatureValue(): Buffer {
     // Signature value is a bit string, so we need to skip the first byte
     return this.signatureValueObj.value.subarray(1);
+  }
+
+  get extensions(): ASN1Obj[] {
+    // The extension list is the first (and only) element of the extensions
+    // context specific tag
+    const extSeq = this.extensionsObj?.subs[0];
+    return extSeq?.subs || [];
   }
 
   get extKeyUsage(): x509KeyUsageExtension | undefined {
@@ -140,12 +144,13 @@ export class x509Certificate {
   public verify(issuerCertificate?: x509Certificate): boolean {
     // Use the issuer's public key if provided, otherwise use the subject's
     const publicKey = issuerCertificate?.publicKey || this.publicKey;
+    const key = crypto.createPublicKey(publicKey);
 
-    return crypto.verify(
-      this.signatureAlgorithm,
-      this.tbsCertificate,
-      publicKey,
-      this.signatureValue
+    return crypto.verifyBlob(
+      this.tbsCertificate.raw,
+      key,
+      this.signatureValue,
+      this.signatureAlgorithm
     );
   }
 
@@ -157,14 +162,71 @@ export class x509Certificate {
     return this.root.raw.equals(other.root.raw);
   }
 
-  private findExtension(oid: string): ASN1Obj | undefined {
-    // The extension list is the first (and only) element of the extensions
-    // context specific tag
-    const extSeq = this.extensionsObj?.subs[0];
+  public verifySCTs(
+    issuer: x509Certificate,
+    logs: sigstore.TransparencyLogInstance[]
+  ): boolean {
+    let extSCT: x509SCTExtension | undefined;
 
+    // Verifying the SCT requires that we remove the SCT extension and
+    // re-encode the TBS structure to DER -- this value is part of the data
+    // over which the signature is calculated. Since this is a destructive action
+    // we create a copy of the certificate so we can remove the SCT extension
+    // without affecting the original certificate.
+    const clone = this.clone();
+
+    // Intentionally not using the findExtension method here because we want to
+    // remove the the SCT extension from the certificate before calculating the
+    // PreCert structure
+    for (let i = 0; i < clone.extensions.length; i++) {
+      const ext = clone.extensions[i];
+
+      if (ext.subs[0].toOID() === EXTENSION_OID_SCT) {
+        extSCT = new x509SCTExtension(ext);
+
+        // Remove the extension from the certificate
+        clone.extensions.splice(i, 1);
+        break;
+      }
+    }
+
+    if (!extSCT) {
+      throw new Error('Certificate does not contain SCT extension');
+    }
+
+    if (extSCT?.signedCertificateTimestamps?.length === 0) {
+      throw new Error('Certificate does not contain any SCTs');
+    }
+
+    // Construct the PreCert structure
+    // https://www.rfc-editor.org/rfc/rfc6962#section-3.2
+    const preCert = new ByteStream();
+
+    // Calculate hash of the issuer's public key
+    const issuerId = crypto.hash(issuer.publicKey);
+    preCert.appendView(issuerId);
+
+    // Re-encodes the certificate to DER after removing the SCT extension
+    const tbs = clone.tbsCertificate.toDER();
+    preCert.appendUint24(tbs.length);
+    preCert.appendView(tbs);
+
+    return extSCT.signedCertificateTimestamps.every((sct) =>
+      sct.verify(preCert.buffer, logs)
+    );
+  }
+
+  // Creates a copy of the certificate with a new buffer
+  private clone(): x509Certificate {
+    const clone = Buffer.alloc(this.root.raw.length);
+    this.root.raw.copy(clone);
+    return x509Certificate.parse(clone);
+  }
+
+  private findExtension(oid: string): ASN1Obj | undefined {
     // Find the extension with the given OID. The OID will always be the first
     // element of the extension sequence
-    return extSeq?.subs.find((ext) => ext.subs[0].toOID() === oid);
+    return this.extensions.find((ext) => ext.subs[0].toOID() === oid);
   }
 
   // A certificate should be considered invalid if it contains critical


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds a `verifySCTs` function to the `x509Certificate` class which will verify each of the signed-certificate timestamps in the SCT extension against the certificate's issuer and the transparency log public key.