### PR TITLE
fix tlog-upload flag in cli

### DIFF
--- a/.changeset/tender-crabs-obey.md
+++ b/.changeset/tender-crabs-obey.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/cli': patch
+---
+
+Fix support for `--tlog-upload`/`--no-tlog-upload` flag

--- a/packages/cli/src/commands/attest.ts
+++ b/packages/cli/src/commands/attest.ts
@@ -78,6 +78,7 @@ export default class Attest extends Command {
       rekorURL: flags['rekor-url'],
       fulcioURL: flags['fulcio-url'],
       tsaServerURL: flags['tsa-server-url'],
+      tlogUpload: flags['tlog-upload'],
     };
 
     const bundle = await fs


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Bugfix in CLI to support `--tlog-upload` flag