### PR TITLE
expose rekor option to choose 'intoto' or 'dsse'

### DIFF
--- a/.changeset/cyan-impalas-look.md
+++ b/.changeset/cyan-impalas-look.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/sign': minor
+---
+
+Expose `entryType` option on `RekorWitness` constructor

--- a/package-lock.json
+++ b/package-lock.json
@@ -13903,7 +13903,7 @@
     },
     "packages/cli": {
       "name": "@sigstore/cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/color": "^1.0.13",
@@ -13948,7 +13948,7 @@
     },
     "packages/conformance": {
       "name": "@sigstore/conformance",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "dependencies": {
         "@oclif/core": "^3",
         "sigstore": "^2.0.0"
@@ -13982,7 +13982,7 @@
     },
     "packages/mock": {
       "name": "@sigstore/mock",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.3",
@@ -14006,11 +14006,11 @@
     },
     "packages/mock-server": {
       "name": "@sigstore/mock-server",
-      "version": "0.0.5",
+      "version": "0.1.0",
       "dependencies": {
         "@oclif/color": "^1.0.13",
         "@oclif/core": "^3",
-        "@sigstore/mock": "^0.6.0",
+        "@sigstore/mock": "^0.6.1",
         "@tufjs/repo-mock": "^2.0.0",
         "express": "4.18.2"
       },
@@ -16469,7 +16469,7 @@
       "requires": {
         "@oclif/color": "^1.0.13",
         "@oclif/core": "^3",
-        "@sigstore/mock": "^0.6.0",
+        "@sigstore/mock": "^0.6.1",
         "@tufjs/repo-mock": "^2.0.0",
         "@types/express": "^4.17.20",
         "express": "4.18.2",

--- a/packages/sign/src/__tests__/witness/tlog/index.test.ts
+++ b/packages/sign/src/__tests__/witness/tlog/index.test.ts
@@ -158,65 +158,140 @@ describe('RekorWitness', () => {
           },
         };
 
-        it('returns the tlog entry', async () => {
-          const vm = await subject.testify(sigBundle, publicKey);
+        describe('when the Rekor entry type is "intoto"', () => {
+          const subject = new RekorWitness({
+            rekorBaseURL,
+            entryType: 'intoto',
+          });
 
-          expect(vm).toBeDefined();
-          assert(vm.tlogEntries);
-          expect(vm.tlogEntries).toHaveLength(1);
+          it('returns the tlog entry', async () => {
+            const vm = await subject.testify(sigBundle, publicKey);
 
-          const tlogEntry = vm.tlogEntries[0];
-          expect(tlogEntry).toBeDefined();
-          expect(tlogEntry.logIndex).toEqual(
-            rekorEntry[uuid].logIndex.toString()
-          );
-          expect(tlogEntry.logId?.keyId).toEqual(
-            Buffer.from(rekorEntry[uuid].logID, 'hex')
-          );
-          expect(tlogEntry.kindVersion?.kind).toEqual(proposedEntry.kind);
-          expect(tlogEntry.kindVersion?.version).toEqual(
-            proposedEntry.apiVersion
-          );
-          expect(tlogEntry.integratedTime).toEqual(
-            rekorEntry[uuid].integratedTime.toString()
-          );
-          expect(tlogEntry.inclusionPromise?.signedEntryTimestamp).toEqual(
-            Buffer.from(
-              rekorEntry[uuid].verification.signedEntryTimestamp,
-              'base64'
-            )
-          );
-          expect(tlogEntry.inclusionProof?.checkpoint?.envelope).toEqual(
-            rekorEntry[uuid].verification.inclusionProof.checkpoint
-          );
-          expect(tlogEntry.inclusionProof?.hashes).toHaveLength(2);
-          expect(tlogEntry.inclusionProof?.hashes[0]).toEqual(
-            Buffer.from(
-              rekorEntry[uuid].verification.inclusionProof.hashes[0],
-              'hex'
-            )
-          );
-          expect(tlogEntry.inclusionProof?.hashes[1]).toEqual(
-            Buffer.from(
-              rekorEntry[uuid].verification.inclusionProof.hashes[1],
-              'hex'
-            )
-          );
-          expect(tlogEntry.inclusionProof?.logIndex).toEqual(
-            rekorEntry[uuid].verification.inclusionProof.logIndex.toString()
-          );
-          expect(tlogEntry.inclusionProof?.rootHash).toEqual(
-            Buffer.from(
-              rekorEntry[uuid].verification.inclusionProof.rootHash,
-              'hex'
-            )
-          );
-          expect(tlogEntry.inclusionProof?.treeSize).toEqual(
-            rekorEntry[uuid].verification.inclusionProof.treeSize.toString()
-          );
-          expect(tlogEntry.canonicalizedBody).toEqual(
-            Buffer.from(rekorEntry[uuid].body, 'base64')
-          );
+            expect(vm).toBeDefined();
+            assert(vm.tlogEntries);
+            expect(vm.tlogEntries).toHaveLength(1);
+
+            const tlogEntry = vm.tlogEntries[0];
+            expect(tlogEntry).toBeDefined();
+            expect(tlogEntry.logIndex).toEqual(
+              rekorEntry[uuid].logIndex.toString()
+            );
+            expect(tlogEntry.logId?.keyId).toEqual(
+              Buffer.from(rekorEntry[uuid].logID, 'hex')
+            );
+            expect(tlogEntry.kindVersion?.kind).toEqual(proposedEntry.kind);
+            expect(tlogEntry.kindVersion?.version).toEqual(
+              proposedEntry.apiVersion
+            );
+            expect(tlogEntry.integratedTime).toEqual(
+              rekorEntry[uuid].integratedTime.toString()
+            );
+            expect(tlogEntry.inclusionPromise?.signedEntryTimestamp).toEqual(
+              Buffer.from(
+                rekorEntry[uuid].verification.signedEntryTimestamp,
+                'base64'
+              )
+            );
+            expect(tlogEntry.inclusionProof?.checkpoint?.envelope).toEqual(
+              rekorEntry[uuid].verification.inclusionProof.checkpoint
+            );
+            expect(tlogEntry.inclusionProof?.hashes).toHaveLength(2);
+            expect(tlogEntry.inclusionProof?.hashes[0]).toEqual(
+              Buffer.from(
+                rekorEntry[uuid].verification.inclusionProof.hashes[0],
+                'hex'
+              )
+            );
+            expect(tlogEntry.inclusionProof?.hashes[1]).toEqual(
+              Buffer.from(
+                rekorEntry[uuid].verification.inclusionProof.hashes[1],
+                'hex'
+              )
+            );
+            expect(tlogEntry.inclusionProof?.logIndex).toEqual(
+              rekorEntry[uuid].verification.inclusionProof.logIndex.toString()
+            );
+            expect(tlogEntry.inclusionProof?.rootHash).toEqual(
+              Buffer.from(
+                rekorEntry[uuid].verification.inclusionProof.rootHash,
+                'hex'
+              )
+            );
+            expect(tlogEntry.inclusionProof?.treeSize).toEqual(
+              rekorEntry[uuid].verification.inclusionProof.treeSize.toString()
+            );
+            expect(tlogEntry.canonicalizedBody).toEqual(
+              Buffer.from(rekorEntry[uuid].body, 'base64')
+            );
+          });
+        });
+
+        describe('when the Rekor entry type is "dsse"', () => {
+          const subject = new RekorWitness({
+            rekorBaseURL,
+            entryType: 'dsse',
+          });
+
+          it('returns the tlog entry', async () => {
+            const vm = await subject.testify(sigBundle, publicKey);
+
+            expect(vm).toBeDefined();
+            assert(vm.tlogEntries);
+            expect(vm.tlogEntries).toHaveLength(1);
+
+            const tlogEntry = vm.tlogEntries[0];
+            expect(tlogEntry).toBeDefined();
+            expect(tlogEntry.logIndex).toEqual(
+              rekorEntry[uuid].logIndex.toString()
+            );
+            expect(tlogEntry.logId?.keyId).toEqual(
+              Buffer.from(rekorEntry[uuid].logID, 'hex')
+            );
+            expect(tlogEntry.kindVersion?.kind).toEqual(proposedEntry.kind);
+            expect(tlogEntry.kindVersion?.version).toEqual(
+              proposedEntry.apiVersion
+            );
+            expect(tlogEntry.integratedTime).toEqual(
+              rekorEntry[uuid].integratedTime.toString()
+            );
+            expect(tlogEntry.inclusionPromise?.signedEntryTimestamp).toEqual(
+              Buffer.from(
+                rekorEntry[uuid].verification.signedEntryTimestamp,
+                'base64'
+              )
+            );
+            expect(tlogEntry.inclusionProof?.checkpoint?.envelope).toEqual(
+              rekorEntry[uuid].verification.inclusionProof.checkpoint
+            );
+            expect(tlogEntry.inclusionProof?.hashes).toHaveLength(2);
+            expect(tlogEntry.inclusionProof?.hashes[0]).toEqual(
+              Buffer.from(
+                rekorEntry[uuid].verification.inclusionProof.hashes[0],
+                'hex'
+              )
+            );
+            expect(tlogEntry.inclusionProof?.hashes[1]).toEqual(
+              Buffer.from(
+                rekorEntry[uuid].verification.inclusionProof.hashes[1],
+                'hex'
+              )
+            );
+            expect(tlogEntry.inclusionProof?.logIndex).toEqual(
+              rekorEntry[uuid].verification.inclusionProof.logIndex.toString()
+            );
+            expect(tlogEntry.inclusionProof?.rootHash).toEqual(
+              Buffer.from(
+                rekorEntry[uuid].verification.inclusionProof.rootHash,
+                'hex'
+              )
+            );
+            expect(tlogEntry.inclusionProof?.treeSize).toEqual(
+              rekorEntry[uuid].verification.inclusionProof.treeSize.toString()
+            );
+            expect(tlogEntry.canonicalizedBody).toEqual(
+              Buffer.from(rekorEntry[uuid].body, 'base64')
+            );
+          });
         });
       });
     });

--- a/packages/sign/src/witness/tlog/index.ts
+++ b/packages/sign/src/witness/tlog/index.ts
@@ -30,12 +30,16 @@ export const DEFAULT_REKOR_URL = 'https://rekor.sigstore.dev';
 
 type TransparencyLogEntries = { tlogEntries: TransparencyLogEntry[] };
 
-export type RekorWitnessOptions = Partial<TLogClientOptions>;
+export type RekorWitnessOptions = Partial<TLogClientOptions> & {
+  entryType?: 'dsse' | 'intoto';
+};
 
 export class RekorWitness implements Witness {
   private tlog: TLog;
+  private entryType?: 'dsse' | 'intoto';
 
   constructor(options: RekorWitnessOptions) {
+    this.entryType = options.entryType;
     this.tlog = new TLogClient({
       ...options,
       rekorBaseURL:
@@ -47,7 +51,7 @@ export class RekorWitness implements Witness {
     content: SignatureBundle,
     publicKey: string
   ): Promise<TransparencyLogEntries> {
-    const proposedEntry = toProposedEntry(content, publicKey);
+    const proposedEntry = toProposedEntry(content, publicKey, this.entryType);
     const entry = await this.tlog.createEntry(proposedEntry);
     return toTransparencyLogEntry(entry);
   }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Exposes an option on the `RekorWitness` class which allows the caller to choose between "intoto" and "dsse" entry types when creating a new TLog entry. Will continue to default to "intoto" if no value is specified.
