### PR TITLE
add narrowed versions of sigstore generated types

### DIFF
--- a/src/__tests__/tlog/verify/index.test.ts
+++ b/src/__tests__/tlog/verify/index.test.ts
@@ -22,7 +22,7 @@ import bundles from '../../__fixtures__/bundles';
 describe('verifyTLogEntries', () => {
   const bundle = sigstore.bundleFromJSON(
     bundles.signature.valid.withSigningCert
-  ) as sigstore.BundleWithTLogEntries;
+  ) as sigstore.BundleWithVerificationMaterial;
 
   const trustedRootJSON = JSON.parse(
     fs
@@ -50,7 +50,7 @@ describe('verifyTLogEntries', () => {
     describe('when the bundle does NOT have a signing certificate', () => {
       const bundle = sigstore.bundleFromJSON(
         bundles.signature.valid.withPublicKey
-      ) as sigstore.BundleWithTLogEntries;
+      ) as sigstore.BundleWithVerificationMaterial;
 
       it('does NOT throw an error', () => {
         expect(() =>
@@ -91,7 +91,7 @@ describe('verifyTLogEntries', () => {
   describe('when tlog entries are missing data necessary for verification', () => {
     const bundle = sigstore.bundleFromJSON(
       bundles.dsse.invalid.tlogKindVersionMissing
-    ) as sigstore.BundleWithTLogEntries;
+    ) as sigstore.BundleWithVerificationMaterial;
 
     it('throws an error', () => {
       expect(() => verifyTLogEntries(bundle, trustedRoot, options)).toThrow(

--- a/src/__tests__/types/sigstore/index.test.ts
+++ b/src/__tests__/types/sigstore/index.test.ts
@@ -19,6 +19,38 @@ import * as sigstore from '../../../types/sigstore';
 import { encoding as enc, pem } from '../../../util';
 import bundles from '../../__fixtures__/bundles/';
 
+describe('isBundleWithVerificationMaterial', () => {
+  describe('when the bundle contains verification material', () => {
+    const json = bundles.dsse.valid.withSigningCert;
+    const bundle = sigstore.Bundle.fromJSON(json);
+
+    it('returns true', () => {
+      expect(sigstore.isBundleWithVerificationMaterial(bundle)).toBe(true);
+    });
+  });
+
+  describe('when the bundle does NOT contain verification material', () => {
+    const bundle: sigstore.Bundle = {
+      mediaType: 'application/vnd.dev.cosign.simplesigning.v1+json',
+      verificationMaterial: undefined,
+      content: {
+        $case: 'messageSignature',
+        messageSignature: {
+          messageDigest: {
+            algorithm: sigstore.HashAlgorithm.SHA2_256,
+            digest: Buffer.from(''),
+          },
+          signature: Buffer.from(''),
+        },
+      },
+    };
+
+    it('returns false', () => {
+      expect(sigstore.isBundleWithVerificationMaterial(bundle)).toBe(false);
+    });
+  });
+});
+
 describe('isBundleWithCertificateChain', () => {
   describe('when the bundle contains a certificate chain', () => {
     const json = bundles.dsse.valid.withSigningCert;
@@ -83,8 +115,8 @@ describe('isCAVerificationOptions', () => {
       },
     };
 
-    it('returns false', () => {
-      expect(sigstore.isCAVerificationOptions(opts)).toBe(false);
+    it('returns true', () => {
+      expect(sigstore.isCAVerificationOptions(opts)).toBe(true);
     });
   });
 

--- a/src/tlog/verify/index.ts
+++ b/src/tlog/verify/index.ts
@@ -22,7 +22,7 @@ import { verifyTLogSET } from './set';
 // Verifies that the number of tlog entries that pass offline verification
 // is greater than or equal to the threshold specified in the options.
 export function verifyTLogEntries(
-  bundle: sigstore.BundleWithTLogEntries,
+  bundle: sigstore.BundleWithVerificationMaterial,
   trustedRoot: sigstore.TrustedRoot,
   options: sigstore.ArtifactVerificationOptions_TlogOptions
 ): void {


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds some more "narrowed" versions of the Sigstore-generated types to reduce unnecessary `undefined`-checking:

* `BundleWithVerificationMaterial` - Sigstore bundle where the `verificationMaterial` field is guaranteed to be defined
* `RequiredArtifactVerificationOptions` - Subtype of `ArtifactVerificationOptions` with the `ctlogOptions` and `tlogOptions` fields guaranteed to be defined.

Also updates the `CAArtifactVerificationOptions` type to make the `signers` field optional.