### PR TITLE
use new oauth identity provider in cli

### DIFF
--- a/.changeset/friendly-kangaroos-raise.md
+++ b/.changeset/friendly-kangaroos-raise.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/cli': minor
+---
+
+Use new OAuth identity provider for retrieving OIDC tokens in non-CI environments

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,7 +9,7 @@ $ npm install -g @sigstore/cli
 $ sigstore COMMAND
 running command...
 $ sigstore (--version)
-@sigstore/cli/0.0.1 darwin-arm64 node-v18.12.1
+@sigstore/cli/0.0.5 darwin-arm64 node-v18.12.1
 $ sigstore --help [COMMAND]
 USAGE
   $ sigstore COMMAND
@@ -37,13 +37,14 @@ ARGUMENTS
 
 FLAGS
   -o, --output-file=<value>    write output to file
-  -t, --type=<value>           [default: application/vnd.in-toto+json] type to apply to the DSSE envelope
+  -t, --payload-type=<value>   [default: application/vnd.in-toto+json] MIME or content type to apply to the DSSE
+                               envelope
   --fulcio-url=<value>         [default: https://fulcio.sigstore.dev] URL to the Sigstore PKI server
   --oidc-client-id=<value>     [default: sigstore] OIDC client ID for application
   --oidc-issuer=<value>        [default: https://oauth2.sigstore.dev/auth] OIDC provider to be used to issue ID token
   --oidc-redirect-url=<value>  OIDC redirect URL
   --rekor-url=<value>          [default: https://rekor.sigstore.dev] URL to the Rekor transparency log
-  --tlog-upload                whether or not to upload entry to the transparency log
+  --[no-]tlog-upload           whether or not to upload entry to the transparency log
   --tsa-server-url=<value>     URL to the Timestamping Authority
 
 GLOBAL FLAGS
@@ -53,10 +54,10 @@ DESCRIPTION
   attest the supplied file
 
 EXAMPLES
-  $ sigstore attest
+  $ sigstore attest ./statement.json
 ```
 
-_See code: [dist/commands/attest.ts](https://github.com/sigstore/sigstore-js/blob/v0.0.1/dist/commands/attest.ts)_
+_See code: [dist/commands/attest.ts](https://github.com/sigstore/sigstore-js/blob/v0.0.5/dist/commands/attest.ts)_
 
 ## `sigstore help [COMMANDS]`
 
@@ -80,7 +81,7 @@ _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.2.9
 
 ## `sigstore verify BUNDLE`
 
-describe the command here
+verify the supplied .sigstore bundle file
 
 ```
 USAGE
@@ -97,11 +98,11 @@ GLOBAL FLAGS
   --json  Format output as json.
 
 DESCRIPTION
-  describe the command here
+  verify the supplied .sigstore bundle file
 
 EXAMPLES
-  $ sigstore verify
+  $ sigstore verify ./bundle.sigstore
 ```
 
-_See code: [dist/commands/verify.ts](https://github.com/sigstore/sigstore-js/blob/v0.0.1/dist/commands/verify.ts)_
+_See code: [dist/commands/verify.ts](https://github.com/sigstore/sigstore-js/blob/v0.0.5/dist/commands/verify.ts)_
 <!-- commandsstop -->


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the CLI to use it's embedded OAuth identity provider instead of the one bundled in the core library. This is the first step toward deprecating the older OAuth implementation.