### PR TITLE
better error handling for invalid OIDC token

### DIFF
--- a/.changeset/fair-toys-build.md
+++ b/.changeset/fair-toys-build.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/sign': patch
+---
+
+Better error handling when an invalid OIDC token is encountered

--- a/packages/sign/src/__tests__/signer/fulcio/index.test.ts
+++ b/packages/sign/src/__tests__/signer/fulcio/index.test.ts
@@ -88,6 +88,24 @@ describe('KeylessSigner', () => {
       });
     });
 
+    describe('when the identity provider returns an invalid token', () => {
+      const errorProvider: IdentityProvider = {
+        getToken: jest.fn().mockResolvedValue(''),
+      };
+
+      const subject = new FulcioSigner({
+        ...options,
+        identityProvider: errorProvider,
+      });
+
+      it('throws an error', async () => {
+        await expect(subject.sign(payload)).rejects.toThrowWithCode(
+          InternalError,
+          'IDENTITY_TOKEN_PARSE_ERROR'
+        );
+      });
+    });
+
     describe('when the child signer returns an invalid key', () => {
       const keyHolder: Signer = {
         sign: () =>

--- a/packages/sign/src/error.ts
+++ b/packages/sign/src/error.ts
@@ -19,7 +19,8 @@ type InternalErrorCode =
   | 'TLOG_CREATE_ENTRY_ERROR'
   | 'CA_CREATE_SIGNING_CERTIFICATE_ERROR'
   | 'TSA_CREATE_TIMESTAMP_ERROR'
-  | 'IDENTITY_TOKEN_READ_ERROR';
+  | 'IDENTITY_TOKEN_READ_ERROR'
+  | 'IDENTITY_TOKEN_PARSE_ERROR';
 
 export class InternalError extends Error {
   code: InternalErrorCode;

--- a/packages/sign/src/signer/fulcio/index.ts
+++ b/packages/sign/src/signer/fulcio/index.ts
@@ -46,7 +46,16 @@ export class FulcioSigner implements Signer {
     const identityToken = await this.getIdentityToken();
 
     // Extract challenge claim from OIDC token
-    const subject = oidc.extractJWTSubject(identityToken);
+    let subject: string;
+    try {
+      subject = oidc.extractJWTSubject(identityToken);
+    } catch (err) {
+      throw new InternalError({
+        code: 'IDENTITY_TOKEN_PARSE_ERROR',
+        message: `invalid identity token: ${identityToken}`,
+        cause: err,
+      });
+    }
 
     // Construct challenge value by signing the subject claim
     const challenge = await this.keyHolder.sign(Buffer.from(subject));


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
See #700 

Improves the error handling in scenarios where the OIDC token used for Fulcio signing is malformed.
