### PR TITLE
split CA verification code into multiple files

### DIFF
--- a/src/__tests__/ca/verify/index.test.ts
+++ b/src/__tests__/ca/verify/index.test.ts
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import fs from 'fs';
-import { verifySigningCertificate } from '../../ca/verify';
-import * as sigstore from '../../types/sigstore';
-import bundles from '../__fixtures__/bundles/';
+import { verifySigningCertificate } from '../../../ca/verify';
+import * as sigstore from '../../../types/sigstore';
+import bundles from '../../__fixtures__/bundles/';
 
 describe('verifySigningCertificate', () => {
   // Temporary until we reconsole bundle formats
@@ -27,7 +27,7 @@ describe('verifySigningCertificate', () => {
 
   const trustedRootJSON = JSON.parse(
     fs
-      .readFileSync(require.resolve('../../../store/trusted_root.json'))
+      .readFileSync(require.resolve('../../../../store/trusted_root.json'))
       .toString('utf8')
   );
   const trustedRoot: sigstore.TrustedRoot =

--- a/src/ca/verify/index.ts
+++ b/src/ca/verify/index.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import * as sigstore from '../../types/sigstore';
+import { verifyChain } from './chain';
+import { verifySCTs } from './sct';
+
+export function verifySigningCertificate(
+  bundle: sigstore.BundleWithCertificateChain,
+  trustedRoot: sigstore.TrustedRoot,
+  options: sigstore.CAArtifactVerificationOptions
+) {
+  // Check that a trusted certificate chain can be found for the signing
+  // certificate in the bundle
+  const trustedChain = verifyChain(
+    bundle.verificationMaterial.content.x509CertificateChain.certificates,
+    trustedRoot.certificateAuthorities
+  );
+
+  // Unless disabled, verify the SCTs in the signing certificate
+  if (options.ctlogOptions.disable === false) {
+    verifySCTs(trustedChain, trustedRoot.ctlogs, options.ctlogOptions);
+  }
+}

--- a/src/ca/verify/sct.ts
+++ b/src/ca/verify/sct.ts
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { VerificationError } from '../../error';
+import * as sigstore from '../../types/sigstore';
+import { x509Certificate } from '../../x509/cert';
+
+export function verifySCTs(
+  certificateChain: x509Certificate[],
+  ctLogs: sigstore.TransparencyLogInstance[],
+  options: sigstore.ArtifactVerificationOptions_CtlogOptions
+) {
+  const signingCert = certificateChain[0];
+  const issuerCert = certificateChain[1];
+  const sctResults = signingCert.verifySCTs(issuerCert, ctLogs);
+
+  // Count the number of verified SCTs which were found
+  const verifiedSCTCount = sctResults.filter((sct) => sct.verified).length;
+
+  if (verifiedSCTCount < options.threshold) {
+    throw new VerificationError(
+      `Not enough SCTs verified (found ${verifiedSCTCount}, need ${options.threshold})`
+    );
+  }
+}


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
This is just a refactor of the existing certificate verification code, splitting it into multiple files. The original "src/ca/verify.ts" was getting pretty long (and I'm about to add a bunch more verification logic in support of signer identity verification) so I'm splitting it across multiple files to make it a bit more maintainable.

May come back and do a similar decomposition of the unit tests at some point, but leaving these as-is for now.