### PR TITLE
remove duplicate tsconfig options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,9 @@
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "allowUnreachableCode": false,
-    "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noUnusedParameters": true,
     "outDir": "./dist"


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Remove duplicate tsconfig options.

The `strict` and `forceConsistentCasingInFileNames` options we recently added to the "tsconfig.json" are already set as part of the "@tsconfig/node14/tsconfig.json" file we're inheriting from.

https://github.com/tsconfig/bases/blob/d699759e29cfd5f6ab0fab9f3365c7767fca9787/bases/node14.json#L1-L16
