### PR TITLE
Unbundle @sigstore/protobuf-specs

### DIFF
--- a/.changeset/silver-berries-smoke.md
+++ b/.changeset/silver-berries-smoke.md
@@ -1,0 +1,5 @@
+---
+'sigstore': patch
+---
+
+Unbundles the @sigstore/protobuf-specs dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,12 @@
 {
   "name": "sigstore",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sigstore",
-      "version": "1.0.0",
-      "bundleDependencies": [
-        "@sigstore/protobuf-specs"
-      ],
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.1.0",
@@ -2003,7 +2000,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.1.0.tgz",
       "integrity": "sha512-a31EnjuIDSX8IXBUib3cYLDRlPMU36AWX4xS8ysLaNu4ZzUesDiPt83pgrW2X1YLMe5L2HbDyaKK5BrL4cNKaQ==",
-      "inBundle": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -58,9 +58,6 @@
     "make-fetch-happen": "^11.0.1",
     "tuf-js": "^1.0.0"
   },
-  "bundleDependencies": [
-    "@sigstore/protobuf-specs"
-  ],
   "engines": {
     "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
   }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Unbundling the `@sigstore/protobuf-specs` dependency to work-around an issue in the npm `cli` which can't deal with top-level dependencies which have bundled deps.