### PR TITLE
New @sigstore/mock package

### DIFF
--- a/.changeset/young-bottles-cheer.md
+++ b/.changeset/young-bottles-cheer.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/mock': minor
+---
+
+Initial release

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ JavaScript libraries for interacting with [Sigstore][6] services.
 * [`@sigstore/cli`](./packages/cli) - Command line interface for signing/verifying artifacts with Sigstore.
 * [`@sigstore/tuf`](./packages/tuf) - Library for interacting with the Sigstore TUF repository.
 * [`@sigstore/rekor-types`](./packages/tuf) - TypeScript types for the Sigstore Rekor REST API.
+* [`@sigstore/mock`](./packages/mock) - Mocking library for Sigstore services.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2761,6 +2761,175 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.3.6.tgz",
+      "integrity": "sha512-Kr0XsyjuElTc4NijuPYyd6YkTlbz0KCuoWnNkfPFhXjHTzbUIh/s15ixjxLj8XDrXsI1aPQp3D64uHbrs3Kuyg==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "@peculiar/asn1-x509-attr": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.3.6.tgz",
+      "integrity": "sha512-gCTEB/PvUxapmxo4SzGZT1JtEdevRnphRGZZmc9oJE7+pLuj2Px0Q6x+w8VvObfozA3pyPRTq+Wkocnu64+oLw==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.6.tgz",
+      "integrity": "sha512-Hu1xzMJQWv8/GvzOiinaE6XiD1/kEhq2C/V89UEoWeZ2fLUcGNIvMxOr/pMyL0OmpRWj/mhCTXOZp4PP+a0aTg==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.3.6.tgz",
+      "integrity": "sha512-bScrrpQ59mppcoZLkDEW/Wruu+daSWQxpR2vqGjg69+v7VoQ1Le/Elm10ObfNShV2eNNridNQcOQvsHMLvUOCg==",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.3.6",
+        "@peculiar/asn1-pkcs8": "^2.3.6",
+        "@peculiar/asn1-rsa": "^2.3.6",
+        "@peculiar/asn1-schema": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.3.6.tgz",
+      "integrity": "sha512-poqgdjsHNiyR0gnxP8l5VjRInSgpQvOM3zLULF/ZQW67uUsEiuPfplvaNJUlNqNOCd2szGo9jKW9+JmVVpWojA==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.3.6.tgz",
+      "integrity": "sha512-uaxSBF60glccuu5BEZvoPsaJzebVYcQRjXx2wXsGe7Grz/BXtq5RQAJ/3i9fEXawFK/zIbvbXBBpy07cnvrqhA==",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.3.6",
+        "@peculiar/asn1-pfx": "^2.3.6",
+        "@peculiar/asn1-pkcs8": "^2.3.6",
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "@peculiar/asn1-x509-attr": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.6.tgz",
+      "integrity": "sha512-DswjJyAXZnvESuImGNTvbNKvh1XApBVqU+r3UmrFFTAI23gv62byl0f5OFKWTNhCf66WQrd3sklpsCZc/4+jwA==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
+      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.6.tgz",
+      "integrity": "sha512-dRwX31R1lcbIdzbztiMvLNTDoGptxdV7HocNx87LfKU0fEWh7fTWJjx4oV+glETSy6heF/hJHB2J4RGB3vVSYg==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "ipaddr.js": "^2.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.3.6.tgz",
+      "integrity": "sha512-x5Kax8xp3fz+JSc+4Sq0/SUXIdbJeOePibYqvjHMGkP6AoeCOVcP+gg7rZRRGkTlDSyQnAoUTgTEsfAfFEd1/g==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509/node_modules/ipaddr.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.5.0",
+        "webcrypto-core": "^1.7.7"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.9.3.tgz",
+      "integrity": "sha512-rv1TrPi85jOtBJ7Xmqx08p3QPIE2avd5CWgtiwOIAbhV3hoUCLlGIUtXn9CuShfFBCjGy8EnZRQ6YbNFaDL8vw==",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.3.4",
+        "@peculiar/asn1-csr": "^2.3.4",
+        "@peculiar/asn1-ecc": "^2.3.4",
+        "@peculiar/asn1-pkcs9": "^2.3.4",
+        "@peculiar/asn1-rsa": "^2.3.4",
+        "@peculiar/asn1-schema": "^2.3.3",
+        "@peculiar/asn1-x509": "^2.3.4",
+        "pvtsutils": "^1.3.2",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.4.1",
+        "tsyringe": "^4.7.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2776,6 +2945,10 @@
     },
     "node_modules/@sigstore/jest": {
       "resolved": "packages/jest",
+      "link": true
+    },
+    "node_modules/@sigstore/mock": {
+      "resolved": "packages/mock",
       "link": true
     },
     "node_modules/@sigstore/protobuf-specs": {
@@ -2918,7 +3091,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@tufjs/repo-mock/-/repo-mock-1.3.1.tgz",
       "integrity": "sha512-7IDezQbPGReWD3xmgR2pAfG61BZpvW51XnB87OfuiJOe5mkGnziCTTGITtUC3A6htQr9shkk5qIKrhpoMXBwpQ==",
-      "dev": true,
       "dependencies": {
         "@tufjs/models": "1.0.4",
         "nock": "^13.3.1"
@@ -3603,6 +3775,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dependencies": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
@@ -3948,6 +4133,14 @@
       "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
       "dev": true
     },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/cacache": {
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.0.tgz",
@@ -4119,6 +4312,11 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canonicalize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.0.0.tgz",
+      "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w=="
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -7661,7 +7859,6 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -7812,7 +8009,6 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -8484,7 +8680,6 @@
       "version": "13.3.1",
       "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.1.tgz",
       "integrity": "sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==",
-      "dev": true,
       "dependencies": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -10077,6 +10272,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkijs": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.0.14.tgz",
+      "integrity": "sha512-Fi9++44BaOY0VcOEJql27D/HzHIeMU9R48XclfL98Cp8Wh/gGfPbuS1RUwReHQHRIUfzW32eoNO1izxoBMZi6w==",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "bytestreamjs": "^2.0.0",
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/preferred-pm": {
       "version": "3.0.3",
       "dev": true,
@@ -10222,7 +10432,6 @@
     },
     "node_modules/propagate": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -10265,6 +10474,22 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/querystring": {
       "version": "0.2.0",
@@ -10523,6 +10748,11 @@
       "dependencies": {
         "esprima": "~4.0.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
@@ -11752,6 +11982,22 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/tsyringe": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.7.0.tgz",
+      "integrity": "sha512-ncFDM1jTLsok4ejMvSW5jN1VGPQD48y2tfAR0pdptWRKYX4bkbqPt92k7KJ5RFJ1KV36JEs/+TMh7I6OUgj74g==",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/tty-table": {
       "version": "4.1.6",
       "dev": true,
@@ -12127,6 +12373,18 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -12741,6 +12999,50 @@
       "name": "@types/sigstore-jest-extended",
       "version": "0.0.0",
       "license": "Apache-2.0"
+    },
+    "packages/mock": {
+      "name": "@sigstore/mock",
+      "version": "0.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@peculiar/webcrypto": "^1.4.3",
+        "@peculiar/x509": "^1.9.3",
+        "@sigstore/protobuf-specs": "^0.1.0",
+        "@tufjs/repo-mock": "^1.1.0",
+        "asn1js": "^3.0.5",
+        "bytestreamjs": "^2.0.1",
+        "canonicalize": "^2.0.0",
+        "jose": "^4.14.4",
+        "nock": "^13.3.1",
+        "pkijs": "^3.0.14",
+        "pvtsutils": "^1.3.2"
+      },
+      "devDependencies": {
+        "@sigstore/rekor-types": "^0.0.3",
+        "@total-typescript/shoehorn": "^0.1.0",
+        "@types/node": "^18.15.11",
+        "make-fetch-happen": "^11.0.1",
+        "shx": "^0.3.3",
+        "typescript": "^5.0.2"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "packages/mock/node_modules/@sigstore/rekor-types": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@sigstore/rekor-types/-/rekor-types-0.0.3.tgz",
+      "integrity": "sha512-yCPe8wpQOfDNXDxhMGEhcvezJGHyEwZNeBVNa3W7xZ1Jweo/m4oAef6UK8gYowAQEafLZ0LaWUxrsVUp+ljrPg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "packages/mock/node_modules/@types/node": {
+      "version": "18.16.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==",
+      "dev": true
     },
     "packages/oauth": {
       "name": "@sigstore/oauth",
@@ -14855,6 +15157,168 @@
         "@octokit/openapi-types": "^12.11.0"
       }
     },
+    "@peculiar/asn1-cms": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.3.6.tgz",
+      "integrity": "sha512-Kr0XsyjuElTc4NijuPYyd6YkTlbz0KCuoWnNkfPFhXjHTzbUIh/s15ixjxLj8XDrXsI1aPQp3D64uHbrs3Kuyg==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "@peculiar/asn1-x509-attr": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/asn1-csr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.3.6.tgz",
+      "integrity": "sha512-gCTEB/PvUxapmxo4SzGZT1JtEdevRnphRGZZmc9oJE7+pLuj2Px0Q6x+w8VvObfozA3pyPRTq+Wkocnu64+oLw==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/asn1-ecc": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.6.tgz",
+      "integrity": "sha512-Hu1xzMJQWv8/GvzOiinaE6XiD1/kEhq2C/V89UEoWeZ2fLUcGNIvMxOr/pMyL0OmpRWj/mhCTXOZp4PP+a0aTg==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/asn1-pfx": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.3.6.tgz",
+      "integrity": "sha512-bScrrpQ59mppcoZLkDEW/Wruu+daSWQxpR2vqGjg69+v7VoQ1Le/Elm10ObfNShV2eNNridNQcOQvsHMLvUOCg==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.3.6",
+        "@peculiar/asn1-pkcs8": "^2.3.6",
+        "@peculiar/asn1-rsa": "^2.3.6",
+        "@peculiar/asn1-schema": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/asn1-pkcs8": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.3.6.tgz",
+      "integrity": "sha512-poqgdjsHNiyR0gnxP8l5VjRInSgpQvOM3zLULF/ZQW67uUsEiuPfplvaNJUlNqNOCd2szGo9jKW9+JmVVpWojA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/asn1-pkcs9": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.3.6.tgz",
+      "integrity": "sha512-uaxSBF60glccuu5BEZvoPsaJzebVYcQRjXx2wXsGe7Grz/BXtq5RQAJ/3i9fEXawFK/zIbvbXBBpy07cnvrqhA==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.3.6",
+        "@peculiar/asn1-pfx": "^2.3.6",
+        "@peculiar/asn1-pkcs8": "^2.3.6",
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "@peculiar/asn1-x509-attr": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/asn1-rsa": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.6.tgz",
+      "integrity": "sha512-DswjJyAXZnvESuImGNTvbNKvh1XApBVqU+r3UmrFFTAI23gv62byl0f5OFKWTNhCf66WQrd3sklpsCZc/4+jwA==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
+      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+      "requires": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/asn1-x509": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.6.tgz",
+      "integrity": "sha512-dRwX31R1lcbIdzbztiMvLNTDoGptxdV7HocNx87LfKU0fEWh7fTWJjx4oV+glETSy6heF/hJHB2J4RGB3vVSYg==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "ipaddr.js": "^2.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "ipaddr.js": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+          "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ=="
+        }
+      }
+    },
+    "@peculiar/asn1-x509-attr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.3.6.tgz",
+      "integrity": "sha512-x5Kax8xp3fz+JSc+4Sq0/SUXIdbJeOePibYqvjHMGkP6AoeCOVcP+gg7rZRRGkTlDSyQnAoUTgTEsfAfFEd1/g==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/asn1-x509": "^2.3.6",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.5.0",
+        "webcrypto-core": "^1.7.7"
+      }
+    },
+    "@peculiar/x509": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.9.3.tgz",
+      "integrity": "sha512-rv1TrPi85jOtBJ7Xmqx08p3QPIE2avd5CWgtiwOIAbhV3hoUCLlGIUtXn9CuShfFBCjGy8EnZRQ6YbNFaDL8vw==",
+      "requires": {
+        "@peculiar/asn1-cms": "^2.3.4",
+        "@peculiar/asn1-csr": "^2.3.4",
+        "@peculiar/asn1-ecc": "^2.3.4",
+        "@peculiar/asn1-pkcs9": "^2.3.4",
+        "@peculiar/asn1-rsa": "^2.3.4",
+        "@peculiar/asn1-schema": "^2.3.3",
+        "@peculiar/asn1-x509": "^2.3.4",
+        "pvtsutils": "^1.3.2",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.4.1",
+        "tsyringe": "^4.7.0"
+      }
+    },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -14884,6 +15348,42 @@
         "@types/sigstore-jest-extended": "^0.0.0",
         "shx": "^0.3.3",
         "typescript": "^5.1.3"
+      }
+    },
+    "@sigstore/mock": {
+      "version": "file:packages/mock",
+      "requires": {
+        "@peculiar/webcrypto": "^1.4.3",
+        "@peculiar/x509": "^1.9.3",
+        "@sigstore/protobuf-specs": "^0.1.0",
+        "@sigstore/rekor-types": "^0.0.3",
+        "@total-typescript/shoehorn": "^0.1.0",
+        "@tufjs/repo-mock": "^1.1.0",
+        "@types/node": "^18.15.11",
+        "asn1js": "^3.0.5",
+        "bytestreamjs": "^2.0.1",
+        "canonicalize": "^2.0.0",
+        "jose": "^4.14.4",
+        "make-fetch-happen": "^11.0.1",
+        "nock": "^13.3.1",
+        "pkijs": "^3.0.14",
+        "pvtsutils": "^1.3.2",
+        "shx": "^0.3.3",
+        "typescript": "^5.0.2"
+      },
+      "dependencies": {
+        "@sigstore/rekor-types": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/@sigstore/rekor-types/-/rekor-types-0.0.3.tgz",
+          "integrity": "sha512-yCPe8wpQOfDNXDxhMGEhcvezJGHyEwZNeBVNa3W7xZ1Jweo/m4oAef6UK8gYowAQEafLZ0LaWUxrsVUp+ljrPg==",
+          "dev": true
+        },
+        "@types/node": {
+          "version": "18.16.16",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+          "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==",
+          "dev": true
+        }
       }
     },
     "@sigstore/protobuf-specs": {
@@ -15012,7 +15512,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@tufjs/repo-mock/-/repo-mock-1.3.1.tgz",
       "integrity": "sha512-7IDezQbPGReWD3xmgR2pAfG61BZpvW51XnB87OfuiJOe5mkGnziCTTGITtUC3A6htQr9shkk5qIKrhpoMXBwpQ==",
-      "dev": true,
       "requires": {
         "@tufjs/models": "1.0.4",
         "nock": "^13.3.1"
@@ -15508,6 +16007,16 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "requires": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
     "async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
@@ -15744,6 +16253,11 @@
       "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
       "dev": true
     },
+    "bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ=="
+    },
     "cacache": {
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-17.1.0.tgz",
@@ -15859,6 +16373,11 @@
     "caniuse-lite": {
       "version": "1.0.30001450",
       "dev": true
+    },
+    "canonicalize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.0.0.tgz",
+      "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w=="
     },
     "cardinal": {
       "version": "2.1.1",
@@ -18288,8 +18807,7 @@
       "dev": true
     },
     "json-stringify-safe": {
-      "version": "5.0.1",
-      "dev": true
+      "version": "5.0.1"
     },
     "json5": {
       "version": "2.2.3",
@@ -18392,8 +18910,7 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "dev": true
+      "version": "4.17.21"
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -18895,7 +19412,6 @@
       "version": "13.3.1",
       "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.1.tgz",
       "integrity": "sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==",
-      "dev": true,
       "requires": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -20083,6 +20599,18 @@
         }
       }
     },
+    "pkijs": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.0.14.tgz",
+      "integrity": "sha512-Fi9++44BaOY0VcOEJql27D/HzHIeMU9R48XclfL98Cp8Wh/gGfPbuS1RUwReHQHRIUfzW32eoNO1izxoBMZi6w==",
+      "requires": {
+        "asn1js": "^3.0.5",
+        "bytestreamjs": "^2.0.0",
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
     "preferred-pm": {
       "version": "3.0.3",
       "dev": true,
@@ -20177,8 +20705,7 @@
       }
     },
     "propagate": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.1"
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -20201,6 +20728,19 @@
     "pure-rand": {
       "version": "6.0.0",
       "dev": true
+    },
+    "pvtsutils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -20373,6 +20913,11 @@
       "requires": {
         "esprima": "~4.0.0"
       }
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "regenerator-runtime": {
       "version": "0.13.11",
@@ -21217,6 +21762,21 @@
         }
       }
     },
+    "tsyringe": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.7.0.tgz",
+      "integrity": "sha512-ncFDM1jTLsok4ejMvSW5jN1VGPQD48y2tfAR0pdptWRKYX4bkbqPt92k7KJ5RFJ1KV36JEs/+TMh7I6OUgj74g==",
+      "requires": {
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "tty-table": {
       "version": "4.1.6",
       "dev": true,
@@ -21495,6 +22055,18 @@
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
+      }
+    },
+    "webcrypto-core": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
       }
     },
     "webidl-conversions": {

--- a/packages/mock/LICENSE
+++ b/packages/mock/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 The Sigstore Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/mock/README.md
+++ b/packages/mock/README.md
@@ -1,0 +1,79 @@
+# @sigstore/mock &middot; [![npm version](https://img.shields.io/npm/v/@sigstore/tuf.svg?style=flat)](https://www.npmjs.com/package/sigstore) [![CI Status](https://github.com/sigstore/sigstore-js/workflows/CI/badge.svg)](https://github.com/sigstore/sigstore-js/actions/workflows/ci.yml) [![Smoke Test Status](https://github.com/sigstore/sigstore-js/workflows/smoke-test/badge.svg)](https://github.com/sigstore/sigstore-js/actions/workflows/smoke-test.yml)
+
+Builds on top of the [`nock`][1] library to set-up mock endpoints for Sigstore
+services.
+
+## Features
+
+* Mocked version of the Sigstore Fulcio `POST /api/v2/signingCert` API which
+  returns a verifiable certificate signed by an ephemeral certificate authority.
+* Mocked version of the Sigstore Rekor `POST /api/v1/log/entries` API which
+  returns a log entry with a verifiable signed-entry timestamp (SET).
+* Mocked version of the Sigstore Timestamp Authority `POST /api/v1/timestamp`
+  API which returns a verifiable signed timestamp.
+
+## To Do
+
+* Mocked TUF repository which returns the key material necessary to
+  verify artifacts returned from the other services.
+
+## Prerequisites
+
+- Node.js version >= 14.17.0
+
+## Installation
+
+```
+npm install @sigstore/mock
+```
+
+## Usage
+
+```javascript
+const { mockFulcio, mockRekor, mockTSA } = require('@sigstore/mock')
+```
+
+```javascript
+import { mockFulcio, mockRekor, mockTSA } from '@sigstore/mock'
+```
+
+### mockFulcio([options])
+Sets-up a `nock`-based mock endpoint for the Fulcio `POST /api/v2/signingCert` API.
+
+* `options` `<Object>`
+  * `baseURL` `<string>`: Base URL for mocked Fulcio API server. Defaults to
+    `'https://fulcio.sigstore.dev'`
+  * `strict` `<boolean>`: Flag indicating whether or not the request payload
+    will be parsed. When set to `true` the request must contain a well-formed
+    OIDC token and a well-formed public key. The OIDC token does NOT need to be
+    signed or contain a verifiable signature. The supplied public key will be
+    part of the returned certificate. When set to `false` the request body will
+    not be interpreted and a dummy OIDC token and key will be used to provision
+    the certificate. Defaults to `true`.
+
+### mockRekor([options])
+Sets-up a `nock`-based mock endpoint for the Rekor `POST /api/v1/log/entries` API.
+
+* `options` `<Object>`
+  * `baseURL` `<string>`: Base URL for mocked Rekor API server. Defaults to
+    `'https://rekor.sigstore.dev'`
+  * `strict` `<boolean>`: Flag indicating whether or not the request payload
+    will be parsed. When set to `true` the request must contain a well-formed
+    JSON string. The supplied JSON object will be embedded in the returned
+    log entry. When set to `false` the request body will not be interpreted
+    and a dummy proposed entry  be used. Defaults to `true`.
+
+### mockTSA([options])
+Sets-up a `nock`-based mock endpoint for the Timestamp Authority `POST /api/v1/timestamp` API.
+
+* `options` `<Object>`
+  * `baseURL` `<string>`: Base URL for mocked TSA API server. Defaults to
+    `'https://timestamp.sigstore.dev'`
+  * `strict` `<boolean>`: Flag indicating whether or not the request payload
+    will be parsed. When set to `true` the request must contain a well-formed
+    JSON string. The supplied JSON object will be used to set the artifact hash
+    and hash algorithm in the returned timestamp. When set to `false` the
+    request body will not be interpreted and a dummy artifact hash will be
+    used. Defaults to `true`.
+
+[1]: https://github.com/nock/nock

--- a/packages/mock/jest.config.js
+++ b/packages/mock/jest.config.js
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const base = require('../../jest.config.base')
+
+module.exports = {
+  ...base,
+  displayName: 'mock',
+  testPathIgnorePatterns: ['<rootDir>/dist/'],
+};

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@sigstore/mock",
+  "version": "0.0.0",
+  "description": "Mocked version of the Sigstore services",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "clean": "shx rm -rf dist *.tsbuildinfo",
+    "build": "tsc --build",
+    "test": "jest"
+  },
+  "files": [
+    "dist"
+  ],
+  "author": "bdehamer@github.com",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sigstore/sigstore-js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/sigstore/sigstore-js/issues"
+  },
+  "homepage": "https://github.com/sigstore/sigstore-js/tree/main/packages/mock#readme",
+  "publishConfig": {
+    "provenance": true
+  },
+  "devDependencies": {
+    "@sigstore/rekor-types": "^0.0.3",
+    "@total-typescript/shoehorn": "^0.1.0",
+    "@types/node": "^18.15.11",
+    "make-fetch-happen": "^11.0.1",
+    "shx": "^0.3.3",
+    "typescript": "^5.0.2"
+  },
+  "dependencies": {
+    "@peculiar/webcrypto": "^1.4.3",
+    "@peculiar/x509": "^1.9.3",
+    "@sigstore/protobuf-specs": "^0.1.0",
+    "@tufjs/repo-mock": "^1.1.0",
+    "asn1js": "^3.0.5",
+    "bytestreamjs": "^2.0.1",
+    "canonicalize": "^2.0.0",
+    "jose": "^4.14.4",
+    "nock": "^13.3.1",
+    "pkijs": "^3.0.14",
+    "pvtsutils": "^1.3.2"
+  },
+  "engines": {
+    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+  }
+}

--- a/packages/mock/src/constants.ts
+++ b/packages/mock/src/constants.ts
@@ -1,0 +1,27 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+export const DIGEST_SHA256 = 'SHA-256';
+
+export const KEY_ALGORITHM_ECDSA_P256 = { name: 'ECDSA', namedCurve: 'P-256' };
+export const KEY_ALGORITHM_ECDSA_P384 = { name: 'ECDSA', namedCurve: 'P-384' };
+export const SIGNING_ALGORITHM_ECDSA_SHA256 = {
+  name: 'ECDSA',
+  hash: 'SHA-256',
+};
+export const SIGNING_ALGORITHM_ECDSA_SHA384 = {
+  name: 'ECDSA',
+  hash: 'SHA-384',
+};

--- a/packages/mock/src/fulcio/ca.test.ts
+++ b/packages/mock/src/fulcio/ca.test.ts
@@ -1,0 +1,198 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { Crypto } from '@peculiar/webcrypto';
+import { generateKeyPairSync } from 'crypto';
+import * as pkijs from 'pkijs';
+import { initializeCA } from './ca';
+import { initializeCTLog } from './ctlog';
+
+describe('CA', () => {
+  const crypto = new pkijs.CryptoEngine({ crypto: new Crypto() });
+
+  beforeEach(() => {
+    pkijs.setEngine('test', crypto);
+  });
+
+  const extension = {
+    oid: '1.3.6.1.4.1.57264.1.20',
+    value: 'workflow_dispatch',
+  };
+
+  const subjectAltName = 'testsan';
+
+  describe('#rootCertificate', () => {
+    it('returns the root certificate', async () => {
+      const ca = await initializeCA();
+      const root = ca.rootCertificate;
+
+      const cert = pkijs.Certificate.fromBER(root);
+      expect(cert.issuer.typesAndValues[0].value.valueBlock.value).toBe(
+        'sigstore'
+      );
+      expect(cert.issuer.typesAndValues[1].value.valueBlock.value).toBe(
+        'sigstore.mock'
+      );
+    });
+  });
+
+  describe('#issueCertificate', () => {
+    const { publicKey } = generateKeyPairSync('ec', {
+      namedCurve: 'P-256',
+    });
+
+    const keyBytes = publicKey.export({ format: 'der', type: 'spki' });
+
+    describe('when no CT log is provided', () => {
+      it('issues a cert', async () => {
+        const ca = await initializeCA();
+
+        // Issue a certificate with the key above
+        const signingCert = await ca.issueCertificate({
+          publicKey: keyBytes,
+          subjectAltName,
+        });
+        expect(signingCert).toBeDefined();
+
+        const cert = pkijs.Certificate.fromBER(signingCert);
+        expect(cert.issuer.typesAndValues[0].value.valueBlock.value).toBe(
+          'sigstore'
+        );
+        expect(cert.issuer.typesAndValues[1].value.valueBlock.value).toBe(
+          'sigstore.mock'
+        );
+      });
+
+      it('issue a cert with the correct key', async () => {
+        const ca = await initializeCA();
+
+        // Issue a certificate with the key above
+        const signingCert = await ca.issueCertificate({
+          publicKey: keyBytes,
+          subjectAltName,
+        });
+
+        // Check that the key is correct
+        const cert = pkijs.Certificate.fromBER(signingCert);
+        const certKey = await cert.getPublicKey();
+        const cerKeyBuf = await crypto.exportKey('spki', certKey);
+        expect(Buffer.from(cerKeyBuf).toString('base64')).toBe(
+          keyBytes.toString('base64')
+        );
+      });
+
+      it('issue a cert with the correct SAN', async () => {
+        const ca = await initializeCA();
+
+        // Issue a certificate with the key above
+        const signingCert = await ca.issueCertificate({
+          publicKey: keyBytes,
+          subjectAltName,
+        });
+
+        // Check that the key is correct
+        const cert = pkijs.Certificate.fromBER(signingCert);
+
+        expect.assertions(1);
+        cert.extensions!.forEach((ext) => {
+          if (ext.extnID === pkijs.id_SubjectAltName) {
+            expect(ext.parsedValue.altNames[0].value).toBe(subjectAltName);
+          }
+        });
+      });
+
+      it('issue a cert chained back to the root cert', async () => {
+        const ca = await initializeCA();
+
+        // Issue a certificate with the key above
+        const signingCert = await ca.issueCertificate({
+          publicKey: keyBytes,
+          subjectAltName: 'test',
+        });
+
+        const leaf = pkijs.Certificate.fromBER(signingCert);
+        const root = pkijs.Certificate.fromBER(ca.rootCertificate);
+
+        const ccve = new pkijs.CertificateChainValidationEngine({
+          trustedCerts: [root],
+          certs: [leaf],
+          checkDate: new Date(),
+        });
+
+        const result = await ccve.verify({}, crypto);
+        expect(result.result).toBe(true);
+        expect(result.certificatePath).toHaveLength(2);
+      });
+    });
+
+    describe('when a custom extension is provided', () => {
+      it('issues a cert with the extension', async () => {
+        const ca = await initializeCA();
+
+        // Issue a certificate with the key above
+        const signingCert = await ca.issueCertificate({
+          publicKey: keyBytes,
+          subjectAltName: 'test',
+          extensions: [extension],
+        });
+
+        const cert = pkijs.Certificate.fromBER(signingCert);
+
+        expect.assertions(1);
+        cert.extensions!.forEach((ext) => {
+          if (ext.extnID === extension.oid) {
+            expect(ext.parsedValue.valueBlock.value).toBe(extension.value);
+          }
+        });
+      });
+    });
+
+    describe('when a CT log is provided', () => {
+      it('issues a cert with a verifiable SCT', async () => {
+        const ctLog = await initializeCTLog();
+        const ca = await initializeCA(ctLog);
+
+        // Issue a certificate with the key above
+        const signingCert = await ca.issueCertificate({
+          publicKey: keyBytes,
+          subjectAltName: 'test',
+        });
+
+        // Verification material
+        const root = ca.rootCertificate;
+        const ctLogList = [
+          {
+            log_id: ctLog.logID.toString('base64'),
+            key: ctLog.publicKey.toString('base64'),
+          },
+        ];
+
+        const cert = pkijs.Certificate.fromBER(signingCert);
+        // Verify the SCT on the issued certificate
+        const result = await pkijs.verifySCTsForCertificate(
+          cert,
+          pkijs.Certificate.fromBER(root),
+          ctLogList,
+          0,
+          crypto
+        );
+        expect(result).toHaveLength(1);
+        expect(result[0]).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/mock/src/fulcio/ca.ts
+++ b/packages/mock/src/fulcio/ca.ts
@@ -1,0 +1,182 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Crypto } from '@peculiar/webcrypto';
+import x509 from '@peculiar/x509';
+import * as asn1js from 'asn1js';
+import {
+  DIGEST_SHA256,
+  KEY_ALGORITHM_ECDSA_P256,
+  KEY_ALGORITHM_ECDSA_P384,
+  SIGNING_ALGORITHM_ECDSA_SHA384,
+} from '../constants';
+import { createRootCertificate } from '../util/root-cert';
+import type { CTLog } from './ctlog';
+
+const ISSUER = 'CN=sigstore,O=sigstore.mock';
+
+const OID_SIGNED_CERTIFICATE_TIMESTAMP_LIST = '1.3.6.1.4.1.11129.2.4.2';
+
+const MS_PER_MINUTE = 1000 * 60;
+
+export interface CA {
+  rootCertificate: Buffer;
+  issueCertificate: (options: CertificateRequestOptions) => Promise<Buffer>;
+}
+
+export interface CertificateRequestOptions {
+  publicKey: Buffer;
+  subjectAltName: string;
+  extensions?: ExtensionValue[];
+}
+
+interface ExtensionValue {
+  oid: string;
+  value: string;
+}
+
+// Initialize the mock CA. Starts by generating a root key pair and self-signed
+// certificate. The root certificate is used to sign any certificates issued by
+// the #issueCertificate method. Doing this work in a function allows us to
+// work around the fact that some of these operations are async and can't be
+// done in the constructor.
+export async function initializeCA(ctLog?: CTLog): Promise<CA> {
+  const root = await createRootCertificate(
+    ISSUER,
+    KEY_ALGORITHM_ECDSA_P384,
+    SIGNING_ALGORITHM_ECDSA_SHA384
+  );
+
+  return new CAImpl({
+    keyPair: root.keyPair,
+    rootCertificate: root.cert,
+    ctLog,
+  });
+}
+
+class CAImpl implements CA {
+  private root: x509.X509Certificate;
+  private keyPair: CryptoKeyPair;
+  private ctLog?: CTLog;
+  private crypto: Crypto;
+
+  constructor(options: {
+    rootCertificate: x509.X509Certificate;
+    keyPair: CryptoKeyPair;
+    ctLog?: CTLog;
+  }) {
+    this.root = options.rootCertificate;
+    this.ctLog = options.ctLog;
+    this.keyPair = options.keyPair;
+    this.crypto = new Crypto();
+  }
+
+  public get rootCertificate(): Buffer {
+    return Buffer.from(this.root.rawData);
+  }
+
+  public async issueCertificate(
+    opts: CertificateRequestOptions
+  ): Promise<Buffer> {
+    // convert key to CryptoKey
+    const key = await this.crypto.subtle.importKey(
+      'spki',
+      opts.publicKey,
+      KEY_ALGORITHM_ECDSA_P256,
+      true,
+      ['sign', 'verify']
+    );
+
+    // https://github.com/sigstore/fulcio/blob/549813ca04ae02b4a19181817a90a66c2a00960c/pkg/ca/common.go#L29
+    const tbs = {
+      serialNumber: '11182004',
+      notBefore: new Date(),
+      notAfter: new Date(Date.now() + 10 * MS_PER_MINUTE),
+      issuer: ISSUER,
+      publicKey: key,
+      signingAlgorithm: SIGNING_ALGORITHM_ECDSA_SHA384,
+      signingKey: this.keyPair.privateKey,
+      extensions: [
+        new x509.KeyUsagesExtension(x509.KeyUsageFlags.digitalSignature, true),
+        new x509.ExtendedKeyUsageExtension([x509.ExtendedKeyUsage.codeSigning]),
+        new x509.SubjectAlternativeNameExtension(
+          [{ type: 'url', value: opts.subjectAltName }],
+          true
+        ),
+        await x509.SubjectKeyIdentifierExtension.create(
+          key,
+          false,
+          this.crypto
+        ),
+        await x509.AuthorityKeyIdentifierExtension.create(
+          this.keyPair.publicKey,
+          false,
+          this.crypto
+        ),
+        ...generateExtensions(opts.extensions || []),
+      ],
+    } satisfies x509.X509CertificateCreateParams;
+
+    if (this.ctLog) {
+      // Pre-sign certificate for submission to CT Log
+      const preCert = await x509.X509CertificateGenerator.create(
+        tbs,
+        this.crypto
+      );
+
+      // Submit to CT Log in exchange for SCT
+      const issuerID = await this.issuerID;
+      const sct = await this.ctLog.log(preCert.rawData, issuerID);
+
+      // Add the SCT extension to the certificate
+      tbs.extensions.push(extSCTList(sct));
+    }
+
+    const cert = await x509.X509CertificateGenerator.create(tbs, this.crypto);
+    return Buffer.from(cert.rawData);
+  }
+
+  private get issuerID(): Promise<ArrayBuffer> {
+    return this.crypto.subtle
+      .exportKey('spki', this.keyPair.publicKey)
+      .then((key) => this.crypto.subtle.digest({ name: DIGEST_SHA256 }, key));
+  }
+}
+
+const extSCTList = (sct: ArrayBuffer): x509.Extension => {
+  // Manually construct the SCTList
+  const sctBuffer = sct;
+  const sctList = Buffer.concat([
+    Buffer.from([0x00]),
+    Buffer.from([sctBuffer.byteLength]),
+    Buffer.from(sctBuffer),
+  ]);
+
+  // Wrap the SCTList in an OctetString
+  const sctListWrapper = new asn1js.OctetString({ valueHex: sctList });
+
+  return new x509.Extension(
+    OID_SIGNED_CERTIFICATE_TIMESTAMP_LIST,
+    false,
+    sctListWrapper.toBER(false)
+  );
+};
+
+const generateExtensions = (extensions: ExtensionValue[]): x509.Extension[] =>
+  extensions.map((extension) => {
+    const value = new asn1js.Utf8String({ value: extension.value });
+    return new x509.Extension(extension.oid, false, value.toBER(false));
+  });

--- a/packages/mock/src/fulcio/ctlog.test.ts
+++ b/packages/mock/src/fulcio/ctlog.test.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import crypto from 'crypto';
+import { CTLog, initializeCTLog } from './ctlog';
+
+describe('CTLog', () => {
+  describe('initializeCTLog', () => {
+    it('returns a CTLog', async () => {
+      const ctLog: CTLog = await initializeCTLog();
+      expect(ctLog).toBeDefined();
+    });
+  });
+
+  describe('#publicKey', () => {
+    it('returns a key', async () => {
+      const ctLog: CTLog = await initializeCTLog();
+      expect(ctLog.publicKey).toBeDefined();
+    });
+  });
+
+  describe('#logID', () => {
+    it('returns the log ID', async () => {
+      const ctLog: CTLog = await initializeCTLog();
+      expect(ctLog.logID.toString('hex')).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('returns the log ID matching the public key', async () => {
+      const ctLog: CTLog = await initializeCTLog();
+
+      const logID = ctLog.logID.toString('hex');
+      const keyDigest = crypto
+        .createHash('sha256')
+        .update(ctLog.publicKey)
+        .digest('hex');
+      expect(logID).toMatch(keyDigest);
+    });
+  });
+});

--- a/packages/mock/src/fulcio/ctlog.ts
+++ b/packages/mock/src/fulcio/ctlog.ts
@@ -1,0 +1,131 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Crypto, CryptoKey } from '@peculiar/webcrypto';
+import * as asn1js from 'asn1js';
+import * as bs from 'bytestreamjs';
+import * as pkijs from 'pkijs';
+import * as pvutils from 'pvutils';
+import {
+  DIGEST_SHA256,
+  KEY_ALGORITHM_ECDSA_P256,
+  SIGNING_ALGORITHM_ECDSA_SHA256,
+} from '../constants';
+
+export interface CTLog {
+  publicKey: Buffer;
+  logID: Buffer;
+  log: (
+    certificate: ArrayBuffer,
+    issuerID: ArrayBuffer
+  ) => Promise<ArrayBuffer>;
+}
+
+export async function initializeCTLog(): Promise<CTLog> {
+  const crypto = new Crypto();
+
+  const { publicKey, privateKey } = await crypto.subtle.generateKey(
+    KEY_ALGORITHM_ECDSA_P256,
+    true,
+    ['sign', 'verify']
+  );
+
+  const publicKeyBytes = await crypto.subtle
+    .exportKey('spki', publicKey)
+    .then((bytes) => Buffer.from(bytes));
+
+  const logID = await crypto.subtle
+    .digest({ name: DIGEST_SHA256 }, publicKeyBytes)
+    .then((bytes) => Buffer.from(bytes));
+
+  return new CTLogImpl({
+    publicKey: publicKeyBytes,
+    privateKey,
+    logID,
+    crypto,
+  });
+}
+
+interface CTLogOptions {
+  publicKey: Buffer;
+  logID: Buffer;
+  privateKey: CryptoKey;
+  crypto: Crypto;
+}
+
+class CTLogImpl implements CTLog {
+  public readonly publicKey: Buffer;
+  public readonly logID: Buffer;
+  private privateKey: CryptoKey;
+  private crypto: Crypto;
+
+  constructor(options: CTLogOptions) {
+    this.publicKey = options.publicKey;
+    this.privateKey = options.privateKey;
+    this.logID = options.logID;
+    this.crypto = options.crypto;
+  }
+
+  public async log(
+    certificate: ArrayBuffer,
+    issuerID: ArrayBuffer
+  ): Promise<ArrayBuffer> {
+    const version = 0;
+    const timestamp = new Date();
+    const logID = this.logID;
+
+    // A bit of a hack to get the TBS bytes
+    const tbs = pkijs.Certificate.fromBER(certificate).encodeTBS().toBER();
+
+    // Calculate the SCT signature
+    // https://www.rfc-editor.org/rfc/rfc6962#section-3.2
+    const stream = new bs.SeqStream();
+    stream.appendChar(version);
+    stream.appendChar(0x00); // SignatureType - certificate_timestamp(0)
+    stream.appendView(encodeTimeStamp(timestamp));
+    stream.appendUint16(0x01); // LogEntryType = precert_entry(1)
+    stream.appendView(new Uint8Array(issuerID));
+    stream.appendUint24(tbs.byteLength);
+    stream.appendView(new Uint8Array(tbs));
+    stream.appendUint16(0x00); // extensions length
+
+    const sig = await this.sign(stream.buffer);
+
+    return new pkijs.SignedCertificateTimestamp({
+      version,
+      logID,
+      timestamp,
+      signature: asn1js.fromBER(sig).result,
+      hashAlgorithm: 'sha256',
+      signatureAlgorithm: 'ecdsa',
+    }).toStream().buffer;
+  }
+
+  private async sign(data: BufferSource): Promise<ArrayBuffer> {
+    return this.crypto.subtle
+      .sign(SIGNING_ALGORITHM_ECDSA_SHA256, this.privateKey, data)
+      .then((bytes) => pkijs.createCMSECDSASignature(bytes));
+  }
+}
+
+const encodeTimeStamp = (timestamp: Date): Uint8Array => {
+  const timeBuffer = new ArrayBuffer(8);
+  const timeView = new Uint8Array(timeBuffer);
+  const baseArray = pvutils.utilToBase(timestamp.valueOf(), 8);
+  timeView.set(new Uint8Array(baseArray), 8 - baseArray.byteLength);
+
+  return timeView;
+};

--- a/packages/mock/src/fulcio/handler.test.ts
+++ b/packages/mock/src/fulcio/handler.test.ts
@@ -1,0 +1,102 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { generateKeyPairSync } from 'crypto';
+import { CA, initializeCA } from './ca';
+import { fulcioHandler } from './handler';
+
+describe('fulcioHandler', () => {
+  describe('#path', () => {
+    it('returns the correct path', async () => {
+      const ca = await initializeCA();
+      const handler = fulcioHandler(ca);
+      expect(handler.path).toBe('/api/v2/signingCert');
+    });
+  });
+
+  describe('#fn', () => {
+    it('returns a function', async () => {
+      const ca = await initializeCA();
+      const handler = fulcioHandler(ca);
+      expect(handler.fn).toBeInstanceOf(Function);
+    });
+
+    describe('when invoked', () => {
+      const { publicKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+
+      const claims = {
+        sub: 'http://github.com/foo/workflow.yml@refs/heads/main',
+      };
+      const jwt = jwtify(claims);
+
+      const certRequest = {
+        credentials: {
+          oidcIdentityToken: jwt,
+        },
+        publicKeyRequest: {
+          publicKey: {
+            algorithm: 'ECDSA',
+            content: publicKey
+              .export({ format: 'pem', type: 'spki' })
+              .toString('ascii'),
+          },
+          proofOfPossession: 'foobar',
+        },
+      };
+
+      it('returns a certificate chain', async () => {
+        const ca = await initializeCA();
+        const { fn } = fulcioHandler(ca);
+
+        // Make a request
+        const resp = await fn(JSON.stringify(certRequest));
+        expect(resp.statusCode).toBe(201);
+
+        // Check the response
+        const certs = JSON.parse(resp.response.toString());
+        expect(certs).toBeDefined();
+        expect(certs.signedCertificateEmbeddedSct).toBeDefined();
+        expect(certs.signedCertificateEmbeddedSct.chain).toBeDefined();
+        expect(
+          certs.signedCertificateEmbeddedSct.chain.certificates
+        ).toBeDefined();
+        expect(
+          certs.signedCertificateEmbeddedSct.chain.certificates
+        ).toHaveLength(2);
+      });
+
+      describe('when the CA raises an error', () => {
+        const ca: CA = {
+          rootCertificate: Buffer.from(''),
+          issueCertificate: async () => {
+            throw new Error('oops');
+          },
+        };
+
+        it('returns 400 error', async () => {
+          const { fn } = fulcioHandler(ca, { strict: false });
+          const resp = await fn(JSON.stringify(certRequest));
+          expect(resp.statusCode).toBe(400);
+        });
+      });
+    });
+  });
+});
+
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+function jwtify(obj: any): string {
+  return `.${Buffer.from(JSON.stringify(obj)).toString('base64')}.`;
+}

--- a/packages/mock/src/fulcio/handler.ts
+++ b/packages/mock/src/fulcio/handler.ts
@@ -1,0 +1,125 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import assert from 'assert';
+import { generateKeyPairSync } from 'crypto';
+import * as jose from 'jose';
+import type { Handler, HandlerFn, HandlerFnResult } from '../shared.types';
+import type { CA } from './ca';
+
+const CREATE_SIGNING_CERT_PATH = '/api/v2/signingCert';
+const DEFAULT_SUBJECT = 'NO-SUBJECT';
+
+interface FulcioHandlerOptions {
+  strict?: boolean;
+  subjectClaim?: string;
+}
+
+export function fulcioHandler(
+  ca: CA,
+  opts: FulcioHandlerOptions = {}
+): Handler {
+  return {
+    path: CREATE_SIGNING_CERT_PATH,
+    fn: createSigningCertHandler(ca, opts),
+  };
+}
+
+function createSigningCertHandler(
+  ca: CA,
+  opts: FulcioHandlerOptions
+): HandlerFn {
+  const strict = opts.strict ?? true;
+  const subjectClaim = opts.subjectClaim || 'sub';
+
+  return async (body: string): Promise<HandlerFnResult> => {
+    try {
+      // Extract relevant fields from the request
+      const { subject, publicKey } = strict
+        ? parseBody(body, subjectClaim)
+        : stubBody();
+
+      // Request certificate from CA
+      const cert = await ca.issueCertificate({
+        publicKey: fromPEM(publicKey),
+        subjectAltName: subject,
+      });
+
+      // Format the response
+      const response = buildResponse(cert, ca.rootCertificate);
+
+      return { statusCode: 201, response, contentType: 'application/json' };
+    } catch (e) {
+      assert(e instanceof Error);
+      return { statusCode: 400, response: e.message };
+    }
+  };
+}
+
+function parseBody(
+  body: string,
+  subjectClaim: string
+): { subject: string; publicKey: string } {
+  const json = JSON.parse(body.toString());
+  const oidc = json.credentials.oidcIdentityToken;
+  const pem = json.publicKeyRequest.publicKey.content;
+
+  // Decode the JWT
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const claims = jose.decodeJwt(oidc) as any;
+
+  /* istanbul ignore next */
+  return { subject: claims[subjectClaim] || DEFAULT_SUBJECT, publicKey: pem };
+}
+
+function stubBody(): { subject: string; publicKey: string } {
+  const { publicKey } = generateKeyPairSync('ec', {
+    namedCurve: 'P-256',
+  });
+  return {
+    subject: DEFAULT_SUBJECT,
+    publicKey: publicKey.export({ format: 'pem', type: 'spki' }).toString(),
+  };
+}
+
+function buildResponse(leaf: Buffer, root: Buffer): string {
+  const body = {
+    signedCertificateEmbeddedSct: {
+      chain: {
+        certificates: [toPEM(leaf), toPEM(root)],
+      },
+    },
+  };
+  return JSON.stringify(body);
+}
+
+// PEM string to DER-encoded byte buffer conversion
+function fromPEM(pem: string): Buffer {
+  return Buffer.from(
+    pem.replace(/-{5}(BEGIN|END) .*-{5}/gm, '').replace(/\s/gm, ''),
+    'base64'
+  );
+}
+
+// DER-encoded byte buffer to PEM string conversion
+function toPEM(der: Buffer): string {
+  return [
+    '-----BEGIN CERTIFICATE-----',
+    der.toString('base64'),
+    '-----END CERTIFICATE-----',
+    '',
+  ].join('\n');
+}

--- a/packages/mock/src/fulcio/index.ts
+++ b/packages/mock/src/fulcio/index.ts
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { CA, initializeCA } from './ca';
+export { CTLog, initializeCTLog } from './ctlog';
+export { fulcioHandler } from './handler';

--- a/packages/mock/src/index.test.ts
+++ b/packages/mock/src/index.test.ts
@@ -1,0 +1,75 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import nock from 'nock';
+import {
+  HandlerFn,
+  fulcioHandler,
+  initializeCA,
+  initializeCTLog,
+  initializeTLog,
+  initializeTSA,
+  mockFulcio,
+  mockRekor,
+  mockTSA,
+  rekorHandler,
+  tsaHandler,
+} from '.';
+
+it('exports types', () => {
+  const handlerFn: HandlerFn = async () => ({
+    statusCode: 200,
+    response: 'ok',
+  });
+  expect(handlerFn).toBeDefined();
+});
+
+it('exports functions', () => {
+  expect(initializeCA).toBeDefined();
+  expect(initializeCTLog).toBeDefined();
+  expect(initializeTLog).toBeDefined();
+  expect(initializeTSA).toBeDefined();
+  expect(fulcioHandler).toBeDefined();
+  expect(rekorHandler).toBeDefined();
+  expect(tsaHandler).toBeDefined();
+});
+
+describe('exports mock functions', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('mockFulcio', () => {
+    it('mocks fulcio', async () => {
+      await mockFulcio();
+      expect(nock.pendingMocks()).toHaveLength(1);
+    });
+  });
+
+  describe('mockRekor', () => {
+    it('mocks rekor', async () => {
+      await mockRekor();
+      expect(nock.pendingMocks()).toHaveLength(1);
+    });
+  });
+
+  describe('mockTSA', () => {
+    it('mocks tsa', async () => {
+      await mockTSA();
+      expect(nock.pendingMocks()).toHaveLength(1);
+    });
+  });
+});

--- a/packages/mock/src/index.ts
+++ b/packages/mock/src/index.ts
@@ -1,0 +1,77 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { fulcioHandler, initializeCA, initializeCTLog } from './fulcio';
+import { mock } from './mock';
+import { initializeTLog, rekorHandler } from './rekor';
+import { initializeTSA, tsaHandler } from './timestamp';
+
+const DEFAULT_FULCIO_URL = 'https://fulcio.sigstore.dev';
+const DEFAULT_REKOR_URL = 'https://rekor.sigstore.dev';
+const DEFAULT_TSA_URL = 'https://timestamp.sigstore.dev';
+
+interface FulcioOptions {
+  baseURL?: string;
+  strict?: boolean;
+}
+
+interface RekorOptions {
+  baseURL?: string;
+  strict?: boolean;
+}
+
+interface TSAOptions {
+  baseURL?: string;
+  strict?: boolean;
+}
+
+export async function mockFulcio(options: FulcioOptions = {}) {
+  const url = options.baseURL || DEFAULT_FULCIO_URL;
+  const strict = options.strict ?? true;
+  const handler = await initializeCTLog()
+    .then((ctlog) => initializeCA(ctlog))
+    .then((ca) => fulcioHandler(ca, { strict }));
+  mock(url, handler);
+}
+
+export async function mockRekor(options: RekorOptions = {}) {
+  const url = options.baseURL || DEFAULT_REKOR_URL;
+  const strict = options.strict ?? true;
+  const handler = await initializeTLog().then((tlog) =>
+    rekorHandler(tlog, { strict })
+  );
+  mock(url, handler);
+}
+
+export async function mockTSA(options: TSAOptions = {}) {
+  const url = options.baseURL || DEFAULT_TSA_URL;
+  const strict = options.strict ?? true;
+  const handler = await initializeTSA().then((tsa) =>
+    tsaHandler(tsa, { strict })
+  );
+  mock(url, handler);
+}
+
+export type { HandlerFn } from './shared.types';
+export {
+  initializeCA,
+  initializeCTLog,
+  initializeTLog,
+  initializeTSA,
+  fulcioHandler,
+  rekorHandler,
+  tsaHandler,
+};

--- a/packages/mock/src/mock.test.ts
+++ b/packages/mock/src/mock.test.ts
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import fetch from 'make-fetch-happen';
+import { mock } from './mock';
+import type { Handler, HandlerFnResult } from './shared.types';
+
+describe('mock', () => {
+  const result: HandlerFnResult = {
+    statusCode: 201,
+    response: 'test',
+    contentType: 'text/plain',
+  };
+
+  const handler: Handler = {
+    path: '/test',
+    fn: jest.fn().mockResolvedValue(result),
+  };
+
+  describe('when request body is a string', () => {
+    it('mocks', async () => {
+      mock('http://example.com', handler);
+      const response = await fetch('http://example.com/test', {
+        method: 'POST',
+        body: 'test',
+      });
+      expect(handler.fn).toBeCalled();
+      expect(response.status).toBe(result.statusCode);
+      await expect(response.text()).resolves.toBe(result.response);
+    });
+  });
+
+  describe('when request body is JSON', () => {
+    it('mocks', async () => {
+      mock('http://example.com', handler);
+      const response = await fetch('http://example.com/test', {
+        method: 'POST',
+        body: JSON.stringify({ test: 'test' }),
+      });
+      expect(handler.fn).toBeCalled();
+      expect(response.status).toBe(result.statusCode);
+      await expect(response.text()).resolves.toBe(result.response);
+    });
+  });
+});

--- a/packages/mock/src/mock.ts
+++ b/packages/mock/src/mock.ts
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import nock from 'nock';
+import type { Handler, HandlerFn } from './shared.types';
+
+type NockHandler = (
+  uri: string,
+  request: nock.Body
+) => Promise<nock.ReplyFnResult>;
+
+// Sets-up nock-based mocking for the given handler
+export function mock(base: string, handler: Handler): void {
+  nock(base).post(handler.path).reply(adapt(handler.fn));
+}
+
+// Adapts our HandlerFn to nock's NockHandler format
+function adapt(handler: HandlerFn): NockHandler {
+  /* istanbul ignore next */
+  return async (_: string, body: nock.Body): Promise<nock.ReplyFnResult> => {
+    const req = typeof body === 'string' ? body : JSON.stringify(body);
+    return handler(req).then(({ statusCode, response, contentType }) => [
+      statusCode,
+      response,
+      { 'Content-Type': contentType || 'text/plain' },
+    ]);
+  };
+}

--- a/packages/mock/src/rekor/handler.test.ts
+++ b/packages/mock/src/rekor/handler.test.ts
@@ -1,0 +1,96 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { fromPartial } from '@total-typescript/shoehorn';
+import crypto from 'crypto';
+import { rekorHandler } from './handler';
+import { initializeTLog, TLog } from './tlog';
+
+describe('rekorHandler', () => {
+  describe('#path', () => {
+    it('returns the correct path', async () => {
+      const tlog = await initializeTLog();
+      const handler = rekorHandler(tlog);
+      expect(handler.path).toBe('/api/v1/log/entries');
+    });
+  });
+
+  describe('#fn', () => {
+    it('returns a function', async () => {
+      const tlog = await initializeTLog();
+      const handler = rekorHandler(tlog);
+      expect(handler.fn).toBeInstanceOf(Function);
+    });
+
+    describe('when invoked', () => {
+      const proposedEntry = {
+        apiVersion: '0.0.1',
+        kind: 'hashedrekord',
+      };
+
+      it('returns a tlog entry', async () => {
+        const tlog = await initializeTLog();
+        const { fn } = rekorHandler(tlog);
+
+        const resp = await fn(JSON.stringify(proposedEntry));
+        expect(resp.statusCode).toBe(201);
+
+        // Check the response
+        const logID = crypto
+          .createHash('sha256')
+          .update(tlog.publicKey)
+          .digest()
+          .toString('hex');
+
+        const body = JSON.parse(resp.response.toString());
+        expect(body).toBeDefined();
+        expect(Object.keys(body)).toHaveLength(1);
+
+        const uuid = Object.keys(body)[0];
+        expect(uuid).toMatch(/^[0-9a-f]{64}$/);
+
+        const entry = body[uuid];
+        expect(entry.body).toBeDefined();
+        expect(
+          JSON.parse(Buffer.from(entry.body, 'base64').toString())
+        ).toEqual(proposedEntry);
+        expect(entry.integratedTime).toBeGreaterThan(0);
+        expect(entry.logID).toBe(logID);
+        expect(entry.logIndex).toBeGreaterThan(0);
+        expect(entry.verification).toBeDefined();
+        expect(entry.verification?.signedEntryTimestamp).toBeDefined();
+      });
+
+      describe('when the TLog raises an error', () => {
+        const tlog = fromPartial<TLog>({
+          log: async () => {
+            throw new Error('oops');
+          },
+        });
+
+        it('returns 400 error', async () => {
+          const { fn } = rekorHandler(tlog, { strict: false });
+
+          // Make a request
+          const request = {};
+
+          const resp = await fn(JSON.stringify(request));
+          expect(resp.statusCode).toBe(400);
+        });
+      });
+    });
+  });
+});

--- a/packages/mock/src/rekor/handler.ts
+++ b/packages/mock/src/rekor/handler.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import assert from 'assert';
+import type { Handler, HandlerFn, HandlerFnResult } from '../shared.types';
+import type { TLog } from './tlog';
+
+const CREATE_ENTRY_PATH = '/api/v1/log/entries';
+
+interface RekorHandlerOptions {
+  strict?: boolean;
+}
+
+export function rekorHandler(
+  tlog: TLog,
+  opts: RekorHandlerOptions = {}
+): Handler {
+  return {
+    path: CREATE_ENTRY_PATH,
+    fn: createEntryHandler(tlog, opts),
+  };
+}
+
+function createEntryHandler(tlog: TLog, opts: RekorHandlerOptions): HandlerFn {
+  const strict = opts.strict ?? true;
+
+  return async (body: string): Promise<HandlerFnResult> => {
+    try {
+      const proposedEntry = strict ? JSON.parse(body) : {};
+      const tlogEntry = await tlog.log(proposedEntry);
+      const response = JSON.stringify(tlogEntry);
+
+      return { statusCode: 201, response, contentType: 'application/json' };
+    } catch (e) {
+      assert(e instanceof Error);
+      return { statusCode: 400, response: e.message };
+    }
+  };
+}

--- a/packages/mock/src/rekor/index.ts
+++ b/packages/mock/src/rekor/index.ts
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { rekorHandler } from './handler';
+export { TLog, initializeTLog } from './tlog';

--- a/packages/mock/src/rekor/tlog.test.ts
+++ b/packages/mock/src/rekor/tlog.test.ts
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import crypto from 'crypto';
+import { initializeTLog } from './tlog';
+
+describe('TLog', () => {
+  describe('#publicKey', () => {
+    it('should be a public key', async () => {
+      const subject = await initializeTLog();
+      expect(subject.publicKey).toBeDefined();
+    });
+  });
+
+  describe('#log', () => {
+    it('returns an entry', async () => {
+      const proposedEntry = { foo: 'bar' };
+      const subject = await initializeTLog();
+      const result = await subject.log(proposedEntry);
+
+      const logID = crypto
+        .createHash('sha256')
+        .update(subject.publicKey)
+        .digest()
+        .toString('hex');
+
+      expect(Object.keys(result)).toHaveLength(1);
+      const uuid = Object.keys(result)[0];
+      expect(uuid).toMatch(/^[0-9a-f]{64}$/);
+
+      const entry = result[uuid];
+      expect(entry.body).toBeDefined();
+      expect(JSON.parse(Buffer.from(entry.body, 'base64').toString())).toEqual(
+        proposedEntry
+      );
+      expect(entry.integratedTime).toBeGreaterThan(0);
+      expect(entry.logID).toEqual(logID);
+      expect(entry.logIndex).toBeGreaterThan(0);
+      expect(entry.verification).toBeDefined();
+      expect(entry.verification?.signedEntryTimestamp).toBeDefined();
+    });
+  });
+});

--- a/packages/mock/src/rekor/tlog.ts
+++ b/packages/mock/src/rekor/tlog.ts
@@ -1,0 +1,93 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { LogEntry } from '@sigstore/rekor-types';
+import canonicalize from 'canonicalize';
+import crypto from 'crypto';
+
+type InclusionProof = NonNullable<
+  LogEntry['x']['verification']
+>['inclusionProof'];
+
+const EMPTY_INCLUSION_PROOF: InclusionProof = {
+  checkpoint: '',
+  hashes: [],
+  logIndex: 0,
+  rootHash: '',
+  treeSize: 0,
+};
+
+export interface TLog {
+  publicKey: Buffer;
+  log(proposedEntry: object): Promise<LogEntry>;
+}
+
+export async function initializeTLog(): Promise<TLog> {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ec', {
+    namedCurve: 'P-256',
+  });
+
+  return new TLogImpl(publicKey, privateKey);
+}
+
+class TLogImpl implements TLog {
+  public readonly publicKey: Buffer;
+  private readonly privateKey: crypto.KeyObject;
+
+  constructor(publicKey: crypto.KeyObject, privateKey: crypto.KeyObject) {
+    this.privateKey = privateKey;
+    this.publicKey = publicKey.export({ format: 'der', type: 'spki' });
+  }
+
+  public async log(proposedEntry: object): Promise<LogEntry> {
+    const uuid = crypto.randomBytes(32).toString('hex');
+    const timestamp = Math.floor(Date.now() / 1000);
+    const logID = crypto
+      .createHash('sha256')
+      .update(this.publicKey)
+      .digest()
+      .toString('hex');
+    const body = canonicalize(proposedEntry);
+
+    // Random number for logIndex
+    const logIndex = Math.floor(Math.random() * 9000000) + 1000000;
+
+    // Calculate SET
+    // https://github.com/sigstore/rekor/blob/9eb7ec628a41ffed291b605a57e716e86ef0d680/pkg/api/entries.go#L71
+    const setData = {
+      body: body,
+      integratedTime: timestamp,
+      logIndex: logIndex,
+      logID: logID,
+    };
+    const setBuffer = Buffer.from(canonicalize(setData)!, 'utf8');
+    const set = crypto.sign('sha256', setBuffer, this.privateKey);
+
+    return {
+      [uuid]: {
+        body: Buffer.from(body!).toString('base64'),
+        integratedTime: timestamp,
+        logID: logID,
+        logIndex: logIndex,
+        verification: {
+          inclusionProof: EMPTY_INCLUSION_PROOF,
+          signedEntryTimestamp: set.toString('base64'),
+        },
+      },
+    };
+  }
+}

--- a/packages/mock/src/shared.types.ts
+++ b/packages/mock/src/shared.types.ts
@@ -1,0 +1,27 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export type HandlerFnResult = {
+  statusCode: number;
+  response: string | Buffer;
+  contentType?: string;
+};
+export type HandlerFn = (request: string) => Promise<HandlerFnResult>;
+
+export type Handler = {
+  path: string;
+  fn: HandlerFn;
+};

--- a/packages/mock/src/timestamp/handler.test.ts
+++ b/packages/mock/src/timestamp/handler.test.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { fromPartial } from '@total-typescript/shoehorn';
+import { tsaHandler } from './handler';
+import { initializeTSA, TSA } from './tsa';
+
+describe('tsaHandler', () => {
+  describe('#path', () => {
+    it('returns the correct path', async () => {
+      const tsa = await initializeTSA();
+      const handler = tsaHandler(tsa);
+      expect(handler.path).toBe('/api/v1/timestamp');
+    });
+  });
+
+  describe('#fn', () => {
+    it('returns a function', async () => {
+      const tsa = await initializeTSA();
+      const handler = tsaHandler(tsa);
+      expect(handler.fn).toBeInstanceOf(Function);
+    });
+
+    describe('when invoked', () => {
+      const timestampRequest = {
+        artifactHash: Buffer.from('foo').toString('base64'),
+        hashAlgorithm: 'sha256',
+      };
+
+      it('returns a tlog entry', async () => {
+        const tsa = await initializeTSA();
+        const { fn } = tsaHandler(tsa);
+
+        const resp = await fn(JSON.stringify(timestampRequest));
+        expect(resp.statusCode).toBe(201);
+
+        // Check the response
+        const body = resp.response;
+        expect(body).toBeDefined();
+      });
+
+      describe('when the TLog raises an error', () => {
+        const tsa = fromPartial<TSA>({
+          timestamp: async () => {
+            throw new Error('oops');
+          },
+        });
+
+        it('returns 400 error', async () => {
+          const { fn } = tsaHandler(tsa, { strict: false });
+
+          // Make a request
+          const request = {};
+
+          const resp = await fn(JSON.stringify(request));
+          expect(resp.statusCode).toBe(400);
+        });
+      });
+    });
+  });
+});

--- a/packages/mock/src/timestamp/handler.ts
+++ b/packages/mock/src/timestamp/handler.ts
@@ -1,0 +1,95 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import assert from 'assert';
+import type { Handler, HandlerFn, HandlerFnResult } from '../shared.types';
+import type { TSA, TimestampRequest } from './tsa';
+
+const OID_SHA256_ALGO_ID = '2.16.840.1.101.3.4.2.1';
+const OID_SHA384_ALGO_ID = '2.16.840.1.101.3.4.2.2';
+const OID_SHA512_ALGO_ID = '2.16.840.1.101.3.4.2.3';
+
+const OID_TSA_POLICY = '1.3.6.1.4.1.57264.2';
+
+const DEFAULT_NONCE = 1234567890;
+
+const CREATE_TIMESTAMP_PATH = '/api/v1/timestamp';
+
+interface TSAHandlerOptions {
+  strict?: boolean;
+}
+
+export function tsaHandler(tsa: TSA, opts: TSAHandlerOptions = {}): Handler {
+  return {
+    path: CREATE_TIMESTAMP_PATH,
+    fn: createTimestampHandler(tsa, opts),
+  };
+}
+
+function createTimestampHandler(tsa: TSA, opts: TSAHandlerOptions): HandlerFn {
+  const strict = opts.strict ?? true;
+
+  return async (body: string): Promise<HandlerFnResult> => {
+    try {
+      const tsr = strict ? parseRequest(body) : stubRequest();
+      const timestamp = await tsa.timestamp(tsr);
+
+      return {
+        statusCode: 201,
+        response: timestamp,
+        contentType: 'application/timestamp-reply',
+      };
+    } catch (e) {
+      assert(e instanceof Error);
+      return { statusCode: 400, response: e.message };
+    }
+  };
+}
+
+function parseRequest(body: string): TimestampRequest {
+  const json = JSON.parse(body.toString());
+
+  return {
+    artifactHash: Buffer.from(json.artifactHash, 'base64'),
+    hashAlgorithmOID: hashToOID(json.hashAlgorithm),
+    nonce: json.nonce || DEFAULT_NONCE,
+    policyOID: json.tsaPolicyOID || OID_TSA_POLICY,
+    certReq: json.certificates ?? false,
+  };
+}
+
+function stubRequest(): TimestampRequest {
+  return {
+    artifactHash: Buffer.from('deadbeef', 'hex'),
+    hashAlgorithmOID: OID_SHA256_ALGO_ID,
+    nonce: DEFAULT_NONCE,
+    policyOID: OID_TSA_POLICY,
+    certReq: false,
+  };
+}
+
+function hashToOID(hash: string): string {
+  switch (true) {
+    /* istanbul ignore next */
+    case /512/.test(hash):
+      return OID_SHA512_ALGO_ID;
+    /* istanbul ignore next */
+    case /384/.test(hash):
+      return OID_SHA384_ALGO_ID;
+    default:
+      return OID_SHA256_ALGO_ID;
+  }
+}

--- a/packages/mock/src/timestamp/index.ts
+++ b/packages/mock/src/timestamp/index.ts
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { tsaHandler } from './handler';
+export { TSA, initializeTSA } from './tsa';

--- a/packages/mock/src/timestamp/tsa.test.ts
+++ b/packages/mock/src/timestamp/tsa.test.ts
@@ -1,0 +1,59 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import * as pkijs from 'pkijs';
+import { initializeTSA, TimestampRequest } from './tsa';
+
+const OID_TSA_POLICY = '1.3.6.1.4.1.57264.2';
+const OID_SHA256_ALGO_ID = '2.16.840.1.101.3.4.2.1';
+
+describe('TSA', () => {
+  describe('rootCertificate', () => {
+    it('returns the root certificate', async () => {
+      const tsa = await initializeTSA();
+      const root = tsa.rootCertificate;
+
+      expect(root).toBeDefined();
+
+      const cert = pkijs.Certificate.fromBER(root);
+      expect(cert.issuer.typesAndValues[0].value.valueBlock.value).toBe('tsa');
+      expect(cert.issuer.typesAndValues[1].value.valueBlock.value).toBe(
+        'sigstore.mock'
+      );
+    });
+  });
+
+  describe('#timestamp', () => {
+    const request: TimestampRequest = {
+      hashAlgorithmOID: OID_SHA256_ALGO_ID,
+      artifactHash: Buffer.from('hello world'),
+      nonce: 12345,
+      policyOID: OID_TSA_POLICY,
+    };
+
+    it('returns a timestamp', async () => {
+      const tsa = await initializeTSA();
+      const result = await tsa.timestamp(request);
+      expect(result).toBeDefined();
+
+      const timestamp = pkijs.TimeStampResp.fromBER(result);
+      expect(timestamp.status.status).toBe(0);
+      expect(timestamp.timeStampToken?.contentType).toBe(
+        '1.2.840.113549.1.7.2'
+      );
+    });
+  });
+});

--- a/packages/mock/src/timestamp/tsa.ts
+++ b/packages/mock/src/timestamp/tsa.ts
@@ -1,0 +1,180 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { Crypto } from '@peculiar/webcrypto';
+import * as asn1js from 'asn1js';
+import * as pkijs from 'pkijs';
+import {
+  DIGEST_SHA256,
+  KEY_ALGORITHM_ECDSA_P256,
+  SIGNING_ALGORITHM_ECDSA_SHA384,
+} from '../constants';
+import { createRootCertificate } from '../util/root-cert';
+
+const ISSUER = 'CN=tsa,O=sigstore.mock';
+const OID_TSTINFO_CONTENT_TYPE = '1.2.840.113549.1.9.16.1.4';
+const OID_SIGNED_DATA_CONTENT_TYPE = '1.2.840.113549.1.7.2';
+
+export interface TSA {
+  rootCertificate: Buffer;
+  timestamp: (req: TimestampRequest) => Promise<Buffer>;
+}
+
+export interface TimestampRequest {
+  artifactHash: Buffer;
+  hashAlgorithmOID: string;
+  nonce: number;
+  policyOID: string;
+  certReq?: boolean;
+}
+
+export async function initializeTSA(): Promise<TSA> {
+  const root = await createRootCertificate(
+    ISSUER,
+    KEY_ALGORITHM_ECDSA_P256,
+    SIGNING_ALGORITHM_ECDSA_SHA384
+  );
+  return new TSAImpl({
+    rootCertificate: pkijs.Certificate.fromBER(root.cert.rawData),
+    keyPair: root.keyPair,
+  });
+}
+
+interface TSAOptions {
+  rootCertificate: pkijs.Certificate;
+  keyPair: CryptoKeyPair;
+}
+
+class TSAImpl implements TSA {
+  private rootCert: pkijs.Certificate;
+  private keyPair: CryptoKeyPair;
+  private crypto: pkijs.ICryptoEngine;
+  constructor(options: TSAOptions) {
+    this.rootCert = options.rootCertificate;
+    this.keyPair = options.keyPair;
+    this.crypto = new pkijs.CryptoEngine({ crypto: new Crypto() });
+  }
+
+  public get rootCertificate(): Buffer {
+    return Buffer.from(this.rootCert.toSchema().toBER(false));
+  }
+
+  // Create a timestamp according to
+  // https://www.rfc-editor.org/rfc/rfc3161.html
+  public async timestamp(req: TimestampRequest): Promise<Buffer> {
+    const includeCerts = req.certReq ?? false;
+
+    // Create the TSTInfo structure and sign it
+    const tstInfo = this.tstInfo(req);
+    const signedData = await this.signedData(tstInfo, includeCerts);
+
+    // Encode the SignedData structure
+    const content = new pkijs.ContentInfo({
+      contentType: OID_SIGNED_DATA_CONTENT_TYPE,
+      content: signedData.toSchema(true),
+    });
+
+    const tspResponse = new pkijs.TimeStampResp({
+      status: new pkijs.PKIStatusInfo({ status: 0 }),
+      timeStampToken: new pkijs.ContentInfo({ schema: content.toSchema() }),
+    });
+
+    return Buffer.from(tspResponse.toSchema().toBER(false));
+  }
+
+  // Assemble the TSTInfo structure from the request
+  private tstInfo(req: TimestampRequest): pkijs.TSTInfo {
+    return new pkijs.TSTInfo({
+      version: 1,
+      policy: req.policyOID,
+      messageImprint: new pkijs.MessageImprint({
+        hashAlgorithm: new pkijs.AlgorithmIdentifier({
+          algorithmId: req.hashAlgorithmOID,
+        }),
+        hashedMessage: new asn1js.OctetString({ valueHex: req.artifactHash }),
+      }),
+      serialNumber: new asn1js.Integer({ value: 1 }),
+      genTime: new Date(),
+      accuracy: new pkijs.Accuracy({ seconds: 1 }),
+      nonce: new asn1js.Integer({ value: req.nonce }),
+      tsa: generalName('tsa', 'sigstore.mock'),
+    });
+  }
+
+  // Wrap the TSTInfo structure in a SignedData structure
+  private async signedData(
+    tstInfo: pkijs.TSTInfo,
+    includeCerts: boolean
+  ): Promise<pkijs.SignedData> {
+    // The isConstructed flag makes the encoding of the
+    // EncapsulatedContentInfo look more like what the real TSA returns,
+    // however, it results in a reponse that is not parseable by openssl.
+    // I guess we should leave it at the default but let's revisit this
+    // later if we run into verification problems.
+    const encapContent = new pkijs.EncapsulatedContentInfo({
+      eContentType: OID_TSTINFO_CONTENT_TYPE,
+      eContent: new asn1js.OctetString({
+        valueHex: tstInfo.toSchema().toBER(false),
+        // idBlock: { isConstructed: true },
+      }),
+    });
+
+    /* istanbul ignore next */
+    const signedData = new pkijs.SignedData({
+      version: 1,
+      encapContentInfo: encapContent,
+      certificates: includeCerts ? [this.rootCert] : undefined,
+      signerInfos: [
+        new pkijs.SignerInfo({
+          version: 1,
+          sid: new pkijs.IssuerAndSerialNumber({
+            issuer: this.rootCert.issuer,
+            serialNumber: this.rootCert.serialNumber,
+          }),
+        }),
+      ],
+    });
+
+    // Sign the SignedData structure
+    await signedData.sign(
+      this.keyPair.privateKey,
+      0,
+      DIGEST_SHA256,
+      undefined,
+      this.crypto
+    );
+
+    return signedData;
+  }
+}
+
+function generalName(commonName: string, orgName: string): pkijs.GeneralName {
+  return new pkijs.GeneralName({
+    type: 4,
+    value: new pkijs.RelativeDistinguishedNames({
+      typesAndValues: [
+        new pkijs.AttributeTypeAndValue({
+          type: '2.5.4.10',
+          value: new asn1js.PrintableString({ value: orgName }),
+        }),
+        new pkijs.AttributeTypeAndValue({
+          type: '2.5.4.3',
+          value: new asn1js.PrintableString({ value: commonName }),
+        }),
+      ],
+    }),
+  });
+}

--- a/packages/mock/src/trust-root.ts
+++ b/packages/mock/src/trust-root.ts
@@ -1,0 +1,80 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  CertificateAuthority,
+  HashAlgorithm,
+  PublicKeyDetails,
+  TransparencyLogInstance,
+} from '@sigstore/protobuf-specs';
+import crypto from 'crypto';
+import type { CA, CTLog } from './fulcio';
+import type { TLog } from './rekor';
+
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+function trustCA(ca: CA): CertificateAuthority {
+  return {
+    subject: {
+      commonName: 'sigstore',
+      organization: 'sigstore.mock',
+    },
+    uri: 'https://fulcio.sigstore.dev',
+    certChain: {
+      certificates: [
+        {
+          rawBytes: ca.rootCertificate,
+        },
+      ],
+    },
+    validFor: {
+      start: new Date(),
+    },
+  };
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+function trustTLog(tlog: TLog): TransparencyLogInstance {
+  return {
+    baseUrl: 'https://rekor.sigstore.dev',
+    logId: {
+      keyId: crypto.createHash('sha256').update(tlog.publicKey).digest(),
+    },
+    hashAlgorithm: HashAlgorithm.SHA2_256,
+    publicKey: {
+      rawBytes: tlog.publicKey,
+      keyDetails: PublicKeyDetails.PKIX_ECDSA_P256_SHA_256,
+      validFor: {
+        start: new Date(),
+      },
+    },
+  };
+}
+
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+function trustCTLog(ctlog: CTLog): TransparencyLogInstance {
+  return {
+    baseUrl: 'https://ctfe.sigstore.dev',
+    logId: { keyId: ctlog.logID },
+    hashAlgorithm: HashAlgorithm.SHA2_256,
+    publicKey: {
+      rawBytes: ctlog.publicKey,
+      keyDetails: PublicKeyDetails.PKIX_ECDSA_P256_SHA_256,
+      validFor: {
+        start: new Date(),
+      },
+    },
+  };
+}

--- a/packages/mock/src/util/root-cert.ts
+++ b/packages/mock/src/util/root-cert.ts
@@ -1,0 +1,67 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { Crypto } from '@peculiar/webcrypto';
+import x509 from '@peculiar/x509';
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+interface CertWithKey {
+  cert: x509.X509Certificate;
+  keyPair: CryptoKeyPair;
+}
+
+export async function createRootCertificate(
+  name: string,
+  keyAlgo: EcKeyGenParams,
+  signAlgo: EcdsaParams
+): Promise<CertWithKey> {
+  const crypto = new Crypto();
+  const keyPair = await crypto.subtle.generateKey(keyAlgo, true, [
+    'sign',
+    'verify',
+  ]);
+
+  const tbs: x509.X509CertificateCreateSelfSignedParams = {
+    serialNumber: '01',
+    name: name,
+    notBefore: new Date(),
+    notAfter: new Date(Date.now() + 365 * MS_PER_DAY),
+    signingAlgorithm: signAlgo,
+    keys: keyPair,
+    extensions: [
+      new x509.BasicConstraintsExtension(true, undefined, true),
+      new x509.KeyUsagesExtension(
+        x509.KeyUsageFlags.cRLSign | x509.KeyUsageFlags.keyCertSign,
+        true
+      ),
+      await x509.SubjectKeyIdentifierExtension.create(
+        keyPair.publicKey,
+        false,
+        crypto
+      ),
+      await x509.AuthorityKeyIdentifierExtension.create(
+        keyPair.publicKey,
+        false,
+        crypto
+      ),
+    ],
+  };
+
+  return {
+    cert: await x509.X509CertificateGenerator.createSelfSigned(tbs, crypto),
+    keyPair,
+  };
+}

--- a/packages/mock/tsconfig.json
+++ b/packages/mock/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "exclude": [
+    "./dist",
+    "**/__tests__",
+    "jest.setup.ts"
+  ]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "packages/cli" },
     { "path": "packages/client" },
+    { "path": "packages/mock" },
     { "path": "packages/rekor-types" },
     { "path": "packages/jest" },
     { "path": "packages/jest-types" },


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Package providing mocking support for the core APIs in Fulcio, Rekor and the Timestamp Authority.

Unlike the main `sigstore` project where we've made an intentional effort to limit our reliance on third-party dependencies, I've included all sorts of libraries here to help with the ugly work of generating certificates/timestamps, canonicalizing JSON, parsing OIDC tokens, etc. This package should only ever be used as a `devDependency` so I'm not concerned with dependency bloat.