### PR TITLE
identity: Add support for getting OIDC token from env var.

### DIFF
--- a/.changeset/tasty-lions-melt.md
+++ b/.changeset/tasty-lions-melt.md
@@ -1,0 +1,5 @@
+---
+'sigstore': minor
+---
+
+Added new token provider for looking up OIDC tokens in the SIGSTORE_ID_TOKEN environment variable.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,28 @@ sigstore <command> <artifact>
   sigstore help         print help information
 ```
 
+## Credential Sources
+
+### GitHub Actions
+
+If sigstore-js detects that it is being executed on GitHub Actions, it will use `ACTIONS_ID_TOKEN_REQUEST_URL`
+and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` environment variables to request an OIDC token with the correct scope.
+
+Note: the `id_token: write` permission must be granted to the GitHub Action Job.
+
+See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
+for more details.
+
+### Environment Variables
+
+If the `SIGSTORE_ID_TOKEN` environment variable is set, it will use this to authenticate to Fulcio.
+It is the callers responsibility to make sure that this token has the correct scopes.
+
+### Interactive Flow
+
+If sigstore-js cannot detect ambient credentials, then it will prompt the user to go through the
+interactive flow.
+
 ## Development
 
 ### Changesets

--- a/src/__tests__/identity/ci.test.ts
+++ b/src/__tests__/identity/ci.test.ts
@@ -58,4 +58,30 @@ describe('CIContextProvider', () => {
       });
     });
   });
+
+  describe('#getEnv', () => {
+    describe('when the sigstore environment variables are set', () => {
+      const token = 'hunter2';
+
+      beforeEach(() => {
+        process.env.SIGSTORE_ID_TOKEN = token;
+      });
+
+      afterEach(() => {
+        delete process.env.SIGSTORE_ID_TOKEN;
+      });
+
+      it('returns the token', async () => {
+        const token = await subject.getToken();
+        expect(token).toBe(token);
+      });
+    });
+
+    describe('when the sigstore environment variables are NOT set', () => {
+      it('returns undefined', async () => {
+        const token = subject.getToken();
+        await expect(token).rejects.toBe('CI: no tokens available');
+      });
+    });
+  });
 });

--- a/src/identity/ci.ts
+++ b/src/identity/ci.ts
@@ -20,7 +20,7 @@ import { promise } from '../util';
 type ProviderFunc = (audience: string) => Promise<string>;
 
 // Collection of all the CI-specific providers we have implemented
-const providers: ProviderFunc[] = [getGHAToken];
+const providers: ProviderFunc[] = [getGHAToken, getEnv];
 
 /**
  * CIContextProvider is a composite identity provider which will iterate
@@ -69,4 +69,16 @@ async function getGHAToken(audience: string): Promise<string> {
   });
 
   return response.json().then((data) => data.value);
+}
+
+/**
+ * getEnv can retrieve an OIDC token from an environment variable.
+ * This matches the behavior of https://github.com/sigstore/cosign/tree/main/pkg/providers/envvar
+ */
+async function getEnv(): Promise<string> {
+  if (!process.env.SIGSTORE_ID_TOKEN) {
+    return Promise.reject('no token available');
+  }
+
+  return process.env.SIGSTORE_ID_TOKEN;
 }


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This adds support for reading OIDC tokens from the SIGSTORE_ID_TOKEN environment variable. This mimics the behavior of https://github.com/sigstore/cosign/commit/9b482a5e37d7717a4729544268dd6f928f4af4f6.

The main motivation for supporting this is to enable support for GitLab CI authentication
(https://gitlab.com/gitlab-org/gitlab/-/issues/404793), i.e. for cosign:

```sh
build:
  stage: build
  id_tokens:
    SIGSTORE_ID_TOKEN:
      aud: sigstore
  script:
     - cosign sign ...
```


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Added new token provider for looking up OIDC tokens in the `SIGSTORE_ID_TOKEN` environment variable.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

✅ 