### PR TITLE
integrate ValidBundle type

### DIFF
--- a/src/__tests__/__fixtures__/bundles/signature.ts
+++ b/src/__tests__/__fixtures__/bundles/signature.ts
@@ -139,70 +139,6 @@ const invalidExpiredCert = {
   dsseEnvelope: undefined,
 };
 
-const invalidBundleEmptyCertChain = {
-  mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.1',
-  verificationMaterial: {
-    x509CertificateChain: {
-      certificates: [],
-    },
-    publicKey: undefined,
-    tlogEntries: [
-      {
-        logIndex: '6757503',
-        logId: { keyId: 'wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0=' },
-        kindVersion: { kind: 'hashedrekord', version: '0.0.1' },
-        integratedTime: '1667957590',
-        inclusionPromise: {
-          signedEntryTimestamp:
-            'MEUCIFUNcHgHB318gCNJR0/CH4E0daODbnfePyzKCDqrt3twAiEA9N+ZObaLwVJwvOtPgkfoBa5NzjTH0eC06YBlOyZlMiY=',
-        },
-        inclusionProof: undefined,
-        canonicalizedBody:
-          'eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI2OGU2NTZiMjUxZTY3ZTgzNThiZWY4NDgzYWIwZDUxYzY2MTlmM2U3YTFhOWYwZTc1ODM4ZDQxZmYzNjhmNzI4In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJSHM1YVV1bHExSHBSK2Z3bVNLcExrL29Bd3E1TzlDRE5GSGhaQUtmRzVHbUFpQndjVm5mMm9ienNDR1ZsZjBBSXZidkhyMjFOWHQ3dHBMQmw0K0JyaDZPS0E9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTnZSRU5EUVdsaFowRjNTVUpCWjBsVlpYWmhaU3R1VEZFNGJXYzJUM2xQUWpRelRVdEtNVEJHTWtORmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcEplRTFVUVRWTlJFVjZUWHBCTlZkb1kwNU5ha2w0VFZSQk5VMUVSVEJOZWtFMVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVU1UkdKWlFrbE5VVXgwVjJJMlNqVm5kRXcyT1dwblVuZDNSV1prZEZGMFMzWjJSelFLSzI4elducHNUM0p2U25Cc2NGaGhWbWRHTm5kQ1JHOWlLeXR5VGtjNUwwRjZVMkZDYlVGd2EwVjNTVFV5V0VKcVYzRlBRMEZWVlhkblowWkNUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZXU1VsR0NtTXdPSG8yZFZZNVdUazJVeXQyTlc5RVltSnRTRVZaZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1dXNUtjRmxYTlVGYVIxWnZXVmN4YkdOcE5XcGlNakIzVEVGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGbFlVaFNNR05JVFRaTWVUbHVZVmhTYjJSWFNYVlpNamwwVERKNGRsb3liSFZNTWpsb1pGaFNiMDFKUjB0Q1oyOXlRbWRGUlVGa1dqVkJaMUZEQ2tKSWQwVmxaMEkwUVVoWlFUTlVNSGRoYzJKSVJWUktha2RTTkdOdFYyTXpRWEZLUzFoeWFtVlFTek12YURSd2VXZERPSEEzYnpSQlFVRkhSVmRuVlVjS1VYZEJRVUpCVFVGU2VrSkdRV2xGUVd4TGVXTk5Ra015Y1N0UlRTdHRZM1EyTUZKT1JVNTRjRlZTU0dWek5uWm5UMEpYWkhnM01WaGpXR2REU1VGMGJncE5lbmN2WTBKM05XZ3dhSEpaU2poaU1WQkthbTk0YmpOck1VNHlWR1JuYjJaeGRrMW9ZbE5VVFVGdlIwTkRjVWRUVFRRNVFrRk5SRUV5WjBGTlIxVkRDazFSUXpKTFRFWlpVMmxFTHl0VE1WZEZjM2xtT1dONlpqVXlkeXRGTlRjM1NHazNOM0k0Y0VkVlRURnlVUzlDZW1jeFlVZDJVWE13TDJ0Qlp6TlRMMG9LVTBSblEwMUZaRTQxWkVsVE1IUlNiVEZUVDAxaVQwWmpWeXN4ZVhwU0swOXBRMVpLTjBSV1JuZFZaRWt6UkM4M1JWSjRkRTQ1WlM5TVNqWjFZVkp1VWdvdlUyRnVjbmM5UFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PSJ9fX19',
-      },
-    ],
-    timestampVerificationData: { rfc3161Timestamps: [] },
-  },
-  messageSignature: {
-    messageDigest: {
-      algorithm: 'SHA2_256',
-      digest: 'aOZWslHmfoNYvvhIOrDVHGYZ8+ehqfDnWDjUH/No9yg=',
-    },
-    signature:
-      'MEQCIHs5aUulq1HpR+fwmSKpLk/oAwq5O9CDNFHhZAKfG5GmAiBwcVnf2obzsCGVlf0AIvbvHr21NXt7tpLBl4+Brh6OKA==',
-  },
-  dsseEnvelope: undefined,
-};
-
-// Invalid messageSignature bundle - missing digest
-const invalidBundleMissingDigest = {
-  mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.1',
-  verificationMaterial: {
-    publicKey: {
-      hint: '9a76331edc1cfd3933040996615b1c06adbe6f9b4f11df4106dcceb66e3bdb1b',
-    },
-    tlogEntries: [
-      {
-        logIndex: '6757503',
-        logId: { keyId: 'wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0=' },
-        kindVersion: { kind: 'hashedrekord', version: '0.0.1' },
-        integratedTime: '1667957590',
-        inclusionPromise: {
-          signedEntryTimestamp:
-            'MEUCIFUNcHgHB318gCNJR0/CH4E0daODbnfePyzKCDqrt3twAiEA9N+ZObaLwVJwvOtPgkfoBa5NzjTH0eC06YBlOyZlMiY=',
-        },
-        canonicalizedBody:
-          'eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI2OGU2NTZiMjUxZTY3ZTgzNThiZWY4NDgzYWIwZDUxYzY2MTlmM2U3YTFhOWYwZTc1ODM4ZDQxZmYzNjhmNzI4In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJSHM1YVV1bHExSHBSK2Z3bVNLcExrL29Bd3E1TzlDRE5GSGhaQUtmRzVHbUFpQndjVm5mMm9ienNDR1ZsZjBBSXZidkhyMjFOWHQ3dHBMQmw0K0JyaDZPS0E9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTnZSRU5EUVdsaFowRjNTVUpCWjBsVlpYWmhaU3R1VEZFNGJXYzJUM2xQUWpRelRVdEtNVEJHTWtORmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcEplRTFVUVRWTlJFVjZUWHBCTlZkb1kwNU5ha2w0VFZSQk5VMUVSVEJOZWtFMVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVU1UkdKWlFrbE5VVXgwVjJJMlNqVm5kRXcyT1dwblVuZDNSV1prZEZGMFMzWjJSelFLSzI4elducHNUM0p2U25Cc2NGaGhWbWRHTm5kQ1JHOWlLeXR5VGtjNUwwRjZVMkZDYlVGd2EwVjNTVFV5V0VKcVYzRlBRMEZWVlhkblowWkNUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZXU1VsR0NtTXdPSG8yZFZZNVdUazJVeXQyTlc5RVltSnRTRVZaZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1dXNUtjRmxYTlVGYVIxWnZXVmN4YkdOcE5XcGlNakIzVEVGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGbFlVaFNNR05JVFRaTWVUbHVZVmhTYjJSWFNYVlpNamwwVERKNGRsb3liSFZNTWpsb1pGaFNiMDFKUjB0Q1oyOXlRbWRGUlVGa1dqVkJaMUZEQ2tKSWQwVmxaMEkwUVVoWlFUTlVNSGRoYzJKSVJWUktha2RTTkdOdFYyTXpRWEZLUzFoeWFtVlFTek12YURSd2VXZERPSEEzYnpSQlFVRkhSVmRuVlVjS1VYZEJRVUpCVFVGU2VrSkdRV2xGUVd4TGVXTk5Ra015Y1N0UlRTdHRZM1EyTUZKT1JVNTRjRlZTU0dWek5uWm5UMEpYWkhnM01WaGpXR2REU1VGMGJncE5lbmN2WTBKM05XZ3dhSEpaU2poaU1WQkthbTk0YmpOck1VNHlWR1JuYjJaeGRrMW9ZbE5VVFVGdlIwTkRjVWRUVFRRNVFrRk5SRUV5WjBGTlIxVkRDazFSUXpKTFRFWlpVMmxFTHl0VE1WZEZjM2xtT1dONlpqVXlkeXRGTlRjM1NHazNOM0k0Y0VkVlRURnlVUzlDZW1jeFlVZDJVWE13TDJ0Qlp6TlRMMG9LVTBSblEwMUZaRTQxWkVsVE1IUlNiVEZUVDAxaVQwWmpWeXN4ZVhwU0swOXBRMVpLTjBSV1JuZFZaRWt6UkM4M1JWSjRkRTQ1WlM5TVNqWjFZVkp1VWdvdlUyRnVjbmM5UFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PSJ9fX19',
-      },
-    ],
-    timestampVerificationData: { rfc3161Timestamps: [] },
-  },
-  messageSignature: {
-    signature:
-      'MEQCIHs5aUulq1HpR+fwmSKpLk/oAwq5O9CDNFHhZAKfG5GmAiBwcVnf2obzsCGVlf0AIvbvHr21NXt7tpLBl4+Brh6OKA==',
-  },
-};
-
 // Valid messageSignature bundle with incorrect signature
 const invalidBundleBadSignature = {
   mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.1',
@@ -477,8 +413,6 @@ export default {
   },
   invalid: {
     expiredCert: invalidExpiredCert,
-    emptyCertChain: invalidBundleEmptyCertChain,
-    missingDigest: invalidBundleMissingDigest,
     badSignature: invalidBundleBadSignature,
     setMismatch: invalidSET,
     setMissing: invalidMissingSET,

--- a/src/__tests__/verify.test.ts
+++ b/src/__tests__/verify.test.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 import crypto from 'crypto';
 import fs from 'fs';
-import { InvalidBundleError, VerificationError } from '../error';
+import { VerificationError } from '../error';
 import * as sigstore from '../types/sigstore';
 import { Verifier } from '../verify';
 import bundles from './__fixtures__/bundles';
@@ -45,59 +45,6 @@ describe('Verifier', () => {
   const subject = new Verifier(trustedRoot);
 
   describe('#verify', () => {
-    describe('when the bundle is malformed', () => {
-      describe('when there is no verification material', () => {
-        it('throws an error', () => {
-          expect(() => subject.verify({} as sigstore.Bundle, options)).toThrow(
-            InvalidBundleError
-          );
-        });
-      });
-
-      describe('when there is no content in the bundle', () => {
-        const bundle: sigstore.Bundle = {
-          mediaType: 'application/vnd.sigstore.tlog.v1+json',
-          verificationMaterial: {
-            content: {
-              $case: 'x509CertificateChain',
-              x509CertificateChain: {
-                certificates: [
-                  {
-                    rawBytes: Buffer.from(
-                      'MIIBzTCCAVOgAwIBAgIUQSFLFi9Qcj7aAn/JIVCBxeAkaEcwCgYIKoZIzj0EAwMwJjETMBEGA1UECgwKZm9vYmFyLmRldjEPMA0GA1UEAwwGZm9vYmFyMB4XDTkwMDEwMTAwMDAwMFoXDTQwMDEwMTAwMDAwMFowJjETMBEGA1UECgwKZm9vYmFyLmRldjEPMA0GA1UEAwwGZm9vYmFyMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqOXVeodbskCgnezXR4wURjSvZjBps6WcqoGP+3DDYhHlZlyniQ1AutSp4oedGA0sfYNjA/FaVoUUm0QKiYEwtd6oPdkTwDcce/Pq84dR6cz/ue8JMNXEWExf9tRELxpLo0IwQDAdBgNVHQ4EFgQUW8l0k6NwpkGmRu2O9e3ggYlkc8swDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwCgYIKoZIzj0EAwMDaAAwZQIwPjVLiNY6tLnjCGChiCVSyMg2jBHKsW++lf0FJZ+XufJAZOrI3nfbUButmomgt0VAAjEAjDa7mLilx7Jx2FoSEVdDJU/RP8dtt5hUl4GSBmOtv8qfXI0/yCSCjpjMhbMwRixw',
-                      'base64'
-                    ),
-                  },
-                ],
-              },
-            },
-            tlogEntries: [],
-            timestampVerificationData: {
-              rfc3161Timestamps: [],
-            },
-          },
-        };
-
-        it('throws an error', () => {
-          expect(() => subject.verify(bundle, options)).toThrow(
-            InvalidBundleError
-          );
-        });
-      });
-
-      describe('when the certificate chain is empty', () => {
-        const bundle = sigstore.bundleFromJSON(
-          bundles.signature.invalid.emptyCertChain
-        );
-
-        it('throws an error', () => {
-          expect(() => subject.verify(bundle, options)).toThrow(
-            InvalidBundleError
-          );
-        });
-      });
-    });
-
     describe('when bundle type is messageSignature', () => {
       const payload = bundles.signature.artifact;
 
@@ -191,18 +138,6 @@ describe('Verifier', () => {
             });
           });
 
-          describe('when the message digest is missing', () => {
-            const bundle = sigstore.bundleFromJSON(
-              bundles.signature.invalid.missingDigest
-            );
-
-            it('throws an error', () => {
-              expect(() =>
-                subject.verify(bundle, optionsWithSigners, payload)
-              ).toThrow(InvalidBundleError);
-            });
-          });
-
           describe('when the bundle signature is incorrect', () => {
             const bundle = sigstore.bundleFromJSON(
               bundles.signature.invalid.badSignature
@@ -245,17 +180,6 @@ describe('Verifier', () => {
           it('throws an error', () => {
             expect(() => subject.verify(bundle, options)).toThrow(
               VerificationError
-            );
-          });
-        });
-
-        describe('when the signature is missing', () => {
-          const bundle = sigstore.bundleFromJSON(
-            bundles.dsse.invalid.noSignature
-          );
-          it('throws an error', () => {
-            expect(() => subject.verify(bundle, options)).toThrow(
-              InvalidBundleError
             );
           });
         });

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -114,7 +114,7 @@ export async function verify(
   const trustedRoot = tuf.getTrustedRoot();
   const verifier = new Verifier(trustedRoot, options.keySelector);
 
-  const deserializedBundle = sigstore.Bundle.fromJSON(bundle);
+  const deserializedBundle = sigstore.bundleFromJSON(bundle);
   const opts = collectArtifactVerificationOptions(options);
   return verifier.verify(deserializedBundle, opts, data);
 }

--- a/src/types/sigstore/index.ts
+++ b/src/types/sigstore/index.ts
@@ -18,6 +18,7 @@ import { encoding as enc, pem } from '../../util';
 import { x509Certificate } from '../../x509/cert';
 import { SignatureMaterial } from '../signature';
 import { WithRequired } from '../utility';
+import { assertValidBundle, ValidBundle } from './validate';
 import { Envelope } from './__generated__/envelope';
 import { Bundle, VerificationMaterial } from './__generated__/sigstore_bundle';
 import { HashAlgorithm } from './__generated__/sigstore_common';
@@ -34,7 +35,14 @@ export * from './__generated__/sigstore_trustroot';
 export * from './__generated__/sigstore_verification';
 
 export const bundleToJSON = Bundle.toJSON;
-export const bundleFromJSON = Bundle.fromJSON;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const bundleFromJSON = (obj: any): ValidBundle => {
+  const bundle = Bundle.fromJSON(obj);
+  assertValidBundle(bundle);
+  return bundle;
+};
+
 export const envelopeToJSON = Envelope.toJSON;
 export const envelopeFromJSON = Envelope.fromJSON;
 


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the interface of the `Verifier` to use the new `ValidBundle` type (which narrows the standard `Bundle` to a type for which we know all of the required fields have been populated). This allows us to remove a bunch of if-defined checks we have scattered across the code (and the associated unit tests).