### PR TITLE
introduce new CA client class

### DIFF
--- a/src/__tests__/ca/format.test.ts
+++ b/src/__tests__/ca/format.test.ts
@@ -14,22 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import * as crypto from 'crypto';
-import { fulcio } from '../../types/fulcio';
+import { toCertificateRequest } from '../../ca/format';
 
-describe('fulcio', () => {
-  describe('toCertificateRequest', () => {
-    const key = crypto.generateKeyPairSync('ec', {
-      namedCurve: 'P-256',
-    }).publicKey;
-    const challenge = Buffer.from('challenge');
+describe('toCertificateRequest', () => {
+  const key = crypto.generateKeyPairSync('ec', {
+    namedCurve: 'P-256',
+  }).publicKey;
+  const challenge = Buffer.from('challenge');
 
-    it('returns a CertificateRequest', () => {
-      const cr = fulcio.toCertificateRequest(key, challenge);
+  it('returns a CertificateRequest', () => {
+    const cr = toCertificateRequest(key, challenge);
 
-      expect(cr.signedEmailAddress).toEqual(challenge.toString('base64'));
-      expect(cr.publicKey.content).toEqual(
-        key.export({ type: 'spki', format: 'der' }).toString('base64')
-      );
-    });
+    expect(cr.signedEmailAddress).toEqual(challenge.toString('base64'));
+    expect(cr.publicKey.content).toEqual(
+      key.export({ type: 'spki', format: 'der' }).toString('base64')
+    );
   });
 });

--- a/src/__tests__/ca/index.test.ts
+++ b/src/__tests__/ca/index.test.ts
@@ -1,0 +1,98 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import crypto from 'crypto';
+import nock from 'nock';
+import { CAClient } from '../../ca';
+
+describe('CAClient', () => {
+  const baseURL = 'http://localhost:8080';
+
+  describe('constructor', () => {
+    it('should create a new instance', () => {
+      const client = new CAClient({ fulcioBaseURL: baseURL });
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe('createSigningCertificate', () => {
+    const subject = new CAClient({ fulcioBaseURL: baseURL });
+
+    const leafCertificate = `-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n`;
+    const rootCertificate = `-----BEGIN CERTIFICATE-----\nxyz\n-----END CERTIFICATE-----\n`;
+    const certChain = [leafCertificate, rootCertificate].join('');
+
+    // Request data
+    const identityToken = 'a.b.c';
+
+    const pem = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtZO/hiYFB3WveI+iYoN4I6w17rSA
+tbn02XdfIl+ZhQqUZv88dgDB86bfKyoOokA7fagAEOulkquhKKoOxdOySQ==
+-----END PUBLIC KEY-----`;
+    const publicKey = crypto.createPublicKey(pem);
+    const challenge = Buffer.from('challenge');
+
+    const certRequest = {
+      publicKey: {
+        content: publicKey
+          .export({ type: 'spki', format: 'der' })
+          .toString('base64'),
+      },
+      signedEmailAddress: challenge.toString('base64'),
+    };
+
+    describe('when Fulcio returns a valid response', () => {
+      beforeEach(() => {
+        // Mock Fulcio request
+        nock(baseURL)
+          .matchHeader('Accept', 'application/pem-certificate-chain')
+          .matchHeader('Content-Type', 'application/json')
+          .matchHeader('Authorization', `Bearer ${identityToken}`)
+          .matchHeader('User-Agent', new RegExp('sigstore-js\\/\\d+.\\d+.\\d+'))
+          .post('/api/v1/signingCert', certRequest)
+          .reply(201, certChain);
+      });
+
+      it('returns the certificate chain', async () => {
+        const result = await subject.createSigningCertificate(
+          identityToken,
+          publicKey,
+          challenge
+        );
+
+        expect(result).toEqual([leafCertificate, rootCertificate]);
+      });
+    });
+
+    describe('when Fulcio returns an error response', () => {
+      beforeEach(() => {
+        // Mock Fulcio request
+        nock(baseURL)
+          .matchHeader('Accept', 'application/pem-certificate-chain')
+          .matchHeader('Content-Type', 'application/json')
+          .matchHeader('Authorization', `Bearer ${identityToken}`)
+          .matchHeader('User-Agent', new RegExp('sigstore-js\\/\\d+.\\d+.\\d+'))
+          .post('/api/v1/signingCert', certRequest)
+          .reply(500, {});
+      });
+
+      it('throws an error', async () => {
+        await expect(
+          subject.createSigningCertificate(identityToken, publicKey, challenge)
+        ).rejects.toThrow('HTTP Error: 500 Internal Server Error');
+      });
+    });
+  });
+});

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import nock from 'nock';
-import { Fulcio } from '../client';
+import { CAClient } from '../ca';
 import { Signer } from '../sign';
 import { TLogClient } from '../tlog';
 import { HashAlgorithm } from '../types/bundle';
@@ -30,12 +30,12 @@ describe('Signer', () => {
   };
   const jwt = `.${Buffer.from(JSON.stringify(jwtPayload)).toString('base64')}.`;
 
-  const fulcio = new Fulcio({ baseURL: fulcioBaseURL });
+  const ca = new CAClient({ fulcioBaseURL });
   const tlog = new TLogClient({ rekorBaseURL });
   const idp = { getToken: () => Promise.resolve(jwt) };
 
   const subject = new Signer({
-    fulcio,
+    ca,
     tlog,
     identityProviders: [idp],
   });
@@ -51,7 +51,7 @@ describe('Signer', () => {
     describe('when using the default signer', () => {
       describe('when no identity provider returns a token', () => {
         const noIDTokenSubject = new Signer({
-          fulcio,
+          ca,
           tlog,
           identityProviders: [],
         });
@@ -250,7 +250,7 @@ describe('Signer', () => {
 
       it('invokes the custom signer', async () => {
         const s = new Signer({
-          fulcio,
+          ca,
           tlog,
           identityProviders: [],
           signer,

--- a/src/__tests__/sigstore.test.ts
+++ b/src/__tests__/sigstore.test.ts
@@ -116,7 +116,7 @@ describe('sign', () => {
     const options = args[0];
 
     // Signer was constructed with the correct options
-    expect(options).toHaveProperty('fulcio', expect.anything());
+    expect(options).toHaveProperty('ca', expect.anything());
     expect(options).toHaveProperty('tlog', expect.anything());
     expect(options.identityProviders).toHaveLength(1);
   });
@@ -188,7 +188,7 @@ describe('signAttestation', () => {
     const options = args[0];
 
     // Signer was constructed with the correct options
-    expect(options).toHaveProperty('fulcio', expect.anything());
+    expect(options).toHaveProperty('ca', expect.anything());
     expect(options).toHaveProperty('tlog', expect.anything());
     expect(options.identityProviders).toHaveLength(1);
   });

--- a/src/ca/format.ts
+++ b/src/ca/format.ts
@@ -14,22 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { KeyObject } from 'crypto';
+import { CertificateRequest } from '../client/fulcio';
 
-export interface CertificateRequest {
-  publicKey: { content: string };
-  signedEmailAddress: string;
-}
-
-export const fulcio = {
-  toCertificateRequest: (
-    publicKey: KeyObject,
-    challenge: Buffer
-  ): CertificateRequest => ({
+export function toCertificateRequest(
+  publicKey: KeyObject,
+  challenge: Buffer
+): CertificateRequest {
+  return {
     publicKey: {
       content: publicKey
         .export({ type: 'spki', format: 'der' })
         .toString('base64'),
     },
     signedEmailAddress: challenge.toString('base64'),
-  }),
-};
+  };
+}

--- a/src/ca/index.ts
+++ b/src/ca/index.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { KeyObject } from 'crypto';
+import { Fulcio } from '../client';
+import { pem } from '../util';
+import { toCertificateRequest } from './format';
+
+export interface CA {
+  createSigningCertificate: (
+    identityToken: string,
+    publicKey: KeyObject,
+    challenge: Buffer
+  ) => Promise<string[]>;
+}
+
+export interface CAClientOptions {
+  fulcioBaseURL: string;
+}
+
+export class CAClient implements CA {
+  private fulcio: Fulcio;
+
+  constructor(options: CAClientOptions) {
+    this.fulcio = new Fulcio({ baseURL: options.fulcioBaseURL });
+  }
+
+  public async createSigningCertificate(
+    identityToken: string,
+    publicKey: KeyObject,
+    challenge: Buffer
+  ): Promise<string[]> {
+    const request = toCertificateRequest(publicKey, challenge);
+
+    const certificate = await this.fulcio.createSigningCertificate(
+      identityToken,
+      request
+    );
+
+    return pem.split(certificate);
+  }
+}

--- a/src/client/fulcio.ts
+++ b/src/client/fulcio.ts
@@ -14,14 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import fetch, { FetchInterface } from 'make-fetch-happen';
-import { CertificateRequest } from '../types/fulcio';
 import { ua } from '../util';
 import { checkStatus } from './error';
 
-const DEFAULT_BASE_URL = 'https://fulcio.sigstore.dev';
-
 export interface FulcioOptions {
-  baseURL?: string;
+  baseURL: string;
+}
+
+export interface CertificateRequest {
+  publicKey: { content: string };
+  signedEmailAddress: string;
 }
 
 /**
@@ -41,7 +43,7 @@ export class Fulcio {
         'User-Agent': ua.getUserAgent(),
       },
     });
-    this.baseUrl = options.baseURL ?? DEFAULT_BASE_URL;
+    this.baseUrl = options.baseURL;
   }
 
   public async createSigningCertificate(


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Introduces a new `CAClient` which sits between the `Signer` and the `Fulcio` client. This helps to encapsulate some of the details around formatting the Fulcio certificate request (which will come in handy when we switch to the v2 API at some point) and also mirrors the way that we have fronted the `Rekor` API client w/ a `TLog` class.

This will also give us a nice place to add the Fulcio-specific certificate verification logic.