### PR TITLE
allow for optional signer identity verification

### DIFF
--- a/src/__tests__/ca/verify/index.test.ts
+++ b/src/__tests__/ca/verify/index.test.ts
@@ -159,10 +159,30 @@ describe('verifySigningCertificate', () => {
   });
 
   describe('when everything verifies without error', () => {
-    it('returns without error', () => {
-      expect(() =>
-        verifySigningCertificate(bundle, trustedRoot, opts)
-      ).not.toThrow();
+    describe('when signers are not specified', () => {
+      const opts: sigstore.CAArtifactVerificationOptions = {
+        ctlogOptions,
+        signers: undefined,
+      };
+
+      it('returns without error', () => {
+        expect(() =>
+          verifySigningCertificate(bundle, trustedRoot, opts)
+        ).not.toThrow();
+      });
+    });
+
+    describe('when signers are specified', () => {
+      const opts: sigstore.CAArtifactVerificationOptions = {
+        ctlogOptions,
+        signers,
+      };
+
+      it('returns without error', () => {
+        expect(() =>
+          verifySigningCertificate(bundle, trustedRoot, opts)
+        ).not.toThrow();
+      });
     });
   });
 });

--- a/src/ca/verify/index.ts
+++ b/src/ca/verify/index.ts
@@ -35,5 +35,12 @@ export function verifySigningCertificate(
     verifySCTs(trustedChain, trustedRoot.ctlogs, options.ctlogOptions);
   }
 
-  verifySignerIdentity(trustedChain[0], options.signers.certificateIdentities);
+  // Verify the signing certificate against the provided identities
+  // if provided
+  if (options.signers) {
+    verifySignerIdentity(
+      trustedChain[0],
+      options.signers.certificateIdentities
+    );
+  }
 }

--- a/src/types/sigstore/index.ts
+++ b/src/types/sigstore/index.ts
@@ -65,7 +65,7 @@ export function isBundleWithCertificateChain(
 export type CAArtifactVerificationOptions = Required<
   Pick<ArtifactVerificationOptions, 'ctlogOptions'>
 > & {
-  signers: Extract<
+  signers?: Extract<
     ArtifactVerificationOptions['signers'],
     { $case: 'certificateIdentities' }
   >;


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Loosens the requirement that the Fulcio-issued signing certificate must ALWAYS be verified against a list of approved signers. There are use cases where we may not have this information and still want to perform basic verification of the certificate.