### PR TITLE
use 'dsse' as the default rekor type when signing

### DIFF
--- a/.changeset/blue-weeks-hope.md
+++ b/.changeset/blue-weeks-hope.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/sign': minor
+---
+
+Use `dsse` as the default Rekor entry type (instead of `intoto`) when submitting DSSE payloads

--- a/packages/sign/src/__tests__/integration.test.ts
+++ b/packages/sign/src/__tests__/integration.test.ts
@@ -90,7 +90,7 @@ describe('artifact signing', () => {
 
       expect(bundle.verificationMaterial.tlogEntries).toHaveLength(1);
       expect(bundle.verificationMaterial.tlogEntries[0].kindVersion.kind).toBe(
-        'intoto'
+        'dsse'
       );
 
       expect(

--- a/packages/sign/src/__tests__/witness/tlog/entry.test.ts
+++ b/packages/sign/src/__tests__/witness/tlog/entry.test.ts
@@ -13,12 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { envelopeToJSON } from '@sigstore/bundle';
 import { HashAlgorithm } from '@sigstore/protobuf-specs';
 import assert from 'assert';
-import { crypto, encoding as enc } from '../../../util';
+import { encoding as enc } from '../../../util';
 import { toProposedEntry } from '../../../witness/tlog/entry';
 
+import { envelopeToJSON } from '@sigstore/bundle';
 import type { SignatureBundle } from '../../../witness';
 
 describe('toProposedEntry', () => {
@@ -61,176 +61,30 @@ describe('toProposedEntry', () => {
   });
 
   describe('when a DSSE envelope is provided', () => {
-    describe('when the keyid is a non-empty string', () => {
-      const sigBundle: SignatureBundle = {
-        $case: 'dsseEnvelope',
-        dsseEnvelope: {
-          signatures: [{ keyid: '123', sig: signature }],
-          payloadType: 'application/vnd.in-toto+json',
-          payload: Buffer.from('payload'),
-        },
-      };
+    const sigBundle: SignatureBundle = {
+      $case: 'dsseEnvelope',
+      dsseEnvelope: {
+        signatures: [{ keyid: '123', sig: signature }],
+        payloadType: 'application/vnd.in-toto+json',
+        payload: Buffer.from('payload'),
+      },
+    };
 
-      it('return a valid ProposedEntry entry', () => {
-        const entry = toProposedEntry(sigBundle, publicKey);
+    it('return a valid ProposedEntry entry', () => {
+      const entry = toProposedEntry(sigBundle, publicKey);
 
-        assert(entry.apiVersion === '0.0.2');
-        assert(entry.kind === 'intoto');
-        expect(entry.spec).toBeTruthy();
-        expect(entry.spec.content).toBeTruthy();
-        expect(entry.spec.content.envelope).toBeTruthy();
+      assert(entry.apiVersion === '0.0.1');
+      assert(entry.kind === 'dsse');
+      expect(entry.spec).toBeTruthy();
+      expect(entry.spec.proposedContent).toBeTruthy();
 
-        const e = entry.spec.content.envelope;
-        expect(e?.payloadType).toEqual(sigBundle.dsseEnvelope.payloadType);
-        expect(e?.payload).toEqual(
-          enc.base64Encode(sigBundle.dsseEnvelope.payload.toString('base64'))
-        );
-        expect(e?.signatures).toHaveLength(1);
-        expect(e?.signatures[0].keyid).toEqual(
-          sigBundle.dsseEnvelope.signatures[0].keyid
-        );
-        expect(e?.signatures[0].sig).toEqual(
-          enc.base64Encode(
-            sigBundle.dsseEnvelope.signatures[0].sig.toString('base64')
-          )
-        );
-        expect(e?.signatures[0].publicKey).toEqual(enc.base64Encode(publicKey));
+      const e = entry.spec.proposedContent?.envelope;
+      expect(e).toEqual(JSON.stringify(envelopeToJSON(sigBundle.dsseEnvelope)));
 
-        expect(entry.spec.content.payloadHash).toBeTruthy();
-        expect(entry.spec.content.payloadHash?.algorithm).toBe('sha256');
-        expect(entry.spec.content.payloadHash?.value).toBe(
-          crypto.hash(sigBundle.dsseEnvelope.payload).toString('hex')
-        );
-        expect(entry.spec.content.hash).toBeTruthy();
-        expect(entry.spec.content.hash?.algorithm).toBe('sha256');
-
-        // This hard-coded hash value helps us detect if we've unintentionally
-        // changed the hashing algorithm.
-        expect(entry.spec.content.hash?.value).toBe(
-          '37d47ab456ca63a84f6457be655dd49799542f2e1db5d05160b214fb0b9a7f55'
-        );
-      });
-    });
-
-    describe('when the keyid is an empty string', () => {
-      const sigBundle: SignatureBundle = {
-        $case: 'dsseEnvelope',
-        dsseEnvelope: {
-          signatures: [{ keyid: '', sig: signature }],
-          payloadType: 'application/vnd.in-toto+json',
-          payload: Buffer.from('payload'),
-        },
-      };
-
-      it('return a valid ProposedEntry entry', () => {
-        const entry = toProposedEntry(sigBundle, publicKey);
-
-        assert(entry.apiVersion === '0.0.2');
-        assert(entry.kind === 'intoto');
-        expect(entry.spec).toBeTruthy();
-        expect(entry.spec.content).toBeTruthy();
-        expect(entry.spec.content.envelope).toBeTruthy();
-
-        const e = entry.spec.content.envelope;
-        expect(e?.payloadType).toEqual(sigBundle.dsseEnvelope.payloadType);
-        expect(e?.payload).toEqual(
-          enc.base64Encode(sigBundle.dsseEnvelope.payload.toString('base64'))
-        );
-        expect(e?.signatures).toHaveLength(1);
-        expect(e?.signatures[0].keyid).toBeUndefined();
-        expect(e?.signatures[0].sig).toEqual(
-          enc.base64Encode(
-            sigBundle.dsseEnvelope.signatures[0].sig.toString('base64')
-          )
-        );
-        expect(e?.signatures[0].publicKey).toEqual(enc.base64Encode(publicKey));
-
-        expect(entry.spec.content.payloadHash).toBeTruthy();
-        expect(entry.spec.content.payloadHash?.algorithm).toBe('sha256');
-        expect(entry.spec.content.payloadHash?.value).toBe(
-          crypto.hash(sigBundle.dsseEnvelope.payload).toString('hex')
-        );
-        expect(entry.spec.content.hash).toBeTruthy();
-        expect(entry.spec.content.hash?.algorithm).toBe('sha256');
-
-        // This hard-coded hash value helps us detect if we've unintentionally
-        // changed the hashing algorithm.
-        expect(entry.spec.content.hash?.value).toBe(
-          'f39ab279af9d9be421342ce4c8e5c422b5bc3dd20602703b1893283a934fbe72'
-        );
-      });
-    });
-
-    describe('when there are multiple signatures in the envelope', () => {
-      const sigBundle: SignatureBundle = {
-        $case: 'dsseEnvelope',
-        dsseEnvelope: {
-          signatures: [
-            { keyid: '123', sig: signature },
-            { keyid: '', sig: signature },
-          ],
-          payloadType: 'application/vnd.in-toto+json',
-          payload: Buffer.from('payload'),
-        },
-      };
-
-      it('return a valid ProposedEntry entry', () => {
-        const entry = toProposedEntry(sigBundle, publicKey);
-
-        assert(entry.apiVersion === '0.0.2');
-        assert(entry.kind === 'intoto');
-
-        // Check to ensure only the first signature is included in the envelope
-        const e = entry.spec.content.envelope;
-        expect(e?.signatures).toHaveLength(1);
-        expect(e?.signatures[0].keyid).toEqual(
-          sigBundle.dsseEnvelope.signatures[0].keyid
-        );
-        expect(e?.signatures[0].sig).toEqual(
-          enc.base64Encode(
-            sigBundle.dsseEnvelope.signatures[0].sig.toString('base64')
-          )
-        );
-        expect(e?.signatures[0].publicKey).toEqual(enc.base64Encode(publicKey));
-
-        // This hard-coded hash value helps us detect if we've unintentionally
-        // changed the hashing algorithm.
-        expect(entry.spec.content.hash?.value).toBe(
-          '37d47ab456ca63a84f6457be655dd49799542f2e1db5d05160b214fb0b9a7f55'
-        );
-      });
-    });
-  });
-
-  describe('when a DSSE envelope is provided', () => {
-    describe('when the keyid is a non-empty string', () => {
-      const sigBundle: SignatureBundle = {
-        $case: 'dsseEnvelope',
-        dsseEnvelope: {
-          signatures: [{ keyid: '123', sig: signature }],
-          payloadType: 'application/vnd.in-toto+json',
-          payload: Buffer.from('payload'),
-        },
-      };
-
-      it('return a valid ProposedEntry entry', () => {
-        const entry = toProposedEntry(sigBundle, publicKey, 'dsse');
-
-        assert(entry.apiVersion === '0.0.1');
-        assert(entry.kind === 'dsse');
-        expect(entry.spec).toBeTruthy();
-        expect(entry.spec.proposedContent).toBeTruthy();
-
-        const e = entry.spec.proposedContent?.envelope;
-        expect(e).toEqual(
-          JSON.stringify(envelopeToJSON(sigBundle.dsseEnvelope))
-        );
-
-        expect(entry.spec.proposedContent?.verifiers).toHaveLength(1);
-        expect(entry.spec.proposedContent?.verifiers[0]).toEqual(
-          enc.base64Encode(publicKey)
-        );
-      });
+      expect(entry.spec.proposedContent?.verifiers).toHaveLength(1);
+      expect(entry.spec.proposedContent?.verifiers[0]).toEqual(
+        enc.base64Encode(publicKey)
+      );
     });
   });
 });

--- a/packages/sign/src/witness/tlog/entry.ts
+++ b/packages/sign/src/witness/tlog/entry.ts
@@ -14,29 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { Envelope, MessageSignature, envelopeToJSON } from '@sigstore/bundle';
-import { crypto, encoding as enc, json } from '../../util';
+import { encoding as enc } from '../../util';
 
 import type {
   ProposedDSSEEntry,
   ProposedEntry,
   ProposedHashedRekordEntry,
-  ProposedIntotoEntry,
 } from '../../external/rekor';
 import type { SignatureBundle } from '../witness';
 
 export function toProposedEntry(
   content: SignatureBundle,
-  publicKey: string,
-  // TODO: Remove this parameter once have completely switched to 'dsse' entries
-  entryType: 'dsse' | 'intoto' = 'intoto'
+  publicKey: string
 ): ProposedEntry {
   switch (content.$case) {
     case 'dsseEnvelope':
-      // TODO: Remove this conditional once have completely switched to 'dsse' entries
-      if (entryType === 'dsse') {
-        return toProposedDSSEEntry(content.dsseEnvelope, publicKey);
-      }
-      return toProposedIntotoEntry(content.dsseEnvelope, publicKey);
+      return toProposedDSSEEntry(content.dsseEnvelope, publicKey);
     case 'messageSignature':
       return toProposedHashedRekordEntry(content.messageSignature, publicKey);
   }
@@ -91,76 +84,4 @@ function toProposedDSSEEntry(
       },
     },
   };
-}
-
-// Returns a properly formatted Rekor "intoto" entry for the given DSSE
-// envelope and signature
-function toProposedIntotoEntry(
-  envelope: Envelope,
-  publicKey: string
-): ProposedIntotoEntry {
-  // Calculate the value for the payloadHash field in the Rekor entry
-  const payloadHash = crypto.hash(envelope.payload).toString('hex');
-
-  // Calculate the value for the hash field in the Rekor entry
-  const envelopeHash = calculateDSSEHash(envelope, publicKey);
-
-  // Collect values for re-creating the DSSE envelope.
-  // Double-encode payload and signature cause that's what Rekor expects
-  const payload = enc.base64Encode(envelope.payload.toString('base64'));
-  const sig = enc.base64Encode(envelope.signatures[0].sig.toString('base64'));
-  const keyid = envelope.signatures[0].keyid;
-  const encodedKey = enc.base64Encode(publicKey);
-
-  // Create the envelope portion of the entry. Note the inclusion of the
-  // publicKey in the signature struct is not a standard part of a DSSE
-  // envelope, but is required by Rekor.
-  const dsse: ProposedIntotoEntry['spec']['content']['envelope'] = {
-    payloadType: envelope.payloadType,
-    payload: payload,
-    signatures: [{ sig, publicKey: encodedKey }],
-  };
-
-  // If the keyid is an empty string, Rekor seems to remove it altogether. We
-  // need to do the same here so that we can properly recreate the entry for
-  // verification.
-  if (keyid.length > 0) {
-    dsse.signatures[0].keyid = keyid;
-  }
-
-  return {
-    apiVersion: '0.0.2',
-    kind: 'intoto',
-    spec: {
-      content: {
-        envelope: dsse,
-        hash: { algorithm: 'sha256', value: envelopeHash },
-        payloadHash: { algorithm: 'sha256', value: payloadHash },
-      },
-    },
-  };
-}
-
-// Calculates the hash of a DSSE envelope for inclusion in a Rekor entry.
-// There is no standard way to do this, so the scheme we're using as as
-// follows:
-//  * payload is base64 encoded
-//  * signature is base64 encoded (only the first signature is used)
-//  * keyid is included ONLY if it is NOT an empty string
-//  * The resulting JSON is canonicalized and hashed to a hex string
-function calculateDSSEHash(envelope: Envelope, publicKey: string): string {
-  const dsse: ProposedIntotoEntry['spec']['content']['envelope'] = {
-    payloadType: envelope.payloadType,
-    payload: envelope.payload.toString('base64'),
-    signatures: [
-      { sig: envelope.signatures[0].sig.toString('base64'), publicKey },
-    ],
-  };
-
-  // If the keyid is an empty string, Rekor seems to remove it altogether.
-  if (envelope.signatures[0].keyid.length > 0) {
-    dsse.signatures[0].keyid = envelope.signatures[0].keyid;
-  }
-
-  return crypto.hash(json.canonicalize(dsse)).toString('hex');
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->
Fixes #526 
Replaces https://github.com/sigstore/sigstore-js/pull/552

#### Summary
Updates `@sigstore/sign` to use "dsse" as the default Rekor type when submitting DSSE-wrapped payloads. This replaces the current "intoto" type currently in use.

NOTE: Do not merge until the necessary support has been added to the rest of the stack accepting npm provenance statements.