### PR TITLE
surface error msgs from sigstore services

### DIFF
--- a/.changeset/shaggy-rocks-fly.md
+++ b/.changeset/shaggy-rocks-fly.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/sign': minor
+---
+
+Surface error messages returned from Sigstore services in thrown errors

--- a/packages/sign/src/__tests__/error.test.ts
+++ b/packages/sign/src/__tests__/error.test.ts
@@ -1,0 +1,43 @@
+import assert from 'assert';
+import { internalError, InternalError } from '../error';
+import { HTTPError } from '../external/error';
+
+describe('internalError', () => {
+  const code = 'IDENTITY_TOKEN_READ_ERROR';
+
+  describe('when err is an Error', () => {
+    const err = new Error('oops');
+    const msg = 'test error';
+
+    it('throws an InternalError', () => {
+      expect.assertions(4);
+      try {
+        internalError(err, code, msg);
+      } catch (e) {
+        assert(e instanceof InternalError);
+        expect(e.message).toEqual(msg);
+        expect(e.code).toEqual(code);
+        expect(e.cause).toEqual(err);
+        expect(e.name).toEqual('InternalError');
+      }
+    });
+  });
+
+  describe('when err is an HTTPError', () => {
+    const err = new HTTPError({ status: 404, message: 'oops' });
+    const msg = 'test error';
+
+    it('throws an InternalError', () => {
+      expect.assertions(4);
+      try {
+        internalError(err, code, msg);
+      } catch (e) {
+        assert(e instanceof InternalError);
+        expect(e.message).toEqual(`${msg} - ${err.message}`);
+        expect(e.code).toEqual(code);
+        expect(e.cause).toEqual(err);
+        expect(e.name).toEqual('InternalError');
+      }
+    });
+  });
+});

--- a/packages/sign/src/__tests__/external/error.test.ts
+++ b/packages/sign/src/__tests__/external/error.test.ts
@@ -28,8 +28,8 @@ describe('checkStatus', () => {
       ok: true,
     });
 
-    it('returns the response', () => {
-      expect(checkStatus(response)).toEqual<Response>(response);
+    it('returns the response', async () => {
+      await expect(checkStatus(response)).resolves.toEqual<Response>(response);
     });
   });
 
@@ -40,13 +40,13 @@ describe('checkStatus', () => {
       ok: false,
     });
 
-    it('throws an error', () => {
+    it('throws an error', async () => {
       expect.assertions(2);
       try {
-        checkStatus(response);
+        await checkStatus(response);
       } catch (e) {
         assert(e instanceof HTTPError);
-        expect(e.message).toEqual('HTTP Error: 404 Not Found');
+        expect(e.message).toEqual('(404) Not Found');
         expect(e.statusCode).toEqual(404);
       }
     });

--- a/packages/sign/src/__tests__/external/fulcio.test.ts
+++ b/packages/sign/src/__tests__/external/fulcio.test.ts
@@ -83,7 +83,7 @@ describe('Fulcio', () => {
       it('returns an error', async () => {
         await expect(
           subject.createSigningCertificate(certRequest)
-        ).rejects.toThrow('HTTP Error: 400 Bad Request');
+        ).rejects.toThrow('(400) Invalid certificate request');
       });
     });
   });

--- a/packages/sign/src/__tests__/external/rekor.test.ts
+++ b/packages/sign/src/__tests__/external/rekor.test.ts
@@ -99,7 +99,7 @@ describe('Rekor', () => {
 
       it('returns an error', async () => {
         await expect(subject.createEntry(proposedEntry)).rejects.toThrow(
-          'HTTP Error: 409 Conflict'
+          '(409) An equivalent entry already exists'
         );
       });
     });
@@ -153,7 +153,7 @@ describe('Rekor', () => {
 
       it('returns an error', async () => {
         await expect(subject.getEntry('foo')).rejects.toThrow(
-          'HTTP Error: 404 Not Found'
+          '(404) Entry not found'
         );
       });
     });
@@ -229,7 +229,7 @@ describe('Rekor', () => {
 
       it('returns an error', async () => {
         await expect(subject.getEntry('foo')).rejects.toThrow(
-          'HTTP Error: 422 Unprocessable Entity'
+          '(422) Invalid query'
         );
       });
     });

--- a/packages/sign/src/__tests__/external/tsa.test.ts
+++ b/packages/sign/src/__tests__/external/tsa.test.ts
@@ -59,7 +59,7 @@ describe('TimestampAuthority', () => {
 
       it('returns an error', async () => {
         await expect(subject.createTimestamp(timestampRequest)).rejects.toThrow(
-          'HTTP Error: 400 Bad Request'
+          '(400) Error generating timestamp response'
         );
       });
     });

--- a/packages/sign/src/error.ts
+++ b/packages/sign/src/error.ts
@@ -13,6 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+import { HTTPError } from './external/error';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type InternalErrorCode =
   | 'TLOG_FETCH_ENTRY_ERROR'
@@ -40,4 +43,20 @@ export class InternalError extends Error {
     this.cause = cause;
     this.code = code;
   }
+}
+
+export function internalError(
+  err: unknown,
+  code: InternalErrorCode,
+  message: string
+): never {
+  if (err instanceof HTTPError) {
+    message += ` - ${err.message}`;
+  }
+
+  throw new InternalError({
+    code: code,
+    message: message,
+    cause: err,
+  });
 }

--- a/packages/sign/src/external/fulcio.ts
+++ b/packages/sign/src/external/fulcio.ts
@@ -76,7 +76,7 @@ export class Fulcio {
       method: 'POST',
       body: JSON.stringify(request),
     });
-    checkStatus(response);
+    await checkStatus(response);
 
     const data = await response.json();
     return data;

--- a/packages/sign/src/external/rekor.ts
+++ b/packages/sign/src/external/rekor.ts
@@ -84,7 +84,7 @@ export class Rekor {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(propsedEntry),
     });
-    checkStatus(response);
+    await checkStatus(response);
 
     const data = await response.json();
     return entryFromResponse(data);
@@ -99,7 +99,7 @@ export class Rekor {
     const url = `${this.baseUrl}/api/v1/log/entries/${uuid}`;
 
     const response = await this.fetch(url);
-    checkStatus(response);
+    await checkStatus(response);
 
     const data: LogEntry = await response.json();
     return entryFromResponse(data);
@@ -118,7 +118,7 @@ export class Rekor {
       body: JSON.stringify(opts),
       headers: { 'Content-Type': 'application/json' },
     });
-    checkStatus(response);
+    await checkStatus(response);
 
     const data = await response.json();
     return data;
@@ -137,7 +137,7 @@ export class Rekor {
       body: JSON.stringify(opts),
       headers: { 'Content-Type': 'application/json' },
     });
-    checkStatus(response);
+    await checkStatus(response);
 
     const rawData: LogEntry[] = await response.json();
     const data = rawData.map((d) => entryFromResponse(d));

--- a/packages/sign/src/external/tsa.ts
+++ b/packages/sign/src/external/tsa.ts
@@ -54,7 +54,7 @@ export class TimestampAuthority {
       method: 'POST',
       body: JSON.stringify(request),
     });
-    checkStatus(response);
+    await checkStatus(response);
 
     return response.buffer();
   }

--- a/packages/sign/src/signer/fulcio/ca.ts
+++ b/packages/sign/src/signer/fulcio/ca.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { InternalError } from '../../error';
+import { internalError } from '../../error';
 import { Fulcio, SigningCertificateRequest } from '../../external/fulcio';
 
 import type { FetchOptions } from '../../types/fetch';
@@ -60,11 +60,11 @@ export class CAClient implements CA {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return cert!.chain.certificates;
     } catch (err) {
-      throw new InternalError({
-        code: 'CA_CREATE_SIGNING_CERTIFICATE_ERROR',
-        message: 'error creating signing certificate',
-        cause: err,
-      });
+      internalError(
+        err,
+        'CA_CREATE_SIGNING_CERTIFICATE_ERROR',
+        'error creating signing certificate'
+      );
     }
   }
 }

--- a/packages/sign/src/witness/tlog/client.ts
+++ b/packages/sign/src/witness/tlog/client.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { InternalError } from '../../error';
+import { internalError } from '../../error';
 import { HTTPError } from '../../external/error';
 import { Rekor } from '../../external/rekor';
 
@@ -58,18 +58,18 @@ export class TLogClient implements TLog {
         try {
           entry = await this.rekor.getEntry(uuid);
         } catch (err) {
-          throw new InternalError({
-            code: 'TLOG_FETCH_ENTRY_ERROR',
-            message: 'error fetching tlog entry',
-            cause: err,
-          });
+          internalError(
+            err,
+            'TLOG_FETCH_ENTRY_ERROR',
+            'error fetching tlog entry'
+          );
         }
       } else {
-        throw new InternalError({
-          code: 'TLOG_CREATE_ENTRY_ERROR',
-          message: 'error creating tlog entry',
-          cause: err,
-        });
+        internalError(
+          err,
+          'TLOG_CREATE_ENTRY_ERROR',
+          'error creating tlog entry'
+        );
       }
     }
 

--- a/packages/sign/src/witness/tsa/client.ts
+++ b/packages/sign/src/witness/tsa/client.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { InternalError } from '../../error';
+import { internalError } from '../../error';
 import { TimestampAuthority } from '../../external/tsa';
 import { crypto } from '../../util';
 
@@ -47,11 +47,11 @@ export class TSAClient implements TSA {
     try {
       return await this.tsa.createTimestamp(request);
     } catch (err) {
-      throw new InternalError({
-        code: 'TSA_CREATE_TIMESTAMP_ERROR',
-        message: 'error creating timestamp',
-        cause: err,
-      });
+      internalError(
+        err,
+        'TSA_CREATE_TIMESTAMP_ERROR',
+        'error creating timestamp'
+      );
     }
   }
 }


### PR DESCRIPTION
Resovles #561 
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Improved messaging when throwing errors originating from Sigstore services.  Previously, when responding to an error from Fulcio, the consumer would see a generic errror message like this:

```
InternalError: error creating signing certificate
```

This explains that there was some sort of issue with the creation of the certificate, but doesn't relay the specific issue reported by Fulcio.

With this change, the consumer will see the following:

```
InternalError: error creating signing certificate - (400) There was an error processing the identity token
```

Now they have the HTTP status code and the specific Fulcio-reported error message available.