### PR TITLE
verification of bundle certificates

### DIFF
--- a/src/__tests__/ca/verify.test.ts
+++ b/src/__tests__/ca/verify.test.ts
@@ -1,0 +1,147 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import fs from 'fs';
+import { verifySigningCertificate } from '../../ca/verify';
+import { translateLegacyBundleJSON } from '../../types';
+import * as sigstore from '../../types/sigstore';
+import bundles from '../__fixtures__/bundles/';
+
+describe('verifySigningCertificate', () => {
+  // Temporary until we reconsole bundle formats
+  const bundleJSON = translateLegacyBundleJSON(
+    bundles.dsse.valid.withSigningCert
+  );
+  const bundle = sigstore.Bundle.fromJSON(bundleJSON);
+
+  const trustedRootJSON = JSON.parse(
+    fs
+      .readFileSync(require.resolve('../../../store/trusted_root.json'))
+      .toString('utf8')
+  );
+  const trustedRoot: sigstore.TrustedRoot =
+    sigstore.TrustedRoot.fromJSON(trustedRootJSON);
+
+  const opts: sigstore.ArtifactVerificationOptions_CtlogOptions = {
+    disable: false,
+    detachedSct: false,
+    threshold: 1,
+  };
+
+  describe('when the bundle does not contain a certificate chain', () => {
+    // Bundle with no certificate chain
+    const bundleJSON = translateLegacyBundleJSON(
+      bundles.dsse.valid.withPublicKey
+    );
+    const bundle = sigstore.Bundle.fromJSON(bundleJSON);
+
+    it('throws an error', () => {
+      expect(() =>
+        verifySigningCertificate(bundle, trustedRoot, opts)
+      ).toThrowError('No certificate chain in bundle');
+    });
+  });
+
+  describe('when there are NO valid CAs for the signing certificate', () => {
+    // CA w/ validFor.end date in the past
+    const ca: sigstore.CertificateAuthority = {
+      uri: '',
+      subject: undefined,
+      validFor: {
+        start: new Date(0),
+        end: new Date(1),
+      },
+      certChain: { certificates: [] },
+    };
+
+    const trustedRoot: sigstore.TrustedRoot = {
+      certificateAuthorities: [ca],
+      ctlogs: [],
+      tlogs: [],
+      timestampAuthorities: [],
+    };
+
+    it('throws an error', () => {
+      expect(() =>
+        verifySigningCertificate(bundle, trustedRoot, opts)
+      ).toThrowError('No valid certificate authorities');
+    });
+  });
+
+  describe('when signing cert does NOT match the certificate authority', () => {
+    // CA with no trusted cert chain (will prevent signing cert from being verified)
+    const ca: sigstore.CertificateAuthority = {
+      uri: '',
+      subject: undefined,
+      validFor: {
+        start: new Date(0),
+      },
+      certChain: undefined,
+    };
+
+    const trustedRoot: sigstore.TrustedRoot = {
+      certificateAuthorities: [ca],
+      ctlogs: [],
+      tlogs: [],
+      timestampAuthorities: [],
+    };
+
+    it('throws an error', () => {
+      expect(() =>
+        verifySigningCertificate(bundle, trustedRoot, opts)
+      ).toThrowError('No valid certificate chain');
+    });
+  });
+
+  describe('when the SCT verification threshold is not met', () => {
+    const threshold = Number.MAX_SAFE_INTEGER;
+
+    describe('when SCT verification is disabled', () => {
+      const opts: sigstore.ArtifactVerificationOptions_CtlogOptions = {
+        disable: true,
+        detachedSct: false,
+        threshold,
+      };
+
+      it('returns without error', () => {
+        expect(() =>
+          verifySigningCertificate(bundle, trustedRoot, opts)
+        ).not.toThrow();
+      });
+    });
+
+    describe('when SCT verification is NOT disabled', () => {
+      const opts: sigstore.ArtifactVerificationOptions_CtlogOptions = {
+        disable: false,
+        detachedSct: false,
+        threshold,
+      };
+
+      it('throws an error', () => {
+        expect(() =>
+          verifySigningCertificate(bundle, trustedRoot, opts)
+        ).toThrowError(/Not enough SCTs verified/);
+      });
+    });
+  });
+
+  describe('when everything verifies without error', () => {
+    it('returns without error', () => {
+      expect(() =>
+        verifySigningCertificate(bundle, trustedRoot, opts)
+      ).not.toThrow();
+    });
+  });
+});

--- a/src/ca/verify.ts
+++ b/src/ca/verify.ts
@@ -1,0 +1,125 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { VerificationError } from '../error';
+import * as sigstore from '../types/sigstore';
+import { x509Certificate } from '../x509/cert';
+import { verifyCertificateChain } from '../x509/verify';
+
+export function verifySigningCertificate(
+  bundle: sigstore.Bundle,
+  trustedRoot: sigstore.TrustedRoot,
+  options: sigstore.ArtifactVerificationOptions_CtlogOptions
+) {
+  if (bundle.verificationMaterial?.content?.$case !== 'x509CertificateChain') {
+    throw new VerificationError('No certificate chain in bundle');
+  }
+
+  const bundleCerts = parseCerts(
+    bundle.verificationMaterial.content.x509CertificateChain.certificates
+  );
+
+  // Check that a trusted certificate chain can be found for the signing
+  // certificate in the bundle
+  const trustedChain = verifyChain(
+    bundleCerts,
+    trustedRoot.certificateAuthorities
+  );
+
+  // Unless disabled, verify the SCTs in the signing certificate
+  if (!options.disable) {
+    verifySCTs(trustedChain, trustedRoot.ctlogs, options);
+  }
+}
+
+function verifyChain(
+  bundleCerts: x509Certificate[],
+  certificateAuthorities: sigstore.CertificateAuthority[]
+): x509Certificate[] {
+  const signingCert = bundleCerts[0];
+
+  // Filter the list of certificate authorities to those which are valid for the
+  // signing certificate's notBefore date.
+  const validCAs = filterCertificateAuthorities(
+    certificateAuthorities,
+    signingCert.notBefore
+  );
+
+  if (validCAs.length === 0) {
+    throw new VerificationError('No valid certificate authorities');
+  }
+
+  let trustedChain: x509Certificate[] = [];
+
+  // Loop through all valid CAs and attempt to verify the certificate chain
+  const verified = validCAs.find((ca) => {
+    const trustedCerts = parseCerts(ca.certChain?.certificates || []);
+    try {
+      trustedChain = verifyCertificateChain({
+        trustedCerts,
+        certs: bundleCerts,
+        validAt: signingCert.notBefore,
+      });
+      return true;
+    } catch (e) {
+      return false;
+    }
+  });
+
+  if (!verified) {
+    throw new VerificationError('No valid certificate chain');
+  }
+
+  return trustedChain;
+}
+
+function verifySCTs(
+  certificateChain: x509Certificate[],
+  ctLogs: sigstore.TransparencyLogInstance[],
+  options: sigstore.ArtifactVerificationOptions_CtlogOptions
+) {
+  const signingCert = certificateChain[0];
+  const issuerCert = certificateChain[1];
+  const sctResults = signingCert.verifySCTs(issuerCert, ctLogs);
+
+  // Count the number of verified SCTs which were found
+  const verifiedSCTCount = sctResults.filter((sct) => sct.verified).length;
+
+  if (verifiedSCTCount < options.threshold) {
+    throw new VerificationError(
+      `Not enough SCTs verified (found ${verifiedSCTCount}, need ${options.threshold})`
+    );
+  }
+}
+
+// Filter the list of certificate authorities to those which are valid for the
+// given date.
+function filterCertificateAuthorities(
+  certificateAuthorities: sigstore.CertificateAuthority[],
+  validAt: Date
+): sigstore.CertificateAuthority[] {
+  return certificateAuthorities.filter(
+    (ca) =>
+      ca.validFor &&
+      ca.validFor.start &&
+      ca.validFor.start <= validAt &&
+      (!ca.validFor.end || validAt <= ca.validFor.end)
+  );
+}
+
+// Parse the raw bytes of a certificate into an x509Certificate object.
+function parseCerts(certs: sigstore.X509Certificate[]): x509Certificate[] {
+  return certs.map((cert) => x509Certificate.parse(cert.rawBytes));
+}


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds a `verifySigningCertificate` function which accepts a Sigstore bundle and a trusted root and will perform all of the necessary verification steps on the certificate chain contained in the bundle (certificated chain verification, and verification of any SCTs in the signing certificate).