### PR TITLE
bundle conversion helper functions

### DIFF
--- a/src/__tests__/types/index.test.ts
+++ b/src/__tests__/types/index.test.ts
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import * as legacy from '../../types/bundle';
+import {
+  translateLegacyBundle,
+  translateLegacyBundleJSON,
+} from '../../types/index';
+import bundles from '../__fixtures__/bundles/';
+
+describe('translateLegacyBundleJSON', () => {
+  it('should translate legacy bundle', () => {
+    const legacyBundleJSON = bundles.dsse.valid.withSigningCert;
+    const json = translateLegacyBundleJSON(legacyBundleJSON);
+
+    expect(json).toBeDefined();
+    expect(json.verificationMaterial.tlogEntries).toBeDefined();
+    expect(json.verificationData).toBeUndefined();
+  });
+});
+
+describe('translateLegacyBundle', () => {
+  it('should trantlates the legacy bundle', () => {
+    const legacyBundleJSON = bundles.dsse.valid.withSigningCert;
+    const legacyBundle = legacy.Bundle.fromJSON(legacyBundleJSON);
+    const bundle = translateLegacyBundle(legacyBundle);
+
+    expect(bundle).toBeDefined();
+    expect(bundle.verificationMaterial?.tlogEntries).toBeDefined();
+    expect(bundle.verificationMaterial?.tlogEntries).toHaveLength(1);
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import * as legacy from './bundle';
+import * as sigstore from './sigstore';
+
+// Convert from old bundle format to new one
+// TODO: Remove this once we switched all code to use the new format
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function translateLegacyBundleJSON(json: any): any {
+  const legacyBundle = legacy.Bundle.fromJSON(json);
+  const bundle = translateLegacyBundle(legacyBundle);
+  return sigstore.Bundle.toJSON(bundle);
+}
+
+// Convert from old bundle format to new one
+// TODO: Remove this once we switched all code to use the new format
+export function translateLegacyBundle(
+  legacyBundle: legacy.Bundle
+): sigstore.Bundle {
+  let content: sigstore.Bundle['content'];
+
+  // One of the values from the HashAlgorithm enum was removed in the new
+  // version, so we need to unpack the "content" structure and ensure that
+  // the value was not set to the removed value.
+  if (legacyBundle.content?.$case === 'dsseEnvelope') {
+    content = legacyBundle.content;
+  } else if (legacyBundle.content?.$case === 'messageSignature') {
+    content = {
+      $case: 'messageSignature',
+      messageSignature: {
+        signature: legacyBundle.content.messageSignature.signature,
+        messageDigest: legacyBundle.content.messageSignature.messageDigest
+          ? {
+              digest:
+                legacyBundle.content.messageSignature.messageDigest?.digest,
+              algorithm:
+                legacyBundle.content.messageSignature.messageDigest
+                  .algorithm === legacy.HashAlgorithm.SHA2_256
+                  ? sigstore.HashAlgorithm.SHA2_256
+                  : sigstore.HashAlgorithm.HASH_ALGORITHM_UNSPECIFIED,
+            }
+          : undefined,
+      },
+    };
+  }
+
+  // Relocate the tlogEntries and timestampVerificationData fields from the
+  // verificationData field to the verificationMaterial field.
+  return {
+    mediaType: legacyBundle.mediaType,
+    content: content,
+    verificationMaterial: {
+      tlogEntries: legacyBundle.verificationData
+        ? legacyBundle.verificationData.tlogEntries
+        : [],
+      timestampVerificationData:
+        legacyBundle.verificationData?.timestampVerificationData,
+      ...legacyBundle.verificationMaterial,
+    },
+  };
+}

--- a/src/types/sigstore/index.ts
+++ b/src/types/sigstore/index.ts
@@ -1,2 +1,19 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+export * from './__generated__/sigstore_bundle';
 export * from './__generated__/sigstore_common';
 export * from './__generated__/sigstore_trustroot';
+export * from './__generated__/sigstore_verification';


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds a couple of helper functions to convert from the legacy (current) bundle format to the v1 (proposed) format. These will be removed once we have migrated everything to the v1 format, but I don't want to write anymore code against the old format, so I'll use this shim as a temporary way to stitch together code relying on different versions of the bundle.