### PR TITLE
fix bug in mocked inclusion proof calculation

### DIFF
--- a/.changeset/slow-weeks-shop.md
+++ b/.changeset/slow-weeks-shop.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/mock': patch
+---
+
+Fix bug in mocked inclusion proof calculation

--- a/packages/mock/src/rekor/tlog.ts
+++ b/packages/mock/src/rekor/tlog.ts
@@ -56,7 +56,7 @@ class TLogImpl implements TLog {
     const logID = crypto.createHash('sha256').update(this.publicKey).digest();
     const logIndex = crypto.randomInt(10_000_000);
     const timestamp = Math.floor(Date.now() / 1000);
-    const body = Buffer.from(canonicalize(proposedEntry)!).toString('base64');
+    const body = Buffer.from(canonicalize(proposedEntry)!);
 
     const entry = { logID, logIndex, timestamp, body };
     const set = this.calculateSET(entry);
@@ -86,13 +86,13 @@ class TLogImpl implements TLog {
     logIndex,
     logID,
   }: {
-    body: string;
+    body: Buffer;
     timestamp: number;
     logIndex: number;
     logID: Buffer;
   }): Buffer {
     const setData = {
-      body: body,
+      body: body.toString('base64'),
       integratedTime: timestamp,
       logIndex: logIndex,
       logID: logID.toString('hex'),
@@ -109,7 +109,7 @@ class TLogImpl implements TLog {
     timestamp,
     logID,
   }: {
-    body: string;
+    body: Buffer;
     timestamp: number;
     logID: Buffer;
   }): InclusionProof {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fixes a bug in the `mock` library which was generating an invalid merkle tree inclusion proof.

When calculating the leaf hash for the merkle tree inclusion proof, the base-64 encoding of the tlog entry was being used instead of the raw bytes.