### PR TITLE
sigstore attest: print rekor entry

### DIFF
--- a/.changeset/gentle-panthers-pump.md
+++ b/.changeset/gentle-panthers-pump.md
@@ -1,0 +1,5 @@
+---
+'sigstore': patch
+---
+
+Print the rekor search entry when running the `sigstore attest` command


### PR DESCRIPTION
Print the rekor search entry when running the `sigstore attest` command. We already did this for `sigstore sign` so refactored slightly to share.
