### PR TITLE
use CDN instead of GCS endpoint for TUF root

### DIFF
--- a/.changeset/fuzzy-parents-own.md
+++ b/.changeset/fuzzy-parents-own.md
@@ -1,0 +1,5 @@
+---
+'sigstore': patch
+---
+
+Use CDN-backend endpoint to fetch TUF root material

--- a/src/tuf/index.ts
+++ b/src/tuf/index.ts
@@ -23,7 +23,7 @@ import { readTarget } from './target';
 const TRUSTED_ROOT_TARGET = 'trusted_root.json';
 
 const DEFAULT_CACHE_DIR = appdata.appDataPath('sigstore-js');
-const DEFAULT_MIRROR_URL = 'https://sigstore-tuf-root.storage.googleapis.com';
+const DEFAULT_MIRROR_URL = 'https://tuf-repo-cdn.sigstore.dev';
 const DEFAULT_TUF_ROOT_PATH = '../../store/public-good-instance-root.json';
 
 export interface TUFOptions {


### PR DESCRIPTION
#### Summary
This swaps over the default URL for the sigstore TUF root to use a CDN-backed endpoint instead of hitting GCS directly. There should be no different in content delivered, but static files within the root will be now be returned from the cache.