### PR TITLE
update smoke-test workflow with new CLI command

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -29,7 +29,7 @@ jobs:
         echo -n "hello world" > artifact
     - name: Sign artifact
       run: |
-        ./bin/sigstore.js sign-dsse artifact "text/plain" > bundle.sigstore
+        ./bin/sigstore.js attest artifact "text/plain" > bundle.sigstore
     - name: Verify bundle
       run: |
         ./bin/sigstore.js verify bundle.sigstore


### PR DESCRIPTION
Signed-off-by: Brian DeHamer <bdehamer@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fix bug in smoke test workflow introduced with recent refactor of the CLI