### PR TITLE
update return type of verifySCTs

### DIFF
--- a/src/__tests__/x509/cert.test.ts
+++ b/src/__tests__/x509/cert.test.ts
@@ -327,7 +327,10 @@ mygUY7Ii2zbdCdliiow=
 
         it('returns true', () => {
           expect(subject.extSCT).toBeDefined();
-          expect(subject.verifySCTs(issuer, logs)).toBe(true);
+          const results = subject.verifySCTs(issuer, logs);
+          expect(results).toBeDefined();
+          expect(results).toHaveLength(1);
+          expect(results[0].verified).toBe(true);
         });
       });
 
@@ -335,7 +338,10 @@ mygUY7Ii2zbdCdliiow=
         const badIssuer = x509Certificate.parse(certificates.root);
 
         it('returns false', () => {
-          expect(subject.verifySCTs(badIssuer, logs)).toBe(false);
+          const results = subject.verifySCTs(badIssuer, logs);
+          expect(results).toBeDefined();
+          expect(results).toHaveLength(1);
+          expect(results[0].verified).toBe(false);
         });
       });
     });


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the return type of the `verifySCTs` method on the certificate class to return an array of results instead of a rolled-up boolean. As part of the bundle verification we need to be able to count the number of SCTs in the signing certificate which were successfully verified.