### PR TITLE
make oauth redirect URL configurable

### DIFF
--- a/.changeset/nasty-bees-switch.md
+++ b/.changeset/nasty-bees-switch.md
@@ -1,0 +1,5 @@
+---
+'sigstore': minor
+---
+
+Adds new `redirectURL` config option when signing with an OAuth identity provider

--- a/src/__tests__/identity/oauth.test.ts
+++ b/src/__tests__/identity/oauth.test.ts
@@ -28,7 +28,7 @@ jest.mock('child_process', () => ({
 describe('OAuthProvider', () => {
   const baseURL = 'http://localhost:8080';
   const issuer = new Issuer(baseURL);
-  const subject = new OAuthProvider(issuer, 'sigstore', '');
+  const subject = new OAuthProvider({ issuer, clientID: 'sigstore' });
 
   const mockedExec = jest.mocked(child_process.exec);
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -63,6 +63,7 @@ function printUsage() {
 const signOptions = {
   oidcClientID: 'sigstore',
   oidcIssuer: 'https://oauth2.sigstore.dev/auth',
+  oidcRedirectURL: process.env.OIDC_REDIRECT_URL,
   rekorURL: sigstore.DEFAULT_REKOR_URL,
 };
 

--- a/src/identity/index.ts
+++ b/src/identity/index.ts
@@ -27,12 +27,18 @@ import { Provider } from './provider';
  * @param clientSecret Client secret for the issuer (optional)
  * @returns {Provider}
  */
-function oauthProvider(
-  issuer: string,
-  clientID: string,
-  clientSecret?: string
-): Provider {
-  return new OAuthProvider(new Issuer(issuer), clientID, clientSecret);
+function oauthProvider(options: {
+  issuer: string;
+  clientID: string;
+  clientSecret?: string;
+  redirectURL?: string;
+}): Provider {
+  return new OAuthProvider({
+    issuer: new Issuer(options.issuer),
+    clientID: options.clientID,
+    clientSecret: options.clientSecret,
+    redirectURL: options.redirectURL,
+  });
 }
 
 /**

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -46,6 +46,7 @@ export type SignOptions = {
   oidcIssuer?: string;
   oidcClientID?: string;
   oidcClientSecret?: string;
+  oidcRedirectURL?: string;
 } & TLogOptions;
 
 export type VerifyOptions = {
@@ -63,7 +64,11 @@ type Bundle = sigstore.SerializedBundle;
 
 type IdentityProviderOptions = Pick<
   SignOptions,
-  'identityToken' | 'oidcIssuer' | 'oidcClientID' | 'oidcClientSecret'
+  | 'identityToken'
+  | 'oidcIssuer'
+  | 'oidcClientID'
+  | 'oidcClientSecret'
+  | 'oidcRedirectURL'
 >;
 
 function createCAClient(options: { fulcioURL?: string }): CA {
@@ -148,11 +153,12 @@ function configureIdentityProviders(
     idps.push(identity.ciContextProvider());
     if (options.oidcIssuer && options.oidcClientID) {
       idps.push(
-        identity.oauthProvider(
-          options.oidcIssuer,
-          options.oidcClientID,
-          options.oidcClientSecret
-        )
+        identity.oauthProvider({
+          issuer: options.oidcIssuer,
+          clientID: options.oidcClientID,
+          clientSecret: options.oidcClientSecret,
+          redirectURL: options.oidcRedirectURL,
+        })
       );
     }
   }


### PR DESCRIPTION
Closes #306 

#### Summary
Updates the OAuth identity provider to allow for a configurable `redirectURL`. Some authorization servers require a pre-configured redirect URL so using a dynamic port doesn't work. The `redirectURL` option allows a user to specify a specific host/port for listening for the OAuth redirect. If no value is specified it falls back to the previous behavior of picking a random/available port.

#### Release Note
* Adds new `redirectURL` config option when signing with an OAuth identity provider

