### PR TITLE
streamline error handling

### DIFF
--- a/src/__tests__/ca/index.test.ts
+++ b/src/__tests__/ca/index.test.ts
@@ -16,6 +16,7 @@ limitations under the License.
 import crypto from 'crypto';
 import nock from 'nock';
 import { CAClient } from '../../ca';
+import { InternalError } from '../../error';
 
 describe('CAClient', () => {
   const baseURL = 'http://localhost:8080';
@@ -91,7 +92,7 @@ tbn02XdfIl+ZhQqUZv88dgDB86bfKyoOokA7fagAEOulkquhKKoOxdOySQ==
       it('throws an error', async () => {
         await expect(
           subject.createSigningCertificate(identityToken, publicKey, challenge)
-        ).rejects.toThrow('HTTP Error: 500 Internal Server Error');
+        ).rejects.toThrow(InternalError);
       });
     });
   });

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 import nock from 'nock';
 import { CAClient } from '../ca';
+import { InternalError } from '../error';
 import { Signer } from '../sign';
 import { TLogClient } from '../tlog';
 import { SignatureMaterial, SignerFunc } from '../types/signature';
@@ -70,7 +71,7 @@ describe('Signer', () => {
 
         it('returns an error', async () => {
           await expect(subject.signBlob(payload)).rejects.toThrow(
-            'HTTP Error: 500 Internal Server Error'
+            InternalError
           );
         });
       });
@@ -215,7 +216,7 @@ describe('Signer', () => {
 
           it('returns an error', async () => {
             await expect(subject.signBlob(payload)).rejects.toThrow(
-              'HTTP Error: 500 Internal Server Error'
+              InternalError
             );
           });
         });

--- a/src/__tests__/sigstore.test.ts
+++ b/src/__tests__/sigstore.test.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { VerificationError } from '../error';
+import { PolicyError, VerificationError } from '../error';
 import { Signer } from '../sign';
 import {
   sign,
@@ -272,7 +272,7 @@ describe('#verify', () => {
 
     it('throws an error', async () => {
       await expect(verify(bundle, options, artifact)).rejects.toThrowError(
-        VerificationError
+        PolicyError
       );
     });
   });
@@ -288,7 +288,7 @@ describe('#verify', () => {
 
     it('throws an error', async () => {
       await expect(verify(bundle, options, artifact)).rejects.toThrowError(
-        VerificationError
+        PolicyError
       );
     });
   });

--- a/src/__tests__/tlog/index.test.ts
+++ b/src/__tests__/tlog/index.test.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import nock from 'nock';
+import { InternalError } from '../../error';
 import {
   toProposedHashedRekordEntry,
   toProposedIntotoEntry,
@@ -64,7 +65,7 @@ describe('TLogClient', () => {
       it('returns an error', async () => {
         await expect(
           subject.createMessageSignatureEntry(digest, sigMaterial)
-        ).rejects.toThrow('HTTP Error: 500 Internal Server Error');
+        ).rejects.toThrow(InternalError);
       });
     });
 
@@ -213,7 +214,7 @@ describe('TLogClient', () => {
       it('returns an error', async () => {
         await expect(
           subject.createDSSEEntry(dsse, sigMaterial)
-        ).rejects.toThrow('HTTP Error: 500 Internal Server Error');
+        ).rejects.toThrow(InternalError);
       });
     });
 
@@ -235,7 +236,7 @@ describe('TLogClient', () => {
             subject.createDSSEEntry(dsse, sigMaterial, {
               fetchOnConflict: false,
             })
-          ).rejects.toThrow('HTTP Error: 409 Conflict');
+          ).rejects.toThrow(InternalError);
         });
       });
 

--- a/src/__tests__/tlog/index.test.ts
+++ b/src/__tests__/tlog/index.test.ts
@@ -241,47 +241,63 @@ describe('TLogClient', () => {
       });
 
       describe('when fetchOnConflict is true', () => {
-        const signatureBundle = {
-          kind: 'intoto',
-          apiVersion: '0.0.2',
-          spec: {
-            signature: {
-              content: signature,
-              publicKey: { content: leafCertificate },
+        describe('when the fetch is successful', () => {
+          const signatureBundle = {
+            kind: 'intoto',
+            apiVersion: '0.0.2',
+            spec: {
+              signature: {
+                content: signature,
+                publicKey: { content: leafCertificate },
+              },
             },
-          },
-        };
+          };
 
-        const rekorEntry = {
-          [uuid]: {
-            body: Buffer.from(JSON.stringify(signatureBundle)).toString(
-              'base64'
-            ),
-            integratedTime: 1654015743,
-            logID:
-              'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d',
-            logIndex: 2513258,
-            verification: {
-              signedEntryTimestamp:
-                'MEUCIQD6CD7ZNLUipFoxzmSL/L8Ewic4SRkXN77UjfJZ7d/wAAIgatokSuX9Rg0iWxAgSfHMtcsagtDCQalU5IvXdQ+yLEA=',
+          const rekorEntry = {
+            [uuid]: {
+              body: Buffer.from(JSON.stringify(signatureBundle)).toString(
+                'base64'
+              ),
+              integratedTime: 1654015743,
+              logID:
+                'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d',
+              logIndex: 2513258,
+              verification: {
+                signedEntryTimestamp:
+                  'MEUCIQD6CD7ZNLUipFoxzmSL/L8Ewic4SRkXN77UjfJZ7d/wAAIgatokSuX9Rg0iWxAgSfHMtcsagtDCQalU5IvXdQ+yLEA=',
+              },
             },
-          },
-        };
+          };
 
-        beforeEach(() => {
-          nock(baseURL)
-            .get(`/api/v1/log/entries/${uuid}`)
-            .reply(200, rekorEntry);
+          beforeEach(() => {
+            nock(baseURL)
+              .get(`/api/v1/log/entries/${uuid}`)
+              .reply(200, rekorEntry);
+          });
+
+          it('returns a signature bundle', async () => {
+            const bundle = await subject.createDSSEEntry(dsse, sigMaterial, {
+              fetchOnConflict: true,
+            });
+            expect(bundle).toBeTruthy();
+            expect(bundle.mediaType).toEqual(
+              'application/vnd.dev.sigstore.bundle+json;version=0.1'
+            );
+          });
         });
 
-        it('returns a signature bundle', async () => {
-          const bundle = await subject.createDSSEEntry(dsse, sigMaterial, {
-            fetchOnConflict: true,
+        describe('when the fetch returns an error', () => {
+          beforeEach(() => {
+            nock(baseURL).get(`/api/v1/log/entries/${uuid}`).reply(404, {});
           });
-          expect(bundle).toBeTruthy();
-          expect(bundle.mediaType).toEqual(
-            'application/vnd.dev.sigstore.bundle+json;version=0.1'
-          );
+
+          it('returns an error', async () => {
+            await expect(
+              subject.createDSSEEntry(dsse, sigMaterial, {
+                fetchOnConflict: true,
+              })
+            ).rejects.toThrow(InternalError);
+          });
         });
       });
     });

--- a/src/__tests__/tuf/trustroot.test.ts
+++ b/src/__tests__/tuf/trustroot.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { Updater } from 'tuf-js';
-import { TrustedRootError } from '../../error';
+import { InternalError } from '../../error';
 import { TrustedRootFetcher } from '../../tuf/trustroot';
 
 describe('TrustedRootFetcher', () => {
@@ -104,7 +104,7 @@ VQ3bF01uZKteMdcV/3qhCmWOecoxRqwrbYTshGg9NyXcBbve6zKwZVTLeg==
 
       it('assembles and returns the TrustedRoot', async () => {
         await expect(() => subject.getTrustedRoot()).rejects.toThrow(
-          TrustedRootError
+          InternalError
         );
       });
     });
@@ -126,7 +126,7 @@ VQ3bF01uZKteMdcV/3qhCmWOecoxRqwrbYTshGg9NyXcBbve6zKwZVTLeg==
 
       it('assembles and returns the TrustedRoot', async () => {
         await expect(() => subject.getTrustedRoot()).rejects.toThrow(
-          TrustedRootError
+          InternalError
         );
       });
     });

--- a/src/__tests__/types/sigstore/validate.test.ts
+++ b/src/__tests__/types/sigstore/validate.test.ts
@@ -1,4 +1,4 @@
-import { InvalidBundleError } from '../../../error';
+import { ValidationError } from '../../../error';
 import {
   assertValidBundle,
   Bundle,
@@ -11,7 +11,7 @@ describe('assertValidBundle', () => {
     const bundle = {} as Bundle;
 
     it('throws an error', () => {
-      expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+      expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
     });
   });
 
@@ -27,7 +27,7 @@ describe('assertValidBundle', () => {
       } as Bundle;
 
       it('throws an error', () => {
-        expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+        expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
       });
     });
 
@@ -43,7 +43,7 @@ describe('assertValidBundle', () => {
       } as Bundle;
 
       it('throws an error', () => {
-        expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+        expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
       });
     });
 
@@ -59,7 +59,7 @@ describe('assertValidBundle', () => {
       } as Bundle;
 
       it('throws an error', () => {
-        expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+        expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
       });
     });
   });
@@ -78,7 +78,7 @@ describe('assertValidBundle', () => {
       } as Bundle;
 
       it('throws an error', () => {
-        expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+        expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
       });
     });
 
@@ -95,7 +95,7 @@ describe('assertValidBundle', () => {
       } as Bundle;
 
       it('throws an error', () => {
-        expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+        expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
       });
     });
 
@@ -115,7 +115,7 @@ describe('assertValidBundle', () => {
       } as Bundle;
 
       it('throws an error', () => {
-        expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+        expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
       });
     });
 
@@ -132,7 +132,7 @@ describe('assertValidBundle', () => {
       } as Bundle;
 
       it('throws an error', () => {
-        expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+        expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
       });
     });
   });
@@ -149,7 +149,7 @@ describe('assertValidBundle', () => {
     } as Bundle;
 
     it('throws an error', () => {
-      expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+      expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
     });
   });
 
@@ -166,7 +166,7 @@ describe('assertValidBundle', () => {
     } as Bundle;
 
     it('throws an error', () => {
-      expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+      expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
     });
   });
 
@@ -191,7 +191,7 @@ describe('assertValidBundle', () => {
       } as Bundle;
 
       it('throws an error', () => {
-        expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+        expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
       });
     });
 
@@ -215,7 +215,7 @@ describe('assertValidBundle', () => {
       } as Bundle;
 
       it('throws an error', () => {
-        expect(() => assertValidBundle(bundle)).toThrow(InvalidBundleError);
+        expect(() => assertValidBundle(bundle)).toThrow(ValidationError);
       });
     });
   });

--- a/src/ca/index.ts
+++ b/src/ca/index.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 import { KeyObject } from 'crypto';
 import { Fulcio } from '../client';
+import { InternalError } from '../error';
 import { pem } from '../util';
 import { toCertificateRequest } from './format';
 
@@ -44,11 +45,15 @@ export class CAClient implements CA {
   ): Promise<string[]> {
     const request = toCertificateRequest(publicKey, challenge);
 
-    const certificate = await this.fulcio.createSigningCertificate(
-      identityToken,
-      request
-    );
+    try {
+      const certificate = await this.fulcio.createSigningCertificate(
+        identityToken,
+        request
+      );
 
-    return pem.split(certificate);
+      return pem.split(certificate);
+    } catch (err) {
+      throw new InternalError('error creating signing certificate', err);
+    }
   }
 }

--- a/src/ca/verify/signer.ts
+++ b/src/ca/verify/signer.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { VerificationError } from '../../error';
+import { PolicyError } from '../../error';
 import * as sigstore from '../../types/sigstore';
 import { x509Certificate } from '../../x509/cert';
 
@@ -38,7 +38,7 @@ export function verifySignerIdentity(
   );
 
   if (!signerVerified) {
-    throw new VerificationError('Certificate issued to untrusted signer');
+    throw new PolicyError('Certificate issued to untrusted signer');
   }
 }
 

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,9 +1,18 @@
-export class VerificationError extends Error {}
+/* eslint-disable @typescript-eslint/no-explicit-any */
+class BaseError extends Error {
+  cause: any | undefined;
 
-export class InvalidBundleError extends Error {}
+  constructor(message: string, cause?: any) {
+    super(message);
+    this.name = this.constructor.name;
+    this.cause = cause;
+  }
+}
 
-export class UnsupportedVersionError extends Error {}
+export class VerificationError extends BaseError {}
 
-export class CertificateChainVerificationError extends VerificationError {}
+export class ValidationError extends BaseError {}
 
-export class TrustedRootError extends Error {}
+export class InternalError extends BaseError {}
+
+export class PolicyError extends BaseError {}

--- a/src/tlog/index.ts
+++ b/src/tlog/index.ts
@@ -19,7 +19,7 @@ import { InternalError } from '../error';
 import { SignatureMaterial } from '../types/signature';
 import { bundle, Bundle, Envelope } from '../types/sigstore';
 import { toProposedHashedRekordEntry, toProposedIntotoEntry } from './format';
-import { Entry } from './types';
+import { Entry, EntryKind } from './types';
 
 interface CreateEntryOptions {
   fetchOnConflict?: boolean;
@@ -53,16 +53,15 @@ export class TLogClient implements TLog {
 
   async createMessageSignatureEntry(
     digest: Buffer,
-    sigMaterial: SignatureMaterial
+    sigMaterial: SignatureMaterial,
+    options: CreateEntryOptions = {}
   ): Promise<Bundle> {
     const proposedEntry = toProposedHashedRekordEntry(digest, sigMaterial);
-
-    try {
-      const entry = await this.rekor.createEntry(proposedEntry);
-      return bundle.toMessageSignatureBundle(digest, sigMaterial, entry);
-    } catch (err) {
-      throw new InternalError('error creating tlog entry', err);
-    }
+    const entry = await this.createEntry(
+      proposedEntry,
+      options.fetchOnConflict
+    );
+    return bundle.toMessageSignatureBundle(digest, sigMaterial, entry);
   }
 
   async createDSSEEntry(
@@ -70,24 +69,38 @@ export class TLogClient implements TLog {
     sigMaterial: SignatureMaterial,
     options: CreateEntryOptions = {}
   ): Promise<Bundle> {
-    const fetchOnConflict = options.fetchOnConflict ?? false;
+    const proposedEntry = toProposedIntotoEntry(envelope, sigMaterial);
+    const entry = await this.createEntry(
+      proposedEntry,
+      options.fetchOnConflict
+    );
+    return bundle.toDSSEBundle(envelope, sigMaterial, entry);
+  }
+
+  private async createEntry(
+    proposedEntry: EntryKind,
+    fetchOnConflict = false
+  ): Promise<Entry> {
     let entry: Entry;
 
     try {
-      const proposedEntry = toProposedIntotoEntry(envelope, sigMaterial);
       entry = await this.rekor.createEntry(proposedEntry);
     } catch (err) {
       // If the entry already exists, fetch it (if enabled)
       if (entryExistsError(err) && fetchOnConflict) {
         // Grab the UUID of the existing entry from the location header
         const uuid = err.location.split('/').pop() || '';
-        entry = await this.rekor.getEntry(uuid);
+        try {
+          entry = await this.rekor.getEntry(uuid);
+        } catch (err) {
+          throw new InternalError('error fetching tlog entry', err);
+        }
       } else {
         throw new InternalError('error creating tlog entry', err);
       }
     }
 
-    return bundle.toDSSEBundle(envelope, sigMaterial, entry);
+    return entry;
   }
 }
 

--- a/src/tlog/verify/body.ts
+++ b/src/tlog/verify/body.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { UnsupportedVersionError, VerificationError } from '../../error';
+import { VerificationError } from '../../error';
 import * as sigstore from '../../types/sigstore';
 import { crypto, encoding as enc } from '../../util';
 import { EntryKind, HashedRekordKind, IntotoKind } from '../types';
@@ -41,9 +41,7 @@ export function verifyTLogBody(
         verifyHashedRekordTLogBody(body, bundleContent);
         break;
       default:
-        throw new UnsupportedVersionError(
-          `unsupported kind in tlog entry: ${kind}`
-        );
+        throw new VerificationError(`unsupported kind in tlog entry: ${kind}`);
     }
     return true;
   } catch (e) {
@@ -57,7 +55,7 @@ function verifyIntotoTLogBody(
   content: sigstore.Bundle['content']
 ): void {
   if (content?.$case !== 'dsseEnvelope') {
-    throw new UnsupportedVersionError(
+    throw new VerificationError(
       `unsupported bundle content: ${content?.$case || 'unknown'}`
     );
   }
@@ -69,7 +67,7 @@ function verifyIntotoTLogBody(
       verifyIntoto002TLogBody(tlogEntry, dsse);
       break;
     default:
-      throw new UnsupportedVersionError(
+      throw new VerificationError(
         `unsupported intoto version: ${tlogEntry.apiVersion}`
       );
   }
@@ -81,7 +79,7 @@ function verifyHashedRekordTLogBody(
   content: sigstore.Bundle['content']
 ): void {
   if (content?.$case !== 'messageSignature') {
-    throw new UnsupportedVersionError(
+    throw new VerificationError(
       `unsupported bundle content: ${content?.$case || 'unknown'}`
     );
   }
@@ -93,7 +91,7 @@ function verifyHashedRekordTLogBody(
       verifyHashedrekor001TLogBody(tlogEntry, messageSignature);
       break;
     default:
-      throw new UnsupportedVersionError(
+      throw new VerificationError(
         `unsupported hashedrekord version: ${tlogEntry.apiVersion}`
       );
   }

--- a/src/tuf/trustroot.ts
+++ b/src/tuf/trustroot.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { TargetFile, Updater } from 'tuf-js';
-import { TrustedRootError } from '../error';
+import { InternalError } from '../error';
 import * as sigstore from '../types/sigstore';
 import { crypto, pem } from '../util';
 
@@ -59,7 +59,7 @@ export class TrustedRootFetcher {
     try {
       await this.tuf.refresh();
     } catch (e) {
-      throw new TrustedRootError('error refreshing trust metadata');
+      throw new InternalError('error refreshing trust metadata');
     }
 
     return Object.values(
@@ -145,7 +145,7 @@ export class TrustedRootFetcher {
       const file = fs.readFileSync(path);
       return pem.toDER(file.toString('utf-8'));
     } catch (err) {
-      throw new TrustedRootError(
+      throw new InternalError(
         `error reading key/certificate for ${target.path}`
       );
     }

--- a/src/types/sigstore/validate.ts
+++ b/src/types/sigstore/validate.ts
@@ -1,4 +1,4 @@
-import { InvalidBundleError } from '../../error';
+import { ValidationError } from '../../error';
 import { WithRequired } from '../utility';
 import { Bundle, VerificationMaterial } from './__generated__/sigstore_bundle';
 import { MessageSignature } from './__generated__/sigstore_common';
@@ -90,7 +90,7 @@ export function assertValidBundle(b: Bundle): asserts b is ValidBundle {
   }
 
   if (invalidValues.length > 0) {
-    throw new InvalidBundleError(
+    throw new ValidationError(
       `invalid/missing bundle values: ${invalidValues.join(', ')}`
     );
   }


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Standardizes a bunch of the error handling code and streamlines the set of raised errors to the following:

* `ValidationError` - The supplied bundle is malformed in some way (missing and/or invalid fields)
* `VerificationError` - Unable to verify the content of the bundle (signature mismatch, invalid SET, untrusted certificate chain, etc)
* `PolicyError` - The bundle is otherwise valid, but was signed by an untrusted identity.
* `InternalError` - Any unexpected error during signing/verification (unable to connect to TUF root, error trying to request signing certificate from Fulcio, etc)