### PR TITLE
signing cert extension verification by OID

### DIFF
--- a/src/__tests__/sigstore.test.ts
+++ b/src/__tests__/sigstore.test.ts
@@ -245,6 +245,9 @@ describe('#verify', () => {
         'YnJpYW5AZGVoYW1lci5jb20=',
         'base64'
       ).toString('ascii'),
+      certificateOIDs: {
+        '1.3.6.1.4.1.57264.1.1': 'https://github.com/login/oauth',
+      },
     };
 
     it('does not throw an error', async () => {

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -49,6 +49,7 @@ export type VerifyOptions = {
   certificateIssuer?: string;
   certificateIdentityEmail?: string;
   certificateIdentityURI?: string;
+  certificateOIDs?: Record<string, string>;
   keySelector?: KeySelector;
 } & TLogOptions;
 
@@ -175,6 +176,13 @@ function collectArtifactVerificationOptions(
       };
     }
 
+    const oids = Object.entries(
+      options.certificateOIDs || {}
+    ).map<sigstore.ObjectIdentifierValuePair>(([oid, value]) => ({
+      oid: { id: oid.split('.').map((s) => parseInt(s, 10)) },
+      value: Buffer.from(value),
+    }));
+
     signers = {
       $case: 'certificateIdentities',
       certificateIdentities: {
@@ -182,7 +190,7 @@ function collectArtifactVerificationOptions(
           {
             issuer: options.certificateIssuer,
             san: san,
-            oids: [],
+            oids: oids,
           },
         ],
       },


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Update the `VerifyOptions` w/ a new `certificateOIDs` field which allows the caller to supply a list of OID/value pairs which will be used when verifying the signer identity in the Fulcio-issued signing certificate.