### PR TITLE
remove extra dependency in mock pkg

### DIFF
--- a/.changeset/fluffy-squids-report.md
+++ b/.changeset/fluffy-squids-report.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/mock': minor
+---
+
+Remove extraneous `@tufjs/repo-mock` dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -3022,23 +3022,23 @@
       "dev": true
     },
     "node_modules/@tufjs/canonical-json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-1.0.0.tgz",
-      "integrity": "sha512-QTnf++uxunWvG2z3UFNzAoQPHxnSXOwtaI3iJ+AohhV+5vONuArPjJE7aPXPVXfXJsqrVbZBu9b81AJoSd09IQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
+      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@tufjs/models": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-1.0.4.tgz",
-      "integrity": "sha512-qaGV9ltJP0EO25YfFUPhxRVK0evXFIAGicsVXuRim4Ed9cjPxYhNnNJ49SFmbeLgtxpslIkX317IgpfcHPVj/A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-2.0.0.tgz",
+      "integrity": "sha512-c8nj8BaOExmZKO2DXhDfegyhSGcG9E/mPN3U13L+/PsoWm1uaGiHHjxqSHQiasDBQwDA3aHuw9+9spYAP1qvvg==",
       "dependencies": {
-        "@tufjs/canonical-json": "1.0.0",
-        "minimatch": "^9.0.0"
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^9.0.3"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@tufjs/models/node_modules/brace-expansion": {
@@ -3073,48 +3073,6 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@tufjs/repo-mock/node_modules/@tufjs/canonical-json": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
-      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@tufjs/repo-mock/node_modules/@tufjs/models": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-2.0.0.tgz",
-      "integrity": "sha512-c8nj8BaOExmZKO2DXhDfegyhSGcG9E/mPN3U13L+/PsoWm1uaGiHHjxqSHQiasDBQwDA3aHuw9+9spYAP1qvvg==",
-      "dependencies": {
-        "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.3"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@tufjs/repo-mock/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@tufjs/repo-mock/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@types/babel__core": {
@@ -3343,9 +3301,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
-      "integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q=="
+      "version": "20.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
+      "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.3",
@@ -12771,9 +12729,9 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsyringe": {
       "version": "4.7.0",
@@ -12830,48 +12788,6 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/tuf-js/node_modules/@tufjs/canonical-json": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
-      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/tuf-js/node_modules/@tufjs/models": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-2.0.0.tgz",
-      "integrity": "sha512-c8nj8BaOExmZKO2DXhDfegyhSGcG9E/mPN3U13L+/PsoWm1uaGiHHjxqSHQiasDBQwDA3aHuw9+9spYAP1qvvg==",
-      "dependencies": {
-        "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.3"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/tuf-js/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/tuf-js/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/tunnel-agent": {
@@ -13597,7 +13513,7 @@
     },
     "packages/bundle": {
       "name": "@sigstore/bundle",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.2.1"
@@ -13608,7 +13524,7 @@
     },
     "packages/cli": {
       "name": "@sigstore/cli",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/color": "^1.0.10",
@@ -13616,7 +13532,7 @@
         "@oclif/plugin-help": "^5",
         "open": "^8.4.2",
         "openid-client": "^5.4.3",
-        "sigstore": "^1.9.0"
+        "sigstore": "^2.0.0"
       },
       "bin": {
         "sigstore": "bin/run"
@@ -13632,18 +13548,18 @@
     },
     "packages/client": {
       "name": "sigstore",
-      "version": "1.9.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^1.1.0",
+        "@sigstore/bundle": "^2.0.0",
         "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/sign": "^1.0.0",
-        "@sigstore/tuf": "^1.0.3"
+        "@sigstore/sign": "^2.0.0",
+        "@sigstore/tuf": "^2.0.0"
       },
       "devDependencies": {
         "@sigstore/jest": "^0.0.0",
-        "@sigstore/mock": "^0.2.0",
-        "@sigstore/rekor-types": "^1.0.0",
+        "@sigstore/mock": "^0.3.0",
+        "@sigstore/rekor-types": "^2.0.0",
         "@tufjs/repo-mock": "^2.0.0",
         "@types/make-fetch-happen": "^10.0.0"
       },
@@ -13653,10 +13569,10 @@
     },
     "packages/conformance": {
       "name": "@sigstore/conformance",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@oclif/core": "^2",
-        "sigstore": "^1.7.0"
+        "sigstore": "^2.0.0"
       },
       "bin": {
         "sigstore": "bin/run"
@@ -13687,13 +13603,12 @@
     },
     "packages/mock": {
       "name": "@sigstore/mock",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.3",
         "@peculiar/x509": "^1.9.3",
         "@sigstore/protobuf-specs": "^0.2.1",
-        "@tufjs/repo-mock": "^2.0.0",
         "asn1js": "^3.0.5",
         "bytestreamjs": "^2.0.1",
         "canonicalize": "^2.0.0",
@@ -13703,7 +13618,7 @@
         "pvutils": "^1.1.3"
       },
       "devDependencies": {
-        "@sigstore/rekor-types": "^0.0.3",
+        "@sigstore/rekor-types": "^2.0.0",
         "make-fetch-happen": "^13.0.0"
       },
       "engines": {
@@ -13712,11 +13627,11 @@
     },
     "packages/mock-server": {
       "name": "@sigstore/mock-server",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@oclif/color": "^1.0.10",
         "@oclif/core": "^2",
-        "@sigstore/mock": "^0.2.0",
+        "@sigstore/mock": "^0.3.0",
         "@tufjs/repo-mock": "^2.0.0",
         "express": "4.18.2"
       },
@@ -13730,15 +13645,6 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "packages/mock/node_modules/@sigstore/rekor-types": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@sigstore/rekor-types/-/rekor-types-0.0.3.tgz",
-      "integrity": "sha512-yCPe8wpQOfDNXDxhMGEhcvezJGHyEwZNeBVNa3W7xZ1Jweo/m4oAef6UK8gYowAQEafLZ0LaWUxrsVUp+ljrPg==",
-      "dev": true,
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "packages/oauth": {
@@ -13762,7 +13668,7 @@
     },
     "packages/rekor-types": {
       "name": "@sigstore/rekor-types",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "json-schema-to-typescript": "^13.0.2",
@@ -13798,17 +13704,17 @@
     },
     "packages/sign": {
       "name": "@sigstore/sign",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^1.1.0",
+        "@sigstore/bundle": "^2.0.0",
         "@sigstore/protobuf-specs": "^0.2.1",
         "make-fetch-happen": "^13.0.0"
       },
       "devDependencies": {
         "@sigstore/jest": "^0.0.0",
-        "@sigstore/mock": "^0.2.0",
-        "@sigstore/rekor-types": "^1.0.0",
+        "@sigstore/mock": "^0.3.0",
+        "@sigstore/rekor-types": "^2.0.0",
         "@types/make-fetch-happen": "^10.0.0"
       },
       "engines": {
@@ -13817,7 +13723,7 @@
     },
     "packages/tuf": {
       "name": "@sigstore/tuf",
-      "version": "1.0.3",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.2.1",
@@ -16105,7 +16011,7 @@
         "oclif": "^3",
         "open": "^8.4.2",
         "openid-client": "^5.4.3",
-        "sigstore": "^1.9.0",
+        "sigstore": "^2.0.0",
         "tslib": "^2.6.1"
       }
     },
@@ -16114,7 +16020,7 @@
       "requires": {
         "@oclif/core": "^2",
         "oclif": "^3",
-        "sigstore": "^1.7.0",
+        "sigstore": "^2.0.0",
         "tslib": "^2.6.1"
       }
     },
@@ -16130,8 +16036,7 @@
         "@peculiar/webcrypto": "^1.4.3",
         "@peculiar/x509": "^1.9.3",
         "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/rekor-types": "^0.0.3",
-        "@tufjs/repo-mock": "^2.0.0",
+        "@sigstore/rekor-types": "^2.0.0",
         "asn1js": "^3.0.5",
         "bytestreamjs": "^2.0.1",
         "canonicalize": "^2.0.0",
@@ -16140,14 +16045,6 @@
         "nock": "^13.3.3",
         "pkijs": "^3.0.15",
         "pvutils": "^1.1.3"
-      },
-      "dependencies": {
-        "@sigstore/rekor-types": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/@sigstore/rekor-types/-/rekor-types-0.0.3.tgz",
-          "integrity": "sha512-yCPe8wpQOfDNXDxhMGEhcvezJGHyEwZNeBVNa3W7xZ1Jweo/m4oAef6UK8gYowAQEafLZ0LaWUxrsVUp+ljrPg==",
-          "dev": true
-        }
       }
     },
     "@sigstore/mock-server": {
@@ -16155,7 +16052,7 @@
       "requires": {
         "@oclif/color": "^1.0.10",
         "@oclif/core": "^2",
-        "@sigstore/mock": "^0.2.0",
+        "@sigstore/mock": "^0.3.0",
         "@tufjs/repo-mock": "^2.0.0",
         "@types/express": "^4.17.17",
         "express": "4.18.2",
@@ -16178,11 +16075,11 @@
     "@sigstore/sign": {
       "version": "file:packages/sign",
       "requires": {
-        "@sigstore/bundle": "^1.1.0",
+        "@sigstore/bundle": "^2.0.0",
         "@sigstore/jest": "^0.0.0",
-        "@sigstore/mock": "^0.2.0",
+        "@sigstore/mock": "^0.3.0",
         "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/rekor-types": "^1.0.0",
+        "@sigstore/rekor-types": "^2.0.0",
         "@types/make-fetch-happen": "^10.0.0",
         "make-fetch-happen": "^13.0.0"
       }
@@ -16265,17 +16162,17 @@
       "dev": true
     },
     "@tufjs/canonical-json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-1.0.0.tgz",
-      "integrity": "sha512-QTnf++uxunWvG2z3UFNzAoQPHxnSXOwtaI3iJ+AohhV+5vONuArPjJE7aPXPVXfXJsqrVbZBu9b81AJoSd09IQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
+      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA=="
     },
     "@tufjs/models": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-1.0.4.tgz",
-      "integrity": "sha512-qaGV9ltJP0EO25YfFUPhxRVK0evXFIAGicsVXuRim4Ed9cjPxYhNnNJ49SFmbeLgtxpslIkX317IgpfcHPVj/A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-2.0.0.tgz",
+      "integrity": "sha512-c8nj8BaOExmZKO2DXhDfegyhSGcG9E/mPN3U13L+/PsoWm1uaGiHHjxqSHQiasDBQwDA3aHuw9+9spYAP1qvvg==",
       "requires": {
-        "@tufjs/canonical-json": "1.0.0",
-        "minimatch": "^9.0.0"
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^9.0.3"
       },
       "dependencies": {
         "brace-expansion": {
@@ -16303,38 +16200,6 @@
       "requires": {
         "@tufjs/models": "2.0.0",
         "nock": "^13.3.3"
-      },
-      "dependencies": {
-        "@tufjs/canonical-json": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
-          "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA=="
-        },
-        "@tufjs/models": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-2.0.0.tgz",
-          "integrity": "sha512-c8nj8BaOExmZKO2DXhDfegyhSGcG9E/mPN3U13L+/PsoWm1uaGiHHjxqSHQiasDBQwDA3aHuw9+9spYAP1qvvg==",
-          "requires": {
-            "@tufjs/canonical-json": "2.0.0",
-            "minimatch": "^9.0.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
       }
     },
     "@types/babel__core": {
@@ -16554,9 +16419,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
-      "integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q=="
+      "version": "20.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
+      "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg=="
     },
     "@types/node-fetch": {
       "version": "2.6.3",
@@ -22616,13 +22481,13 @@
     "sigstore": {
       "version": "file:packages/client",
       "requires": {
-        "@sigstore/bundle": "^1.1.0",
+        "@sigstore/bundle": "^2.0.0",
         "@sigstore/jest": "^0.0.0",
-        "@sigstore/mock": "^0.2.0",
+        "@sigstore/mock": "^0.3.0",
         "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/rekor-types": "^1.0.0",
-        "@sigstore/sign": "^1.0.0",
-        "@sigstore/tuf": "^1.0.3",
+        "@sigstore/rekor-types": "^2.0.0",
+        "@sigstore/sign": "^2.0.0",
+        "@sigstore/tuf": "^2.0.0",
         "@tufjs/repo-mock": "^2.0.0",
         "@types/make-fetch-happen": "^10.0.0"
       }
@@ -23267,9 +23132,9 @@
       }
     },
     "tslib": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tsyringe": {
       "version": "4.7.0",
@@ -23313,38 +23178,6 @@
         "@tufjs/models": "2.0.0",
         "debug": "^4.3.4",
         "make-fetch-happen": "^13.0.0"
-      },
-      "dependencies": {
-        "@tufjs/canonical-json": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
-          "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA=="
-        },
-        "@tufjs/models": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-2.0.0.tgz",
-          "integrity": "sha512-c8nj8BaOExmZKO2DXhDfegyhSGcG9E/mPN3U13L+/PsoWm1uaGiHHjxqSHQiasDBQwDA3aHuw9+9spYAP1qvvg==",
-          "requires": {
-            "@tufjs/canonical-json": "2.0.0",
-            "minimatch": "^9.0.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
       }
     },
     "tunnel-agent": {

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -33,7 +33,6 @@
     "@peculiar/webcrypto": "^1.4.3",
     "@peculiar/x509": "^1.9.3",
     "@sigstore/protobuf-specs": "^0.2.1",
-    "@tufjs/repo-mock": "^2.0.0",
     "asn1js": "^3.0.5",
     "bytestreamjs": "^2.0.1",
     "canonicalize": "^2.0.0",


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Removes an extraneous dependency from the `mock` package.