### PR TITLE
add Rekor inclusion proof to Sigstore bundle

### DIFF
--- a/.changeset/serious-carpets-help.md
+++ b/.changeset/serious-carpets-help.md
@@ -1,0 +1,5 @@
+---
+'sigstore': minor
+---
+
+Include transparency log inclusion proof in Sigstore bundle

--- a/packages/client/src/__tests__/types/sigstore/index.test.ts
+++ b/packages/client/src/__tests__/types/sigstore/index.test.ts
@@ -145,11 +145,11 @@ describe('bundle', () => {
       verification: {
         signedEntryTimestamp: Buffer.from('set').toString('base64'),
         inclusionProof: {
-          hashes: [],
-          logIndex: 0,
-          rootHash: '',
-          treeSize: 0,
-          checkpoint: '',
+          hashes: ['deadbeef', 'feedface'],
+          logIndex: 12345,
+          rootHash: 'fee1dead',
+          treeSize: 12346,
+          checkpoint: 'checkpoint',
         },
       },
     } satisfies Entry;
@@ -199,9 +199,27 @@ describe('bundle', () => {
       expect(tlog?.logId?.keyId).toBeTruthy();
       expect(tlog?.logId?.keyId.toString('hex')).toEqual(rekorEntry.logID);
       expect(tlog?.logIndex).toEqual(rekorEntry.logIndex.toString());
-      expect(tlog?.inclusionProof).toBeFalsy();
       expect(tlog?.kindVersion?.kind).toEqual(entryKind.kind);
       expect(tlog?.kindVersion?.version).toEqual(entryKind.apiVersion);
+      expect(tlog?.inclusionProof?.checkpoint?.envelope).toEqual(
+        rekorEntry.verification.inclusionProof.checkpoint
+      );
+      expect(tlog?.inclusionProof?.hashes).toHaveLength(2);
+      expect(tlog?.inclusionProof?.hashes[0]).toEqual(
+        Buffer.from(rekorEntry.verification.inclusionProof.hashes[0], 'hex')
+      );
+      expect(tlog?.inclusionProof?.hashes[1]).toEqual(
+        Buffer.from(rekorEntry.verification.inclusionProof.hashes[1], 'hex')
+      );
+      expect(tlog?.inclusionProof?.logIndex).toEqual(
+        rekorEntry.verification.inclusionProof.logIndex.toString()
+      );
+      expect(tlog?.inclusionProof?.rootHash).toEqual(
+        Buffer.from(rekorEntry.verification.inclusionProof.rootHash, 'hex')
+      );
+      expect(tlog?.inclusionProof?.treeSize).toEqual(
+        rekorEntry.verification.inclusionProof.treeSize.toString()
+      );
 
       // Timestamp verification data
       expect(

--- a/packages/client/src/external/rekor.ts
+++ b/packages/client/src/external/rekor.ts
@@ -19,22 +19,24 @@ import { checkStatus } from './error';
 
 import type {
   LogEntry,
-  ProposedEntry,
   ProposedDSSEEntry,
+  ProposedEntry,
   ProposedHashedRekordEntry,
   ProposedIntotoEntry,
+  InclusionProof as RekorInclusionProof,
   SearchIndex,
   SearchLogQuery,
 } from '@sigstore/rekor-types';
 import type { FetchOptions } from '../types/fetch';
 
 export type {
-  ProposedEntry,
-  SearchIndex,
-  SearchLogQuery,
   ProposedDSSEEntry,
+  ProposedEntry,
   ProposedHashedRekordEntry,
   ProposedIntotoEntry,
+  RekorInclusionProof,
+  SearchIndex,
+  SearchLogQuery,
 };
 
 // The LogEntry type from @sigstore/rekor-types is a Record type


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Per https://github.com/sigstore/rekor/issues/1566, updates the generated Sigstore bundle to include the inclusion proof returned from Rekor.