### PR TITLE
Fix bug w/ threshold verification options

### DIFF
--- a/.changeset/dull-cougars-prove.md
+++ b/.changeset/dull-cougars-prove.md
@@ -1,0 +1,5 @@
+---
+'sigstore': patch
+---
+
+Fix bug when setting `tlogThreshold`/`ctLogThreshold` verification options to 0

--- a/packages/client/src/__tests__/config.test.ts
+++ b/packages/client/src/__tests__/config.test.ts
@@ -107,17 +107,17 @@ describe('artifactVerificationOptions', () => {
         '1.2.3.4': 'value1',
         '5.6.7.8': 'value2',
       },
-      ctLogThreshold: 2,
-      tlogThreshold: 3,
+      ctLogThreshold: 0,
+      tlogThreshold: 0,
     };
 
     it('returns the expected options', () => {
       const result = artifactVerificationOptions(options);
-      expect(result.ctlogOptions.disable).toBe(false);
-      expect(result.ctlogOptions.threshold).toBe(2);
+      expect(result.ctlogOptions.disable).toBe(true);
+      expect(result.ctlogOptions.threshold).toBe(0);
       expect(result.ctlogOptions.detachedSct).toBe(false);
-      expect(result.tlogOptions.disable).toBe(false);
-      expect(result.tlogOptions.threshold).toBe(3);
+      expect(result.tlogOptions.disable).toBe(true);
+      expect(result.tlogOptions.threshold).toBe(0);
       expect(result.tlogOptions.performOnlineVerification).toBe(false);
       expect(result.signers).toBeDefined();
 

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -157,13 +157,13 @@ export function artifactVerificationOptions(
   // Construct the artifact verification options w/ defaults
   return {
     ctlogOptions: {
-      disable: false,
-      threshold: options.ctLogThreshold || 1,
+      disable: options.ctLogThreshold === 0,
+      threshold: options.ctLogThreshold ?? 1,
       detachedSct: false,
     },
     tlogOptions: {
-      disable: false,
-      threshold: options.tlogThreshold || 1,
+      disable: options.tlogThreshold === 0,
+      threshold: options.tlogThreshold ?? 1,
       performOnlineVerification: false,
     },
     signers,


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fix bug with default values for the `ctLogThreshold` and `tlogThreshold` verification options. Due to the way the defaults were being applied, it was impossible to specify `0` as a threshold value (it would get overridden with the default value `1`).