### PR TITLE
promote @sigstore/tuf to 1.0.0

### DIFF
--- a/.changeset/wicked-keys-smash.md
+++ b/.changeset/wicked-keys-smash.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/tuf': major
+---
+
+Promote to 1.0.0


### PR DESCRIPTION
Promoting `@sigstore/tuf` to 1.0.0 for inclusion in the next release of the `sigstore` package.
