### PR TITLE
Automate creating changesets for dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-changesets.yml
+++ b/.github/workflows/dependabot-changesets.yml
@@ -1,0 +1,15 @@
+name: "Dependabot Changesets"
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  changesets:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'sigstore' &&  github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot Changesets
+        uses: feelepxyz/dependabot-changesets@b91eb2125cabe58b66aa7f18d3345855108d6e21 # v1


### PR DESCRIPTION
Hacked together a action to autogenerate changesets for dependabot PRs. I started out thinking it would be super easy to just invoke the changesets cli from a custom workflow but it's not possible to pass in the necessary args, and realised it's doing a lot more than just taking a summary and semver update type so ended up with writing this https://github.com/feelepxyz/dependabot-changesets 

Not sure it's a great idea yet 😆  Thoughts @bdehamer?
