### PR TITLE
add tlogUpload option

### DIFF
--- a/.changeset/ninety-walls-behave.md
+++ b/.changeset/ninety-walls-behave.md
@@ -1,0 +1,5 @@
+---
+'sigstore': minor
+---
+
+New `tlogUpload` option for `sign` and `attest` to control signature uploads to the transparency log

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ necessary to verify the signature.
 * `options` `<Object>`
   * `fulcioURL` `<string>`: The base URL of the Fulcio instance to use for retrieving the signing certificate. Defaults to `'https://fulcio.sigstore.dev'`.
   * `rekorURL` `<string>`: The base URL of the Rekor instance to use when adding the signature to the transparency log. Defaults to `'https://rekor.sigstore.dev'`.
+  * `tlogUpload` `<boolean>`: Flag indicating whether or not the signature should be recorded on the Rekor transparency log. Defaults to `true`.
   * `identityToken` `<string>`: The OIDC token identifying the signer. If no explicit token is supplied, an attempt will be made to retrieve one from the environment.
 
 ### attest(payload, payloadType[, options])
@@ -53,6 +54,7 @@ as well as the verification material necessary to verify the signature.
 * `options` `<Object>`
   * `fulcioURL` `<string>`: The base URL of the Fulcio instance to use for retrieving the signing certificate. Defaults to `'https://fulcio.sigstore.dev'`.
   * `rekorURL` `<string>`: The base URL of the Rekor instance to use when adding the signature to the transparency log. Defaults to `'https://rekor.sigstore.dev'`.
+  * `tlogUpload` `<boolean>`: Flag indicating whether or not the signed statement should be recorded on the Rekor transparency log. Defaults to `true`.
   * `identityToken` `<string>`: The OIDC token identifying the signer. If no explicit token is supplied, an attempt will be made to retrieve one from the environment.
 
 

--- a/src/__tests__/__fixtures__/bundles/dsse.ts
+++ b/src/__tests__/__fixtures__/bundles/dsse.ts
@@ -101,6 +101,40 @@ const validBundleWithPublicKey = {
   },
 };
 
+const validBundleWithNoTLogEntries = {
+  mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.1',
+  verificationMaterial: {
+    x509CertificateChain: {
+      certificates: [
+        {
+          rawBytes:
+            'MIICnzCCAiWgAwIBAgIUVHwehOtGn4KSD1H8RI581MfbyewwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjIxMTA4MjI1ODA2WhcNMjIxMTA4MjMwODA2WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGg6Hjxt2UNiJ1kwwq5XQIIwMZnJfVQ3bF01uZKteMdcV/3qhCmWOecoxRqwrbYTshGg9NyXcBbve6zKwZVTLeqOCAUQwggFAMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU7WpR60sCpgfu04wcsjvCFxt0fMkwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERYnJpYW5AZGVoYW1lci5jb20wLAYKKwYBBAGDvzABAQQeaHR0cHM6Ly9naXRodWIuY29tL2xvZ2luL29hdXRoMIGJBgorBgEEAdZ5AgQCBHsEeQB3AHUA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGEWXcR8AAABAMARjBEAiBRTrGE5Y1EnYniaJB+nsv89VaYx3QZjocEin3r91wfkAIgMss+fssu5SLQkn7WDTKXgow7SxbHYSZj3ykxArVnuzEwCgYIKoZIzj0EAwMDaAAwZQIxAPjSGddLIvyUMGIkZ+u6JhE9p1Njt3dEtwYkMxfnEV2k7MH1BVmxg9PsJjqycfi+eAIwDaKn2CdOxKsxcgYNi4HviEnZqxmeDyo2YFItzpHfIMQmcRSl91UeOSC8+PuGgwMK',
+        },
+        {
+          rawBytes:
+            'MIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV77LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYBBQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZIzj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJRnZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsPmygUY7Ii2zbdCdliiow=',
+        },
+        {
+          rawBytes:
+            'MIIB9zCCAXygAwIBAgIUALZNAPFdxHPwjeDloDwyYChAO/4wCgYIKoZIzj0EAwMwKjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0yMTEwMDcxMzU2NTlaFw0zMTEwMDUxMzU2NThaMCoxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjERMA8GA1UEAxMIc2lnc3RvcmUwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT7XeFT4rb3PQGwS4IajtLk3/OlnpgangaBclYpsYBr5i+4ynB07ceb3LP0OIOZdxexX69c5iVuyJRQ+Hz05yi+UF3uBWAlHpiS5sh0+H2GHE7SXrk1EC5m1Tr19L9gg92jYzBhMA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRYwB5fkUWlZql6zJChkyLQKsXF+jAfBgNVHSMEGDAWgBRYwB5fkUWlZql6zJChkyLQKsXF+jAKBggqhkjOPQQDAwNpADBmAjEAj1nHeXZp+13NWBNa+EDsDP8G1WWg1tCMWP/WHPqpaVo0jhsweNFZgSs0eE7wYI4qAjEA2WB9ot98sIkoF3vZYdd3/VtWB5b9TNMea7Ix/stJ5TfcLLeABLE4BNJOsQ4vnBHJ',
+        },
+      ],
+    },
+    tlogEntries: [],
+    timestampVerificationData: { rfc3161Timestamps: [] },
+  },
+  dsseEnvelope: {
+    payload: 'aGVsbG8sIHdvcmxkIQ==',
+    payloadType: 'text/plain',
+    signatures: [
+      {
+        sig: 'MEUCICUhAVewfwKlk5fVzpRDUPhEw9O8I2pxC5nTnPfYDBsOAiEA0ZFqs99QgR9mAtFMWtWrOjmUC47zgaoolKIoLH/OwdM=',
+        keyid: '',
+      },
+    ],
+  },
+};
+
 // Public key material for verifying the above bundle
 const publicKey = `-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGg6Hjxt2UNiJ1kwwq5XQIIwMZnJf
@@ -544,6 +578,7 @@ export default {
   valid: {
     withSigningCert: validBundleWithSigningCert,
     withPublicKey: validBundleWithPublicKey,
+    withNoTLogEntries: validBundleWithNoTLogEntries,
   },
   invalid: {
     badSignature: invalidBadSignature,

--- a/src/__tests__/sign.test.ts
+++ b/src/__tests__/sign.test.ts
@@ -39,6 +39,7 @@ describe('Signer', () => {
     ca,
     tlog,
     identityProviders: [idp],
+    tlogUpload: true,
   });
 
   it('should create an instance', () => {
@@ -104,47 +105,140 @@ describe('Signer', () => {
             });
         });
 
-        describe('when Rekor returns successfully', () => {
-          // Rekor output
-          const signature = 'ABC123';
-          const b64Cert = Buffer.from(leafCertificate).toString('base64');
-          const uuid =
-            '69e5a0c1663ee4452674a5c9d5050d866c2ee31e2faaf79913aea7cc27293cf6';
+        describe('when tlog upload is enabled', () => {
+          describe('when Rekor returns successfully', () => {
+            // Rekor output
+            const signature = 'ABC123';
+            const b64Cert = Buffer.from(leafCertificate).toString('base64');
+            const uuid =
+              '69e5a0c1663ee4452674a5c9d5050d866c2ee31e2faaf79913aea7cc27293cf6';
 
-          const signatureBundle = {
-            kind: 'hashedrekord',
-            apiVersion: '0.0.1',
-            spec: {
-              signature: {
-                content: signature,
-                publicKey: { content: b64Cert },
+            const signatureBundle = {
+              kind: 'hashedrekord',
+              apiVersion: '0.0.1',
+              spec: {
+                signature: {
+                  content: signature,
+                  publicKey: { content: b64Cert },
+                },
               },
-            },
-          };
+            };
 
-          const rekorEntry = {
-            [uuid]: {
-              body: Buffer.from(JSON.stringify(signatureBundle)).toString(
-                'base64'
-              ),
-              integratedTime: 1654015743,
-              logID:
-                'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d',
-              logIndex: 2513258,
-              verification: {
-                signedEntryTimestamp:
-                  'MEUCIQD6CD7ZNLUipFoxzmSL/L8Ewic4SRkXN77UjfJZ7d/wAAIgatokSuX9Rg0iWxAgSfHMtcsagtDCQalU5IvXdQ+yLEA=',
+            const rekorEntry = {
+              [uuid]: {
+                body: Buffer.from(JSON.stringify(signatureBundle)).toString(
+                  'base64'
+                ),
+                integratedTime: 1654015743,
+                logID:
+                  'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d',
+                logIndex: 2513258,
+                verification: {
+                  signedEntryTimestamp:
+                    'MEUCIQD6CD7ZNLUipFoxzmSL/L8Ewic4SRkXN77UjfJZ7d/wAAIgatokSuX9Rg0iWxAgSfHMtcsagtDCQalU5IvXdQ+yLEA=',
+                },
               },
-            },
-          };
+            };
 
-          beforeEach(() => {
-            // Mock Rekor request
-            nock(rekorBaseURL)
-              .matchHeader('Accept', 'application/json')
-              .matchHeader('Content-Type', 'application/json')
-              .post('/api/v1/log/entries')
-              .reply(201, rekorEntry);
+            beforeEach(() => {
+              // Mock Rekor request
+              nock(rekorBaseURL)
+                .matchHeader('Accept', 'application/json')
+                .matchHeader('Content-Type', 'application/json')
+                .post('/api/v1/log/entries')
+                .reply(201, rekorEntry);
+            });
+
+            it('returns a signature bundle', async () => {
+              const bundle = await subject.signBlob(payload);
+
+              expect(bundle).toBeTruthy();
+              expect(bundle.mediaType).toEqual(
+                'application/vnd.dev.sigstore.bundle+json;version=0.1'
+              );
+
+              if (bundle.content?.$case === 'messageSignature') {
+                const ms = bundle.content.messageSignature;
+                expect(ms.messageDigest).toBeTruthy();
+                expect(ms.messageDigest?.algorithm).toEqual(
+                  HashAlgorithm.SHA2_256
+                );
+                expect(ms.messageDigest?.digest).toBeTruthy();
+                expect(ms.signature).toBeTruthy();
+              } else {
+                fail('Expected messageSignature');
+              }
+
+              // Verification material
+              if (
+                bundle.verificationMaterial?.content?.$case ===
+                'x509CertificateChain'
+              ) {
+                const chain =
+                  bundle.verificationMaterial.content.x509CertificateChain;
+                expect(chain).toBeTruthy();
+                expect(chain.certificates).toHaveLength(2);
+                expect(chain.certificates[0].rawBytes).toEqual(
+                  pem.toDER(leafCertificate)
+                );
+                expect(chain.certificates[1].rawBytes).toEqual(
+                  pem.toDER(rootCertificate)
+                );
+              } else {
+                fail('Expected x509CertificateChain');
+              }
+
+              expect(
+                bundle.verificationMaterial?.timestampVerificationData
+              ).toBeUndefined();
+              expect(bundle.verificationMaterial?.tlogEntries).toHaveLength(1);
+
+              const tlog = bundle.verificationMaterial?.tlogEntries[0];
+              expect(tlog?.inclusionPromise).toBeTruthy();
+              expect(tlog?.inclusionPromise?.signedEntryTimestamp).toBeTruthy();
+              expect(
+                tlog?.inclusionPromise?.signedEntryTimestamp.toString('base64')
+              ).toEqual(rekorEntry[uuid].verification.signedEntryTimestamp);
+              expect(tlog?.integratedTime).toEqual(
+                rekorEntry[uuid].integratedTime.toString()
+              );
+              expect(tlog?.logId).toBeTruthy();
+              expect(tlog?.logId?.keyId).toBeTruthy();
+              expect(tlog?.logId?.keyId.toString('hex')).toEqual(
+                rekorEntry[uuid].logID
+              );
+              expect(tlog?.logIndex).toEqual(
+                rekorEntry[uuid].logIndex.toString()
+              );
+              expect(tlog?.inclusionProof).toBeFalsy();
+              expect(tlog?.kindVersion?.kind).toEqual('hashedrekord');
+              expect(tlog?.kindVersion?.version).toEqual('0.0.1');
+            });
+          });
+
+          describe('when Rekor returns an error', () => {
+            beforeEach(() => {
+              nock(rekorBaseURL)
+                .matchHeader('Accept', 'application/json')
+                .matchHeader('Content-Type', 'application/json')
+                .post('/api/v1/log/entries')
+                .reply(500, {});
+            });
+
+            it('returns an error', async () => {
+              await expect(subject.signBlob(payload)).rejects.toThrow(
+                InternalError
+              );
+            });
+          });
+        });
+
+        describe('when tlog upload is disabled', () => {
+          const subject = new Signer({
+            ca,
+            tlog,
+            identityProviders: [idp],
+            tlogUpload: false,
           });
 
           it('returns a signature bundle', async () => {
@@ -189,44 +283,7 @@ describe('Signer', () => {
             expect(
               bundle.verificationMaterial?.timestampVerificationData
             ).toBeUndefined();
-            expect(bundle.verificationMaterial?.tlogEntries).toHaveLength(1);
-
-            const tlog = bundle.verificationMaterial?.tlogEntries[0];
-            expect(tlog?.inclusionPromise).toBeTruthy();
-            expect(tlog?.inclusionPromise?.signedEntryTimestamp).toBeTruthy();
-            expect(
-              tlog?.inclusionPromise?.signedEntryTimestamp.toString('base64')
-            ).toEqual(rekorEntry[uuid].verification.signedEntryTimestamp);
-            expect(tlog?.integratedTime).toEqual(
-              rekorEntry[uuid].integratedTime.toString()
-            );
-            expect(tlog?.logId).toBeTruthy();
-            expect(tlog?.logId?.keyId).toBeTruthy();
-            expect(tlog?.logId?.keyId.toString('hex')).toEqual(
-              rekorEntry[uuid].logID
-            );
-            expect(tlog?.logIndex).toEqual(
-              rekorEntry[uuid].logIndex.toString()
-            );
-            expect(tlog?.inclusionProof).toBeFalsy();
-            expect(tlog?.kindVersion?.kind).toEqual('hashedrekord');
-            expect(tlog?.kindVersion?.version).toEqual('0.0.1');
-          });
-        });
-
-        describe('when Rekor returns an error', () => {
-          beforeEach(() => {
-            nock(rekorBaseURL)
-              .matchHeader('Accept', 'application/json')
-              .matchHeader('Content-Type', 'application/json')
-              .post('/api/v1/log/entries')
-              .reply(500, {});
-          });
-
-          it('returns an error', async () => {
-            await expect(subject.signBlob(payload)).rejects.toThrow(
-              InternalError
-            );
+            expect(bundle.verificationMaterial?.tlogEntries).toHaveLength(0);
           });
         });
       });
@@ -299,47 +356,121 @@ describe('Signer', () => {
           });
       });
 
-      describe('when Rekor returns successfully', () => {
-        // Rekor output
-        const signature = 'ABC123';
-        const b64Cert = Buffer.from(certificate).toString('base64');
-        const uuid =
-          '69e5a0c1663ee4452674a5c9d5050d866c2ee31e2faaf79913aea7cc27293cf6';
+      describe('when tlog upload is enabled', () => {
+        describe('when Rekor returns successfully', () => {
+          // Rekor output
+          const signature = 'ABC123';
+          const b64Cert = Buffer.from(certificate).toString('base64');
+          const uuid =
+            '69e5a0c1663ee4452674a5c9d5050d866c2ee31e2faaf79913aea7cc27293cf6';
 
-        const signatureBundle = {
-          kind: 'intoto',
-          apiVersion: '0.0.2',
-          spec: {
-            signature: {
-              content: signature,
-              publicKey: { content: b64Cert },
+          const signatureBundle = {
+            kind: 'intoto',
+            apiVersion: '0.0.2',
+            spec: {
+              signature: {
+                content: signature,
+                publicKey: { content: b64Cert },
+              },
             },
-          },
-        };
+          };
 
-        const rekorEntry = {
-          [uuid]: {
-            body: Buffer.from(JSON.stringify(signatureBundle)).toString(
-              'base64'
-            ),
-            integratedTime: 1654015743,
-            logID:
-              'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d',
-            logIndex: 2513258,
-            verification: {
-              signedEntryTimestamp:
-                'MEUCIQD6CD7ZNLUipFoxzmSL/L8Ewic4SRkXN77UjfJZ7d/wAAIgatokSuX9Rg0iWxAgSfHMtcsagtDCQalU5IvXdQ+yLEA=',
+          const rekorEntry = {
+            [uuid]: {
+              body: Buffer.from(JSON.stringify(signatureBundle)).toString(
+                'base64'
+              ),
+              integratedTime: 1654015743,
+              logID:
+                'c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d',
+              logIndex: 2513258,
+              verification: {
+                signedEntryTimestamp:
+                  'MEUCIQD6CD7ZNLUipFoxzmSL/L8Ewic4SRkXN77UjfJZ7d/wAAIgatokSuX9Rg0iWxAgSfHMtcsagtDCQalU5IvXdQ+yLEA=',
+              },
             },
-          },
-        };
+          };
 
-        beforeEach(() => {
-          // Mock Rekor request
-          nock(rekorBaseURL)
-            .matchHeader('Accept', 'application/json')
-            .matchHeader('Content-Type', 'application/json')
-            .post('/api/v1/log/entries')
-            .reply(201, rekorEntry);
+          beforeEach(() => {
+            // Mock Rekor request
+            nock(rekorBaseURL)
+              .matchHeader('Accept', 'application/json')
+              .matchHeader('Content-Type', 'application/json')
+              .post('/api/v1/log/entries')
+              .reply(201, rekorEntry);
+          });
+
+          it('returns a signature bundle', async () => {
+            const bundle = await subject.signAttestation(payload, payloadType);
+
+            expect(bundle).toBeTruthy();
+            expect(bundle.mediaType).toEqual(
+              'application/vnd.dev.sigstore.bundle+json;version=0.1'
+            );
+
+            if (bundle.content?.$case === 'dsseEnvelope') {
+              const env = bundle.content.dsseEnvelope;
+              expect(env.payloadType).toEqual(payloadType);
+              expect(env.payload.toString('base64')).toEqual(
+                payload.toString('base64')
+              );
+              expect(env.signatures).toHaveLength(1);
+              expect(env.signatures[0].keyid).toEqual('');
+            } else {
+              fail('Expected dsseEnvelope');
+            }
+
+            // Verification material
+            if (
+              bundle.verificationMaterial?.content?.$case ===
+              'x509CertificateChain'
+            ) {
+              const chain =
+                bundle.verificationMaterial.content.x509CertificateChain;
+              expect(chain).toBeTruthy();
+              expect(chain.certificates).toHaveLength(1);
+              expect(chain.certificates[0].rawBytes).toEqual(
+                pem.toDER(certificate)
+              );
+            } else {
+              fail('Expected x509CertificateChain');
+            }
+
+            expect(
+              bundle.verificationMaterial?.timestampVerificationData
+            ).toBeUndefined();
+            expect(bundle.verificationMaterial?.tlogEntries).toHaveLength(1);
+
+            const tlog = bundle.verificationMaterial?.tlogEntries[0];
+            expect(tlog?.inclusionPromise).toBeTruthy();
+            expect(tlog?.inclusionPromise?.signedEntryTimestamp).toBeTruthy();
+            expect(
+              tlog?.inclusionPromise?.signedEntryTimestamp.toString('base64')
+            ).toEqual(rekorEntry[uuid].verification.signedEntryTimestamp);
+            expect(tlog?.integratedTime).toEqual(
+              rekorEntry[uuid].integratedTime.toString()
+            );
+            expect(tlog?.logId).toBeTruthy();
+            expect(tlog?.logId?.keyId).toBeTruthy();
+            expect(tlog?.logId?.keyId.toString('hex')).toEqual(
+              rekorEntry[uuid].logID
+            );
+            expect(tlog?.logIndex).toEqual(
+              rekorEntry[uuid].logIndex.toString()
+            );
+            expect(tlog?.inclusionProof).toBeFalsy();
+            expect(tlog?.kindVersion?.kind).toEqual('intoto');
+            expect(tlog?.kindVersion?.version).toEqual('0.0.2');
+          });
+        });
+      });
+
+      describe('when tlog upload is disabled', () => {
+        const subject = new Signer({
+          ca,
+          tlog,
+          identityProviders: [idp],
+          tlogUpload: false,
         });
 
         it('returns a signature bundle', async () => {
@@ -381,26 +512,7 @@ describe('Signer', () => {
           expect(
             bundle.verificationMaterial?.timestampVerificationData
           ).toBeUndefined();
-          expect(bundle.verificationMaterial?.tlogEntries).toHaveLength(1);
-
-          const tlog = bundle.verificationMaterial?.tlogEntries[0];
-          expect(tlog?.inclusionPromise).toBeTruthy();
-          expect(tlog?.inclusionPromise?.signedEntryTimestamp).toBeTruthy();
-          expect(
-            tlog?.inclusionPromise?.signedEntryTimestamp.toString('base64')
-          ).toEqual(rekorEntry[uuid].verification.signedEntryTimestamp);
-          expect(tlog?.integratedTime).toEqual(
-            rekorEntry[uuid].integratedTime.toString()
-          );
-          expect(tlog?.logId).toBeTruthy();
-          expect(tlog?.logId?.keyId).toBeTruthy();
-          expect(tlog?.logId?.keyId.toString('hex')).toEqual(
-            rekorEntry[uuid].logID
-          );
-          expect(tlog?.logIndex).toEqual(rekorEntry[uuid].logIndex.toString());
-          expect(tlog?.inclusionProof).toBeFalsy();
-          expect(tlog?.kindVersion?.kind).toEqual('intoto');
-          expect(tlog?.kindVersion?.version).toEqual('0.0.2');
+          expect(bundle.verificationMaterial?.tlogEntries).toHaveLength(0);
         });
       });
     });

--- a/src/__tests__/verify.test.ts
+++ b/src/__tests__/verify.test.ts
@@ -161,6 +161,61 @@ describe('Verifier', () => {
             );
           });
         });
+
+        describe('when there are no tlog entries in the bundle', () => {
+          const bundle = sigstore.bundleFromJSON(
+            bundles.dsse.valid.withNoTLogEntries
+          );
+
+          describe('when tlog verification is disabled', () => {
+            const opts: sigstore.RequiredArtifactVerificationOptions = {
+              ...options,
+              tlogOptions: {
+                disable: true,
+                threshold: 0,
+                performOnlineVerification: false,
+              },
+            };
+
+            it('does NOT throw an error', () => {
+              expect(() => subject.verify(bundle, opts)).not.toThrow();
+            });
+          });
+
+          describe('when tlog verification is enabled', () => {
+            describe('when tlog threshold is 0', () => {
+              const opts: sigstore.RequiredArtifactVerificationOptions = {
+                ...options,
+                tlogOptions: {
+                  disable: false,
+                  threshold: 0,
+                  performOnlineVerification: false,
+                },
+              };
+
+              it('does NOT throw an error', () => {
+                expect(() => subject.verify(bundle, opts)).not.toThrow();
+              });
+            });
+
+            describe('when tlog threshold is greater than 0', () => {
+              const opts: sigstore.RequiredArtifactVerificationOptions = {
+                ...options,
+                tlogOptions: {
+                  disable: false,
+                  threshold: 1,
+                  performOnlineVerification: false,
+                },
+              };
+
+              it('throws an error', () => {
+                expect(() => subject.verify(bundle, opts)).toThrow(
+                  VerificationError
+                );
+              });
+            });
+          });
+        });
       });
 
       describe('when the key comes from the key selector callback', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,11 @@ export interface TUFOptions {
   tufCachePath?: string;
 }
 
-export type SignOptions = CAOptions & TLogOptions & IdentityProviderOptions;
+export type SignOptions = {
+  tlogUpload?: boolean;
+} & CAOptions &
+  TLogOptions &
+  IdentityProviderOptions;
 
 export type VerifyOptions = {
   ctLogThreshold?: number;

--- a/src/sigstore.ts
+++ b/src/sigstore.ts
@@ -30,6 +30,7 @@ export async function sign(
     ca,
     tlog,
     identityProviders: idps,
+    tlogUpload: options.tlogUpload,
   });
 
   const bundle = await signer.signBlob(payload);
@@ -48,6 +49,7 @@ export async function attest(
     ca,
     tlog,
     identityProviders: idps,
+    tlogUpload: options.tlogUpload,
   });
 
   const bundle = await signer.signAttestation(payload, payloadType);

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -45,7 +45,9 @@ export class Verifier {
       this.verifySigningCertificate(bundle, options);
     }
 
-    this.verifyTLogEntries(bundle, options);
+    if (options.tlogOptions.disable === false) {
+      this.verifyTLogEntries(bundle, options);
+    }
   }
 
   // Performs bundle signature verification. Determines the type of the bundle


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Introduces a new `tlogUpload` option to the `sign` and `attest` functions which can be used to control whether the generated signature is uploaded to the transparency log. Defaults to `true`.

