### PR TITLE
signer identity verification

### DIFF
--- a/hack/ca/Makefile
+++ b/hack/ca/Makefile
@@ -97,6 +97,7 @@ nosan.crt: int.crt
 		-subj / \
 		-addext "keyUsage = critical, digitalSignature" \
 		-addext "extendedKeyUsage = codeSigning" \
+		-addext "1.3.6.1.4.1.57264.1.1 = DER:46:4F:4F" \
 		-out store/nosan/nosan.csr
 	openssl ca \
 		-notext \

--- a/src/__tests__/__fixtures__/certs.ts
+++ b/src/__tests__/__fixtures__/certs.ts
@@ -1,3 +1,18 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 export const certificates = {
   root: `-----BEGIN CERTIFICATE-----
 MIIBzTCCAVOgAwIBAgIUQSFLFi9Qcj7aAn/JIVCBxeAkaEcwCgYIKoZIzj0EAwMw
@@ -55,16 +70,16 @@ QHcettKBr/5eWu4DEmBya983E3fB9MlOZ8gYF+UzOJNyvlaTTQ==
 
   // Leaf cert w/ no SAN extension
   nosan: `-----BEGIN CERTIFICATE-----
-MIIBvDCCAUKgAwIBAgIUN0K550PXvbBPMCMMO7PZFueX86kwCgYIKoZIzj0EAwMw
+MIIBzzCCAVWgAwIBAgIUdc4zXkJS22Mlt65StmpkV483+BowCgYIKoZIzj0EAwMw
 MzETMBEGA1UECgwKZm9vYmFyLmRldjEcMBoGA1UEAwwTZm9vYmFyLWludGVybWVk
 aWF0ZTAeFw05MDAxMDEwMDAwMDBaFw00MDAxMDEwMDAwMDBaMAAwWTATBgcqhkjO
-PQIBBggqhkjOPQMBBwNCAASayVcJSt9P2UpIsYVEjzjZnUiRMwNhTaokd2yIjLrO
-ikSDLMl1/0kHZ5YROcmkAx/FPNuwA7ZkVYzjtBgFzq2lo2cwZTAdBgNVHQ4EFgQU
-fDKWWHM3qint4qYiUvpMBaHLmEQwHwYDVR0jBBgwFoAUVtNBsTLmo8a0L+8oILZy
-mLlVkM0wDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMAoGCCqG
-SM49BAMDA2gAMGUCMFZ3uusOrCbg3x4Mllo2/Ih4jLZ6TJOLyZXbavpqVPstTDP8
-r/u/dCuPFTk2MQoLQAIxAKwIpSglj2tswHFhxAw9I05f/hZmVrzMazCREOvenGUX
-mhKxjvJ0LXy4q0jZ+gBNmw==
+PQIBBggqhkjOPQMBBwNCAASgRggQOECzsLeYNRbaoL/u+DhSANDMnSR8V0G0rpFA
+3aC8jyR4SEDEJmYcqBWAq6KTHkYXErw1Hed1Q9xQAp0Ao3oweDAdBgNVHQ4EFgQU
+jN+PiA9IksHiANhHXEOEAH9giwcwHwYDVR0jBBgwFoAUVtNBsTLmo8a0L+8oILZy
+mLlVkM0wDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMDMBEGCisG
+AQQBg78wAQEEA0ZPTzAKBggqhkjOPQQDAwNoADBlAjEA1m+8HyhtQIZmjJ73fhLu
+MrowOQjIF8zsnRQWhYzbWZRPAyvw+vt3yt3/J+VVsWzwAjB+2Cn/HnK6um0X8NnR
+dydvsVlJx6uxwJyljAzgJojn68vWifLuEAdua2I4SvLnqOQ=
 -----END CERTIFICATE-----`,
 
   // Leaf cert with an IP address in the SAN extension.
@@ -106,5 +121,28 @@ FsfiqIos7CnalmGcDuc/xJtZnDAfBgNVHSMEGDAWgBQfdr4pmKJqGYbuWctaU45J
 BBUwE4YRaHR0cDovL2Zvb2Jhci5kZXYwCgYIKoZIzj0EAwMDSAAwRQIgDmojPO/W
 OQ7m6hB+0udxUa+EzeWUnVuVFsDM8BZxM+8CIQDdjO4osDg5Tn9/dWPE8yBLL0ok
 v8E/2yJIGKcbArpcsg==
+-----END CERTIFICATE-----`,
+
+  fulcioleaf: `-----BEGIN CERTIFICATE-----
+MIIDnDCCAyKgAwIBAgIUEg2LbBC+v12QtPBt2jawiYrF33UwCgYIKoZIzj0EAwMw
+NzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRl
+cm1lZGlhdGUwHhcNMjMwMTExMTczMTUyWhcNMjMwMTExMTc0MTUyWjAAMFkwEwYH
+KoZIzj0CAQYIKoZIzj0DAQcDQgAEscmo8xVdr+olWHVVpTlLdKdTwTDvNpINwLXi
+6W2OlPwTkMbJj0zCpO99heNH4ZxF1+NmO6NyjcbynKjf/GPUV6OCAkEwggI9MA4G
+A1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUdsZZ
+492PIgVwGjT/q8AwgHhDkj4wHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4Y
+ZD8wZAYDVR0RAQH/BFowWIZWaHR0cHM6Ly9naXRodWIuY29tL3NpZ3N0b3JlL3Np
+Z3N0b3JlLWpzLy5naXRodWIvd29ya2Zsb3dzL3B1Ymxpc2gueW1sQHJlZnMvdGFn
+cy92MC40LjAwOQYKKwYBBAGDvzABAQQraHR0cHM6Ly90b2tlbi5hY3Rpb25zLmdp
+dGh1YnVzZXJjb250ZW50LmNvbTAVBgorBgEEAYO/MAECBAdyZWxlYXNlMDYGCisG
+AQQBg78wAQMEKDhhMmVlMmZkMjBkZGE1OGZmYTRhOGQ4MDhhNjVjYjFlMDQ3MTFj
+MDMwFQYKKwYBBAGDvzABBAQHcHVibGlzaDAiBgorBgEEAYO/MAEFBBRzaWdzdG9y
+ZS9zaWdzdG9yZS1qczAeBgorBgEEAYO/MAEGBBByZWZzL3RhZ3MvdjAuNC4wMIGK
+BgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4py
+gC8p7o4AAAGFoeNlfwAABAMARzBFAiBqYOxNKEMS4gXVBqU3Mr/w+yYXYtZDYa6d
+aYOZJZB++wIhANat2b2mVTeHERPyhATU/Z8HOfC6iqY/IwiXnwWKsp9xMAoGCCqG
+SM49BAMDA2gAMGUCMQD5OzgtStQId/HNXGwVM1Ydjux8x2d4cr7tzWreGSbMUJhR
+uVlJliOdJKsu8ufHQfYCMC8M76uThWeCI2A5GndGj0TTaI1Cq92T8oXm5iHHFPxm
+vZtjXtnwCuGzLAKHILlmlg==
 -----END CERTIFICATE-----`,
 };

--- a/src/__tests__/ca/verify/index.test.ts
+++ b/src/__tests__/ca/verify/index.test.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Sigstore Authors.
+Copyright 2023 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,7 +42,21 @@ describe('verifySigningCertificate', () => {
   const signers: sigstore.CAArtifactVerificationOptions['signers'] = {
     $case: 'certificateIdentities',
     certificateIdentities: {
-      identities: [],
+      identities: [
+        {
+          issuer: 'https://github.com/login/oauth',
+          san: {
+            type: sigstore.SubjectAlternativeNameType.EMAIL,
+            identity: {
+              $case: 'value',
+              value: Buffer.from('YnJpYW5AZGVoYW1lci5jb20=', 'base64').toString(
+                'utf-8'
+              ),
+            },
+          },
+          oids: [],
+        },
+      ],
     },
   };
 

--- a/src/__tests__/ca/verify/signer.test.ts
+++ b/src/__tests__/ca/verify/signer.test.ts
@@ -1,0 +1,322 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { verifySignerIdentity } from '../../../ca/verify/signer';
+import * as sigstore from '../../../types/sigstore';
+import { x509Certificate } from '../../../x509/cert';
+import { certificates } from '../../__fixtures__/certs';
+
+describe('verifySignerIdentity', () => {
+  const signingCert = x509Certificate.parse(certificates.fulcioleaf);
+
+  const issuer = 'https://token.actions.githubusercontent.com';
+  const workflowURI =
+    'https://github.com/sigstore/sigstore-js/.github/workflows/publish.yml@refs/tags/v0.4.0';
+
+  const workflowSAN: sigstore.SubjectAlternativeName = {
+    type: sigstore.SubjectAlternativeNameType.URI,
+    identity: {
+      $case: 'value',
+      value: workflowURI,
+    },
+  };
+
+  const extFulcioWorkflowName: sigstore.ObjectIdentifierValuePair = {
+    oid: { id: [1, 3, 6, 1, 4, 1, 57264, 1, 4] },
+    value: Buffer.from('publish'),
+  };
+
+  const extFulcioRepository: sigstore.ObjectIdentifierValuePair = {
+    oid: { id: [1, 3, 6, 1, 4, 1, 57264, 1, 5] },
+    value: Buffer.from('sigstore/sigstore-js'),
+  };
+
+  describe('when there is a matching identity', () => {
+    describe('when only one identity is specified', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer,
+            san: workflowSAN,
+            oids: [extFulcioRepository, extFulcioWorkflowName],
+          },
+        ],
+      };
+
+      it('returns without error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).not.toThrowError();
+      });
+    });
+
+    describe('when the matching identity has an empty OID list', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer,
+            san: workflowSAN,
+            oids: [],
+          },
+        ],
+      };
+
+      it('returns without error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).not.toThrowError();
+      });
+    });
+
+    describe('when the identity list contains a non-matching identity', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer,
+            san: workflowSAN,
+            oids: [],
+          },
+          {
+            issuer: 'https://not-the-issuer',
+            san: workflowSAN,
+            oids: [],
+          },
+        ],
+      };
+
+      it('returns without error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).not.toThrowError();
+      });
+    });
+  });
+
+  describe('when there is NO matching identity', () => {
+    describe('when the issuer does not match', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer: 'https://not-the-issuer',
+            san: workflowSAN,
+            oids: [extFulcioRepository, extFulcioWorkflowName],
+          },
+        ],
+      };
+
+      it('throws an error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).toThrowError(
+          'Certificate issued to untrusted signer'
+        );
+      });
+    });
+
+    describe('when the certificate does NOT have a SAN extension', () => {
+      const signingCert = x509Certificate.parse(certificates.nosan);
+
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer: 'FOO',
+            san: workflowSAN,
+            oids: [extFulcioRepository, extFulcioWorkflowName],
+          },
+        ],
+      };
+
+      it('throws an error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).toThrowError(
+          'Certificate issued to untrusted signer'
+        );
+      });
+    });
+
+    describe('when the required SAN is NOT specified', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer,
+            san: undefined,
+            oids: [],
+          },
+        ],
+      };
+
+      it('throws an error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).toThrowError(
+          'Certificate issued to untrusted signer'
+        );
+      });
+    });
+
+    describe('when the required SAN identity is NOT specified', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer,
+            san: {
+              type: sigstore.SubjectAlternativeNameType.URI,
+              identity: undefined,
+            },
+            oids: [],
+          },
+        ],
+      };
+
+      it('throws an error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).toThrowError(
+          'Certificate issued to untrusted signer'
+        );
+      });
+    });
+
+    describe('when the required SAN type is NOT specified', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer,
+            san: {
+              type: sigstore.SubjectAlternativeNameType
+                .SUBJECT_ALTERNATIVE_NAME_TYPE_UNSPECIFIED,
+              identity: {
+                $case: 'value',
+                value: workflowURI,
+              },
+            },
+            oids: [],
+          },
+        ],
+      };
+
+      it('throws an error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).toThrowError(
+          'Certificate issued to untrusted signer'
+        );
+      });
+    });
+
+    describe('when the required SAN type is OTHER_NAME (not supported yet)', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer,
+            san: {
+              type: sigstore.SubjectAlternativeNameType.OTHER_NAME,
+              identity: {
+                $case: 'value',
+                value: workflowURI,
+              },
+            },
+            oids: [],
+          },
+        ],
+      };
+
+      it('throws an error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).toThrowError(
+          'Certificate issued to untrusted signer'
+        );
+      });
+    });
+
+    describe('when the required SAN type does NOT match the certificate', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer,
+            san: {
+              type: sigstore.SubjectAlternativeNameType.EMAIL,
+              identity: {
+                $case: 'value',
+                value: workflowURI,
+              },
+            },
+            oids: [],
+          },
+        ],
+      };
+
+      it('throws an error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).toThrowError(
+          'Certificate issued to untrusted signer'
+        );
+      });
+    });
+
+    describe('when the SAN value is a regexp (not supported yet)', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer,
+            san: {
+              type: sigstore.SubjectAlternativeNameType.URI,
+              identity: {
+                $case: 'regexp',
+                regexp: 'foo*',
+              },
+            },
+            oids: [],
+          },
+        ],
+      };
+
+      it('throws an error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).toThrowError(
+          'Certificate issued to untrusted signer'
+        );
+      });
+    });
+
+    describe('when a required extension is missing', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer,
+            san: workflowSAN,
+            oids: [
+              {
+                oid: { id: [9, 9, 9, 9] },
+                value: Buffer.from('foo'),
+              },
+            ],
+          },
+        ],
+      };
+
+      it('throws an error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).toThrowError(
+          'Certificate issued to untrusted signer'
+        );
+      });
+    });
+
+    describe('when a required extension does NOT specify an OID', () => {
+      const ids: sigstore.CertificateIdentities = {
+        identities: [
+          {
+            issuer,
+            san: workflowSAN,
+            oids: [
+              {
+                oid: undefined,
+                value: Buffer.from('foo'),
+              },
+            ],
+          },
+        ],
+      };
+
+      it('throws an error', () => {
+        expect(() => verifySignerIdentity(signingCert, ids)).toThrowError(
+          'Certificate issued to untrusted signer'
+        );
+      });
+    });
+  });
+});

--- a/src/ca/verify/index.ts
+++ b/src/ca/verify/index.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Sigstore Authors.
+Copyright 2023 The Sigstore Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ limitations under the License.
 import * as sigstore from '../../types/sigstore';
 import { verifyChain } from './chain';
 import { verifySCTs } from './sct';
+import { verifySignerIdentity } from './signer';
 
 export function verifySigningCertificate(
   bundle: sigstore.BundleWithCertificateChain,
@@ -33,4 +34,6 @@ export function verifySigningCertificate(
   if (options.ctlogOptions.disable === false) {
     verifySCTs(trustedChain, trustedRoot.ctlogs, options.ctlogOptions);
   }
+
+  verifySignerIdentity(trustedChain[0], options.signers.certificateIdentities);
 }

--- a/src/ca/verify/signer.ts
+++ b/src/ca/verify/signer.ts
@@ -1,0 +1,136 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { VerificationError } from '../../error';
+import * as sigstore from '../../types/sigstore';
+import { x509Certificate } from '../../x509/cert';
+
+// https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md#1361415726411--issuer
+const OID_FUCIO_ISSUER = '1.3.6.1.4.1.57264.1.1';
+
+// Verifies the identity embedded in a Fulcio-issued signing certificate against
+// the list of trusted identities. Returns without error if at least one of the
+// identities matches the signing certificate; otherwise, throws a
+// VerificationError.
+export function verifySignerIdentity(
+  signingCert: x509Certificate,
+  identities: sigstore.CertificateIdentities
+): void {
+  // Check that the signing certificate was issued to at least one of the
+  // specified identities
+  const signerVerified = identities.identities.some((identity) =>
+    verifyIdentity(signingCert, identity)
+  );
+
+  if (!signerVerified) {
+    throw new VerificationError('Certificate issued to untrusted signer');
+  }
+}
+
+// Checks that the specified certificate was issued to the specified identity.
+// The certificate must match the issuer, subject alternative name, and an
+// optional list of certificate extensions. Returns true if the certificate was
+// issued to the identity; otherwise, returns false.
+function verifyIdentity(
+  cert: x509Certificate,
+  identity: sigstore.CertificateIdentity
+): boolean {
+  return (
+    verifyIssuer(cert, identity.issuer) &&
+    verifySAN(cert, identity.san) &&
+    verifyOIDs(cert, identity.oids)
+  );
+}
+
+// Checks the Fulcio issuer extension against the expected issuer. Returns true
+// if the issuer matches; otherwise, returns false.
+function verifyIssuer(cert: x509Certificate, issuer: string): boolean {
+  const issuerExtension = cert.extension(OID_FUCIO_ISSUER);
+
+  return issuerExtension?.value.toString('ascii') === issuer;
+}
+
+// Checks the certificate against the expected subject alternative name. Returns
+// true if the SAN matches; otherwise, returns false.
+function verifySAN(
+  cert: x509Certificate,
+  expectedSAN?: sigstore.SubjectAlternativeName
+): boolean {
+  // Fail if the SAN is not specified or is not a supported type
+  if (
+    expectedSAN === undefined ||
+    expectedSAN.identity === undefined ||
+    expectedSAN.type ===
+      sigstore.SubjectAlternativeNameType
+        .SUBJECT_ALTERNATIVE_NAME_TYPE_UNSPECIFIED
+  ) {
+    return false;
+  }
+
+  const sanExtension = cert.extSubjectAltName;
+
+  // Fail if the certificate does not have a SAN extension
+  if (!sanExtension) {
+    return false;
+  }
+
+  let sanValue: string | undefined;
+  switch (expectedSAN.type) {
+    case sigstore.SubjectAlternativeNameType.EMAIL:
+      sanValue = sanExtension.rfc822Name;
+      break;
+    case sigstore.SubjectAlternativeNameType.URI:
+      sanValue = sanExtension.uri;
+      break;
+    case sigstore.SubjectAlternativeNameType.OTHER_NAME:
+    // TODO: Support other name types
+  }
+
+  // Missing SAN value is an automatic failure
+  if (sanValue === undefined) {
+    return false;
+  }
+
+  let match: string | undefined;
+  switch (expectedSAN.identity.$case) {
+    case 'value':
+      match = expectedSAN.identity.value;
+      break;
+    case 'regexp':
+      // TODO support regex
+      break;
+  }
+
+  return sanValue === match;
+}
+
+// Checks that the certificate contains the specified extensions. Returns true
+// if all extensions are present and match the expected values; otherwise,
+// returns false.
+function verifyOIDs(
+  cert: x509Certificate,
+  oids: sigstore.ObjectIdentifierValuePair[]
+): boolean {
+  return oids.every((expectedExtension) => {
+    if (!expectedExtension.oid) {
+      return false;
+    }
+
+    const oid = expectedExtension.oid.id.join('.');
+    const extension = cert.extension(oid);
+
+    return extension?.value.equals(expectedExtension.value);
+  });
+}

--- a/src/x509/cert.ts
+++ b/src/x509/cert.ts
@@ -1,3 +1,18 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 import * as sigstore from '../types/sigstore';
 import { crypto, pem } from '../util';
 import { ByteStream } from '../util/stream';
@@ -144,6 +159,11 @@ export class x509Certificate {
     }
 
     return ca;
+  }
+
+  public extension(oid: string): x509Extension | undefined {
+    const ext = this.findExtension(oid);
+    return ext ? new x509Extension(ext) : undefined;
   }
 
   public verify(issuerCertificate?: x509Certificate): boolean {

--- a/src/x509/ext.ts
+++ b/src/x509/ext.ts
@@ -1,3 +1,18 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 import { ByteStream } from '../util/stream';
 import { ASN1Obj } from './asn1/obj';
 import { SignedCertificateTimestamp } from './sct';
@@ -18,6 +33,10 @@ export class x509Extension {
     // The critical field is optional and will be the second element of the
     // extension sequence if present. Default to false if not present.
     return this.root.subs.length === 3 ? this.root.subs[1].toBoolean() : false;
+  }
+
+  get value(): Buffer {
+    return this.extnValueObj.value;
   }
 
   protected get extnValueObj(): ASN1Obj {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Adds a new `verifySignerIdentity` function which will verify the Fulcio-issued signing certificate against the signer identity contained in the `ArtifactVerificationOptions`
```
verifySignerIdentity
  when there is a matching identity
    when only one identity is specified
      ✓ returns without error
    when the matching identity has an empty OID list
      ✓ returns without error
    when the identity list contains a non-matching identity
      ✓ returns without error
  when there is NO matching identity
    when the issuer does not match
      ✓ throws an error
    when the certificate does NOT have a SAN extension
      ✓ throws an error
    when the required SAN is NOT specified
      ✓ throws an error
    when the required SAN identity is NOT specified
      ✓ throws an error 
    when the required SAN type is NOT specified
      ✓ throws an error
    when the required SAN type is OTHER_NAME (not supported yet)
      ✓ throws an error
    when the required SAN type does NOT match the certificate
      ✓ throws an error 
    when the SAN value is a regexp (not supported yet)
      ✓ throws an error
    when a required extension is missing
      ✓ throws an error
    when a required extension does NOT specify an OID
      ✓ throws an error
```