### PR TITLE
public interface clean-up

### DIFF
--- a/src/__tests__/sigstore.test.ts
+++ b/src/__tests__/sigstore.test.ts
@@ -15,13 +15,7 @@ limitations under the License.
 */
 import { PolicyError, VerificationError } from '../error';
 import { Signer } from '../sign';
-import {
-  sign,
-  signAttestation,
-  utils,
-  verify,
-  VerifyOptions,
-} from '../sigstore';
+import { attest, sign, utils, verify, VerifyOptions } from '../sigstore';
 import { getTrustedRoot } from '../tuf';
 import {
   Bundle,
@@ -189,7 +183,7 @@ describe('signAttestation', () => {
   });
 
   it('constructs the Signer with the correct options', async () => {
-    await signAttestation(payload, payloadType);
+    await attest(payload, payloadType);
 
     // Signer was constructed
     expect(mockSigner).toHaveBeenCalledTimes(1);
@@ -206,13 +200,13 @@ describe('signAttestation', () => {
   });
 
   it('invokes the Signer instance with the correct params', async () => {
-    await signAttestation(payload, payloadType);
+    await attest(payload, payloadType);
 
     expect(mockSign).toHaveBeenCalledWith(payload, payloadType);
   });
 
   it('returns the correct envelope', async () => {
-    const sig = await signAttestation(payload, payloadType);
+    const sig = await attest(payload, payloadType);
 
     expect(sig).toEqual(Bundle.toJSON(bundle));
   });
@@ -228,7 +222,7 @@ describe('#verify', () => {
     const artifact = bundles.signature.artifact;
 
     it('does not throw an error', async () => {
-      await expect(verify(bundle, {}, artifact)).resolves.toBe(undefined);
+      await expect(verify(bundle, artifact, {})).resolves.toBe(undefined);
     });
   });
 
@@ -236,7 +230,7 @@ describe('#verify', () => {
     const bundle = bundles.signature.valid.withSigningCert;
     const artifact = Buffer.from('');
     it('throws an error', async () => {
-      await expect(verify(bundle, {}, artifact)).rejects.toThrowError(
+      await expect(verify(bundle, artifact, {})).rejects.toThrowError(
         VerificationError
       );
     });
@@ -258,7 +252,7 @@ describe('#verify', () => {
     };
 
     it('does not throw an error', async () => {
-      await expect(verify(bundle, options, artifact)).resolves.toBeUndefined();
+      await expect(verify(bundle, artifact, options)).resolves.toBeUndefined();
     });
   });
 
@@ -271,7 +265,7 @@ describe('#verify', () => {
     };
 
     it('throws an error', async () => {
-      await expect(verify(bundle, options, artifact)).rejects.toThrowError(
+      await expect(verify(bundle, artifact, options)).rejects.toThrowError(
         PolicyError
       );
     });
@@ -287,7 +281,7 @@ describe('#verify', () => {
     };
 
     it('throws an error', async () => {
-      await expect(verify(bundle, options, artifact)).rejects.toThrowError(
+      await expect(verify(bundle, artifact, options)).rejects.toThrowError(
         PolicyError
       );
     });
@@ -298,7 +292,7 @@ describe('#verify', () => {
     const artifact = bundles.signature.artifact;
 
     it('throws an error', async () => {
-      await expect(verify(bundle, {}, artifact)).rejects.toThrowError(
+      await expect(verify(bundle, artifact, {})).rejects.toThrowError(
         VerificationError
       );
     });

--- a/src/sigstore-utils.ts
+++ b/src/sigstore-utils.ts
@@ -13,12 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {
-  Bundle,
-  DEFAULT_REKOR_BASE_URL,
-  Envelope,
-  SignOptions,
-} from './sigstore';
+import { Bundle, DEFAULT_REKOR_URL, Envelope, SignOptions } from './sigstore';
 import { TLog, TLogClient } from './tlog';
 import { extractSignatureMaterial, SignerFunc } from './types/signature';
 import {
@@ -29,9 +24,9 @@ import {
 } from './types/sigstore';
 import { dsse } from './util';
 
-function createTLogClient(options: { rekorBaseURL?: string }): TLog {
+function createTLogClient(options: { rekorURL?: string }): TLog {
   return new TLogClient({
-    rekorBaseURL: options.rekorBaseURL || DEFAULT_REKOR_BASE_URL,
+    rekorBaseURL: options.rekorURL || DEFAULT_REKOR_URL,
   });
 }
 


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Refactoring the public interface in preparation for the 1.0.0 release (per https://github.com/sigstore/sigstore-js/issues/287):

* `signAttestation` function renamed to `attest`
* `rekorBaseURL` option renamed to `rekorURL`
* `fulcioBaseURL` option renamed to `fulcioURL`
* `tufRootPath` option removed
* `data` param in `verify` function renamed to `payload` (to match param name in `sign` function)
* Swapped the order of the `payload` and `options` params in the `verify` function 