### PR TITLE
expose configurable TrustedRoot resolver

### DIFF
--- a/src/sigstore-utils.ts
+++ b/src/sigstore-utils.ts
@@ -16,12 +16,7 @@ limitations under the License.
 import { Bundle, DEFAULT_REKOR_URL, Envelope, SignOptions } from './sigstore';
 import { TLog, TLogClient } from './tlog';
 import { extractSignatureMaterial, SignerFunc } from './types/signature';
-import {
-  bundleToJSON,
-  Envelope as DSSEEnvelope,
-  envelopeFromJSON,
-  envelopeToJSON,
-} from './types/sigstore';
+import * as sigstore from './types/sigstore';
 import { dsse } from './util';
 
 function createTLogClient(options: { rekorURL?: string }): TLog {
@@ -43,7 +38,7 @@ export async function createDSSEEnvelope(
   // Get signature and verification material for pae
   const sigMaterial = await options.signer(paeBuffer);
 
-  const envelope: DSSEEnvelope = {
+  const envelope: sigstore.Envelope = {
     payloadType,
     payload,
     signatures: [
@@ -54,7 +49,7 @@ export async function createDSSEEnvelope(
     ],
   };
 
-  return envelopeToJSON(envelope) as Envelope;
+  return sigstore.Envelope.toJSON(envelope) as Envelope;
 }
 
 // Accepts a signed DSSE envelope and a PEM-encoded public key to be added to the
@@ -64,7 +59,7 @@ export async function createRekorEntry(
   publicKey: string,
   options: SignOptions = {}
 ): Promise<Bundle> {
-  const envelope = envelopeFromJSON(dsseEnvelope);
+  const envelope = sigstore.Envelope.fromJSON(dsseEnvelope);
   const tlog = createTLogClient(options);
 
   const sigMaterial = extractSignatureMaterial(envelope, publicKey);
@@ -72,5 +67,9 @@ export async function createRekorEntry(
     fetchOnConflict: true,
   });
 
-  return bundleToJSON(bundle) as Bundle;
+  return sigstore.Bundle.toJSON(bundle) as Bundle;
 }
+
+export const TrustedRoot = {
+  fromJSON: sigstore.TrustedRoot.fromJSON,
+};

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -53,6 +53,7 @@ export type VerifyOptions = {
   certificateIdentityURI?: string;
   certificateOIDs?: Record<string, string>;
   keySelector?: KeySelector;
+  trustedRootResolver?: tuf.TrustedRootResolver;
 } & TLogOptions;
 
 type Bundle = sigstore.SerializedBundle;
@@ -115,7 +116,8 @@ export async function verify(
   options: VerifyOptions = {}
 ): Promise<void> {
   const cacheDir = defaultCacheDir();
-  const trustedRoot = await tuf.getTrustedRoot(cacheDir);
+  const trustedRootResolver = options.trustedRootResolver || tuf.getTrustedRoot;
+  const trustedRoot = await trustedRootResolver(cacheDir);
   const verifier = new Verifier(trustedRoot, options.keySelector);
 
   const deserializedBundle = sigstore.bundleFromJSON(bundle);

--- a/src/tuf/index.ts
+++ b/src/tuf/index.ts
@@ -19,6 +19,10 @@ import { Updater } from 'tuf-js';
 import * as sigstore from '../types/sigstore';
 import { TrustedRootFetcher } from './trustroot';
 
+export type TrustedRootResolver = (
+  cacheDir: string
+) => Promise<sigstore.TrustedRoot>;
+
 interface RepositoryMap {
   repositories: Record<string, string[]>;
   mapping: {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Exposes a configurable `trustedRootResolver` as part of the verification options to help in testing situations where we may want to call `verify` but not interact w/ the Sigstore TUF repository.