### PR TITLE
disable dependabot changesets pr trigger

### DIFF
--- a/.github/workflows/dependabot-changesets.yml
+++ b/.github/workflows/dependabot-changesets.yml
@@ -1,6 +1,6 @@
 name: "Dependabot Changesets"
 
-on: pull_request
+on: workflow_dispatch
 
 permissions:
   contents: read


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Temporarily disabling the dependabot changeset action to troubleshoot some issues related to CI checks on dependabot PRs.