### PR TITLE
use valid entry with Rekor mock in non-strict mode

### DIFF
--- a/.changeset/hungry-weeks-lick.md
+++ b/.changeset/hungry-weeks-lick.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/mock': patch
+---
+
+Rekor mock running in non-strict mode creates a valid entry

--- a/packages/mock/src/rekor/handler.ts
+++ b/packages/mock/src/rekor/handler.ts
@@ -39,7 +39,9 @@ function createEntryHandler(tlog: TLog, opts: RekorHandlerOptions): HandlerFn {
 
   return async (body: string): Promise<HandlerFnResult> => {
     try {
-      const proposedEntry = strict ? JSON.parse(body) : {};
+      const proposedEntry = strict
+        ? JSON.parse(body)
+        : { kind: 'intoto', apiVersion: '0.0.2' };
       const tlogEntry = await tlog.log(proposedEntry);
       const response = JSON.stringify(tlogEntry);
 


### PR DESCRIPTION
#### Summary
Updates the default entry for the Rekor mock (used when running in non-strict mode) to something that is shaped more like a real Rekor entry. Previously, it just posted an empty object, but now it creates an entry with a valid kind/apiVersion.