### PR TITLE
narrow some of the sigstore generated types

### DIFF
--- a/src/__tests__/types/sigstore/index.test.ts
+++ b/src/__tests__/types/sigstore/index.test.ts
@@ -1,0 +1,92 @@
+import * as sigstore from '../../../types/sigstore';
+import bundles from '../../__fixtures__/bundles/';
+
+describe('isBundleWithCertificateChain', () => {
+  describe('when the bundle contains a certificate chain', () => {
+    const json = bundles.dsse.valid.withSigningCert;
+    const bundle = sigstore.Bundle.fromJSON(json);
+
+    it('returns true', () => {
+      expect(sigstore.isBundleWithCertificateChain(bundle)).toBe(true);
+    });
+  });
+
+  describe('when the bundle does NOT contain a certificate chain', () => {
+    const json = bundles.dsse.valid.withPublicKey;
+    const bundle = sigstore.Bundle.fromJSON(json);
+
+    it('returns false', () => {
+      expect(sigstore.isBundleWithCertificateChain(bundle)).toBe(false);
+    });
+  });
+});
+
+describe('isCAVerificationOptions', () => {
+  describe('when the verification options are for a CA', () => {
+    const opts: sigstore.ArtifactVerificationOptions = {
+      ctlogOptions: {
+        detachedSct: false,
+        disable: false,
+        threshold: 1,
+      },
+      signers: {
+        $case: 'certificateIdentities',
+        certificateIdentities: {
+          identities: [],
+        },
+      },
+    };
+    it('returns true', () => {
+      expect(sigstore.isCAVerificationOptions(opts)).toBe(true);
+    });
+  });
+
+  describe('when the verification options do not include ctlogOptions', () => {
+    const opts: sigstore.ArtifactVerificationOptions = {
+      signers: {
+        $case: 'certificateIdentities',
+        certificateIdentities: {
+          identities: [],
+        },
+      },
+    };
+
+    it('returns false', () => {
+      expect(sigstore.isCAVerificationOptions(opts)).toBe(false);
+    });
+  });
+
+  describe('when the verification options do not include signers', () => {
+    const opts: sigstore.ArtifactVerificationOptions = {
+      ctlogOptions: {
+        detachedSct: false,
+        disable: false,
+        threshold: 1,
+      },
+    };
+
+    it('returns false', () => {
+      expect(sigstore.isCAVerificationOptions(opts)).toBe(false);
+    });
+  });
+
+  describe('when the verification options include public key signers', () => {
+    const opts: sigstore.ArtifactVerificationOptions = {
+      ctlogOptions: {
+        detachedSct: false,
+        disable: false,
+        threshold: 1,
+      },
+      signers: {
+        $case: 'publicKeys',
+        publicKeys: {
+          publicKeys: [],
+        },
+      },
+    };
+
+    it('returns false', () => {
+      expect(sigstore.isCAVerificationOptions(opts)).toBe(false);
+    });
+  });
+});

--- a/src/ca/verify.ts
+++ b/src/ca/verify.ts
@@ -19,14 +19,10 @@ import { x509Certificate } from '../x509/cert';
 import { verifyCertificateChain } from '../x509/verify';
 
 export function verifySigningCertificate(
-  bundle: sigstore.Bundle,
+  bundle: sigstore.BundleWithCertificateChain,
   trustedRoot: sigstore.TrustedRoot,
-  options: sigstore.ArtifactVerificationOptions_CtlogOptions
+  options: sigstore.CAArtifactVerificationOptions
 ) {
-  if (bundle.verificationMaterial?.content?.$case !== 'x509CertificateChain') {
-    throw new VerificationError('No certificate chain in bundle');
-  }
-
   const bundleCerts = parseCerts(
     bundle.verificationMaterial.content.x509CertificateChain.certificates
   );
@@ -39,8 +35,8 @@ export function verifySigningCertificate(
   );
 
   // Unless disabled, verify the SCTs in the signing certificate
-  if (!options.disable) {
-    verifySCTs(trustedChain, trustedRoot.ctlogs, options);
+  if (options.ctlogOptions.disable === false) {
+    verifySCTs(trustedChain, trustedRoot.ctlogs, options.ctlogOptions);
   }
 }
 

--- a/src/types/sigstore/index.ts
+++ b/src/types/sigstore/index.ts
@@ -13,7 +13,53 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import { Bundle, VerificationMaterial } from './__generated__/sigstore_bundle';
+import { ArtifactVerificationOptions } from './__generated__/sigstore_verification';
+
 export * from './__generated__/sigstore_bundle';
 export * from './__generated__/sigstore_common';
 export * from './__generated__/sigstore_trustroot';
 export * from './__generated__/sigstore_verification';
+
+// Subset of sigstore.Bundle that has a certificate chain as part
+// of the verification material (as opposed to a public key)
+export type BundleWithCertificateChain = Bundle & {
+  verificationMaterial: VerificationMaterial & {
+    content: Extract<
+      VerificationMaterial['content'],
+      { $case: 'x509CertificateChain' }
+    >;
+  };
+};
+
+// Type guard for narrowing a Bundle to a BundleWithCertificateChain
+export function isBundleWithCertificateChain(
+  bundle: Bundle
+): bundle is BundleWithCertificateChain {
+  return (
+    bundle.verificationMaterial !== undefined &&
+    bundle.verificationMaterial.content !== undefined &&
+    bundle.verificationMaterial.content.$case === 'x509CertificateChain'
+  );
+}
+
+// Subset of sigstore.ArtifactVerificationOptions that has a
+// both ctlogOptions and certificate identities defined
+export type CAArtifactVerificationOptions = Required<
+  Pick<ArtifactVerificationOptions, 'ctlogOptions'>
+> & {
+  signers: Extract<
+    ArtifactVerificationOptions['signers'],
+    { $case: 'certificateIdentities' }
+  >;
+};
+
+export function isCAVerificationOptions(
+  options: ArtifactVerificationOptions
+): options is CAArtifactVerificationOptions {
+  return (
+    options.ctlogOptions !== undefined &&
+    options.signers !== undefined &&
+    options.signers.$case === 'certificateIdentities'
+  );
+}


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Establishes some "narrowed" versions of the types generated from the Sigstore protobufs. Specifically:

* `BundleWithCertificateChain` - a version of the Sigstore `Bundle` which is known to have a Fulcio certificate chain as part of the verification material.
* `CAArtifactVerificationOptions` a version of the `ArtifactVerificationOptions` which is known to contain the `ctlogOptions` and `signers` data necessary to verify a bundle containing a Fulcio certificate chain.

Using these narrowed types (and associated type guards) limits the number of places where we need to check for the presence of certain optional values as we pass these objects through the various layers of the system.

I expect to add more types like this as I build out the rest of the verification logic.