### PR TITLE
update cert verifier to return trusted chain

### DIFF
--- a/src/__tests__/x509/verify.test.ts
+++ b/src/__tests__/x509/verify.test.ts
@@ -82,8 +82,17 @@ describe('CertificateChainVerifier', () => {
         validAt: new Date('2022-12-21T16:22:00.000Z'),
       };
 
-      it('returns without error', () => {
-        verifyCertificateChain(opts);
+      it('does not throw an error', () => {
+        expect(() => verifyCertificateChain(opts)).not.toThrowError();
+      });
+
+      it('returns the trusted chain', () => {
+        const trustedChain = verifyCertificateChain(opts);
+        expect(trustedChain).toBeDefined();
+        expect(trustedChain).toHaveLength(4);
+
+        // The first cert in the chain is the leaf cert
+        expect(trustedChain[0]).toEqual(opts.certs[2]);
       });
     });
 
@@ -93,8 +102,15 @@ describe('CertificateChainVerifier', () => {
         certs: [rootCert],
       };
 
-      it('returns without error', () => {
-        verifyCertificateChain(opts);
+      it('does not throw an error', () => {
+        expect(() => verifyCertificateChain(opts)).not.toThrowError();
+      });
+
+      it('returns the trusted chain', () => {
+        const trustedChain = verifyCertificateChain(opts);
+        expect(trustedChain).toBeDefined();
+        expect(trustedChain).toHaveLength(2);
+        expect(trustedChain[0]).toEqual(opts.certs[0]);
       });
     });
   });

--- a/src/x509/verify.ts
+++ b/src/x509/verify.ts
@@ -9,9 +9,9 @@ interface VerifyCertificateChainOptions {
 
 export function verifyCertificateChain(
   opts: VerifyCertificateChainOptions
-): void {
+): x509Certificate[] {
   const verifier = new CertificateChainVerifier(opts);
-  verifier.verify();
+  return verifier.verify();
 }
 
 class CertificateChainVerifier {
@@ -27,7 +27,7 @@ class CertificateChainVerifier {
     this.validAt = opts.validAt || new Date();
   }
 
-  public verify(): void {
+  public verify(): x509Certificate[] {
     if (this.certs.length === 0) {
       throw new CertificateChainVerificationError('No certificates provided');
     }
@@ -37,6 +37,9 @@ class CertificateChainVerifier {
 
     // Perform validation checks on each certificate in the path
     this.checkPath(certificatePath);
+
+    // Return verified certificate path
+    return certificatePath;
   }
 
   private sort(): x509Certificate[] {


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the `verifyCertificateChain` function to return the verified chain of certificates (as an ordered array of `x509Certificate` objects). By returning the specific list of verified certificates we can use this as input to the SCT verifier to ensure that we are checking the SCTs in the signing certificate against the proper issuer.