### PR TITLE
revisit implementation for verifyTLogSET

### DIFF
--- a/src/__tests__/tlog/verify/set.test.ts
+++ b/src/__tests__/tlog/verify/set.test.ts
@@ -1,0 +1,161 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { verifyTLogSET } from '../../../tlog/verify/set';
+import * as sigstore from '../../../types/sigstore';
+import { crypto } from '../../../util';
+import bundles from '../../__fixtures__/bundles';
+
+describe('verifyTLogSET', () => {
+  const keyBytes = Buffer.from(
+    'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==',
+    'base64'
+  );
+  const keyID = crypto.hash(keyBytes);
+
+  const publicKey: sigstore.PublicKey = {
+    rawBytes: keyBytes,
+    keyDetails: sigstore.PublicKeyDetails.PKIX_ECDSA_P256_SHA_256,
+  };
+
+  const validTLog: sigstore.TransparencyLogInstance = {
+    baseUrl: 'https://tlog.sigstore.dev',
+    hashAlgorithm: sigstore.HashAlgorithm.SHA2_256,
+    publicKey,
+    logId: { keyId: keyID },
+  };
+
+  const invalidTLog: sigstore.TransparencyLogInstance = {
+    hashAlgorithm: sigstore.HashAlgorithm.SHA2_256,
+    baseUrl: 'https://invalid.tlog.example.com',
+    logId: { keyId: Buffer.from('invalid') },
+    publicKey: {
+      keyDetails: sigstore.PublicKeyDetails.PKIX_ECDSA_P256_SHA_256,
+      rawBytes: Buffer.from('invalid'),
+    },
+  };
+
+  const bundle = sigstore.bundleFromJSON(
+    bundles.signature.valid.withSigningCert
+  );
+  const entry = bundle.verificationMaterial
+    ?.tlogEntries[0] as sigstore.VerifiableTransparencyLogEntry;
+
+  describe('when there is a matching TLogInstance', () => {
+    const tlogs = [invalidTLog, validTLog];
+
+    describe('when the SET can be verified', () => {
+      it('returns true', () => {
+        expect(verifyTLogSET(entry, tlogs)).toBe(true);
+      });
+    });
+
+    describe('when the SET can NOT be verified', () => {
+      const bundle = sigstore.bundleFromJSON(
+        bundles.signature.invalid.setMismatch
+      );
+      const entry = bundle.verificationMaterial
+        ?.tlogEntries[0] as sigstore.VerifiableTransparencyLogEntry;
+
+      it('returns false', () => {
+        expect(verifyTLogSET(entry, tlogs)).toBe(false);
+      });
+    });
+
+    describe('when the matching TLogInstance has no public key', () => {
+      const tlogs = [
+        {
+          ...validTLog,
+          publicKey: undefined,
+        },
+      ];
+
+      it('returns false', () => {
+        expect(verifyTLogSET(entry, tlogs)).toBe(false);
+      });
+    });
+
+    describe('when the matching TLogInstance has an empty public key', () => {
+      const tlogs = [
+        {
+          ...validTLog,
+          publicKey: { ...publicKey, rawBytes: undefined },
+        },
+      ];
+
+      it('returns false', () => {
+        expect(verifyTLogSET(entry, tlogs)).toBe(false);
+      });
+    });
+
+    describe('when the public key for the matching TLogInstance is not valid', () => {
+      describe('when public key has no start', () => {
+        const tlogs: sigstore.TransparencyLogInstance[] = [
+          {
+            ...validTLog,
+            publicKey: {
+              ...publicKey,
+              validFor: { start: undefined },
+            },
+          },
+        ];
+
+        it('returns false', () => {
+          expect(verifyTLogSET(entry, tlogs)).toBe(false);
+        });
+      });
+
+      describe('when the public key has a start after the integrated time', () => {
+        const tlogs = [
+          {
+            ...validTLog,
+            publicKey: {
+              ...publicKey,
+              validFor: { start: new Date(Number.MIN_SAFE_INTEGER) },
+            },
+          },
+        ];
+
+        it('returns false', () => {
+          expect(verifyTLogSET(entry, tlogs)).toBe(false);
+        });
+      });
+
+      describe('when the public key has an end before the integrated time', () => {
+        const tlogs = [
+          {
+            ...validTLog,
+            publicKey: {
+              ...publicKey,
+              validFor: { start: new Date(0), end: new Date(0) },
+            },
+          },
+        ];
+
+        it('returns false', () => {
+          expect(verifyTLogSET(entry, tlogs)).toBe(false);
+        });
+      });
+    });
+  });
+
+  describe('when there is NO matching TLogInstance', () => {
+    const tlogs = [invalidTLog];
+
+    it('returns false', () => {
+      expect(verifyTLogSET(entry, tlogs)).toBe(false);
+    });
+  });
+});

--- a/src/tlog/verify/set.ts
+++ b/src/tlog/verify/set.ts
@@ -1,0 +1,117 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import * as sigstore from '../../types/sigstore';
+import { crypto, json } from '../../util';
+
+// Structure over which the tlog SET signature is generated
+interface VerificationPayload {
+  body: string;
+  integratedTime: number;
+  logIndex: number;
+  logID: string;
+}
+
+// Verifies the SET for the given entry against the list of trusted
+// transparency logs. Returns true if the SET can be verified against at least
+// one of the trusted logs; otherwise, returns false.
+export function verifyTLogSET(
+  entry: sigstore.VerifiableTransparencyLogEntry,
+  tlogs: sigstore.TransparencyLogInstance[]
+): boolean {
+  // Filter the list of tlog instances to only those which might be able to
+  // verify the SET
+  const validTLogs = filterTLogInstances(
+    tlogs,
+    entry.logId.keyId,
+    entry.integratedTime
+  );
+
+  // Check to see if we can verify the SET against any of the valid tlogs
+  return validTLogs.some((tlog) => {
+    if (!tlog.publicKey?.rawBytes) {
+      return false;
+    }
+
+    const publicKey = crypto.createPublicKey(tlog.publicKey.rawBytes);
+
+    // Re-create the original Rekor verification payload
+    const payload = toVerificationPayload(entry);
+
+    // Canonicalize the payload and turn into a buffer for verification
+    const data = Buffer.from(json.canonicalize(payload), 'utf8');
+
+    // Extract the SET from the tlog entry
+    const signature = entry.inclusionPromise.signedEntryTimestamp;
+
+    return crypto.verifyBlob(data, publicKey, signature);
+  });
+}
+
+// Returns a properly formatted "VerificationPayload" for one of the
+// transaction log entires in the given bundle which can be used for SET
+// verification.
+function toVerificationPayload(
+  entry: sigstore.VerifiableTransparencyLogEntry
+): VerificationPayload {
+  const { integratedTime, logIndex, logId, canonicalizedBody } = entry;
+
+  return {
+    body: canonicalizedBody.toString('base64'),
+    integratedTime: Number(integratedTime),
+    logIndex: Number(logIndex),
+    logID: logId.keyId.toString('hex'),
+  };
+}
+
+// Filter the list of tlog instances to only those which match the given log
+// ID and have public keys which are valid for the given integrated time.
+function filterTLogInstances(
+  tlogInstances: sigstore.TransparencyLogInstance[],
+  logID: Buffer,
+  integratedTime: string
+): sigstore.TransparencyLogInstance[] {
+  const targetDate = new Date(Number(integratedTime) * 1000);
+
+  return tlogInstances.filter((tlog) => {
+    // If the log IDs don't match, we can't use this tlog
+    if (!tlog.logId?.keyId.equals(logID)) {
+      return false;
+    }
+
+    // If the tlog doesn't have a public key, we can't use it
+    const publicKey = tlog.publicKey;
+    if (publicKey === undefined) {
+      return false;
+    }
+
+    // If the tlog doesn't have a rawBytes field, we can't use it
+    if (publicKey.rawBytes === undefined) {
+      return false;
+    }
+
+    // If the tlog doesn't have a validFor field, we don't need to check it
+    if (publicKey.validFor === undefined) {
+      return true;
+    }
+
+    // Check that the integrated time is within the validFor range
+    return (
+      publicKey.validFor.start &&
+      publicKey.validFor.start <= targetDate &&
+      (!publicKey.validFor.end || targetDate <= publicKey.validFor.end)
+    );
+  });
+}

--- a/src/types/sigstore/index.ts
+++ b/src/types/sigstore/index.ts
@@ -16,6 +16,7 @@ limitations under the License.
 import { Entry, EntryKind } from '../../tlog';
 import { encoding as enc, pem } from '../../util';
 import { SignatureMaterial } from '../signature';
+import { WithRequired } from '../utility';
 import { Envelope } from './__generated__/envelope';
 import { Bundle, VerificationMaterial } from './__generated__/sigstore_bundle';
 import { HashAlgorithm } from './__generated__/sigstore_common';
@@ -80,6 +81,12 @@ export function isCAVerificationOptions(
     options.signers.$case === 'certificateIdentities'
   );
 }
+
+export type VerifiableTransparencyLogEntry = WithRequired<
+  TransparencyLogEntry,
+  'logId' | 'inclusionPromise'
+>;
+
 export const bundle = {
   toDSSEBundle: (
     envelope: Envelope,

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -30,3 +30,9 @@ type OneOfByKey<Obj> = { [key in keyof Obj]: OneOnly<Obj, key> };
 
 // Returns a type that is the union of all OneOnly types for the given object.
 export type OneOf<T> = ValueOf<OneOfByKey<T>>;
+
+// Returns a type that is a copy of the given object with the specified keys
+// made required.
+export type WithRequired<T, K extends keyof T> = T & {
+  [P in K]-?: NonNullable<T[P]>;
+};


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Re-implementation of the `verifyTLogSET` function to account for the fact that we need to be able check the SET against multiple trusted TLog instances -- returning `true` as long as we get verification against one of them.

Note that I'm adding this alongside the existing implementation until I finish refactoring all of the TLog verification functions. At that time, I'll remove the old code and wire-in the new implementations.

```
verifyTLogSET
  when there is a matching TLogInstance
    when the SET can be verified
      ✓ returns true 
    when the SET can NOT be verified
      ✓ returns false
    when the matching TLogInstance has no public key
      ✓ returns false
    when the matching TLogInstance has an empty public key
      ✓ returns false
    when the public key for the matching TLogInstance is not valid
      when public key has no start
        ✓ returns false
      when the public key has a start after the integrated time
        ✓ returns false
      when the public key has an end before the integrated time
        ✓ returns false
  when there is NO matching TLogInstance
    ✓ returns false
```