### PR TITLE
add identity/issuer policy support to verifier

### DIFF
--- a/.changeset/selfish-ants-exercise.md
+++ b/.changeset/selfish-ants-exercise.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/verify': minor
+---
+
+Add support for verifying identity of certificate issuer

--- a/packages/verify/src/__tests__/policty.test.ts
+++ b/packages/verify/src/__tests__/policty.test.ts
@@ -1,0 +1,53 @@
+import { PolicyError } from '../error';
+import { verifyExtensions, verifySubjectAlternativeName } from '../policy';
+
+describe('verifySubjectAlternativeName', () => {
+  describe('when the signer identity is undefined', () => {
+    it('throws an error', () => {
+      expect(() =>
+        verifySubjectAlternativeName('foo', undefined)
+      ).toThrowWithCode(PolicyError, 'UNTRUSTED_SIGNER_ERROR');
+    });
+  });
+
+  describe('when the signer identity does not match the policy', () => {
+    it('throws an error', () => {
+      expect(() => verifySubjectAlternativeName('foo', 'bar')).toThrowWithCode(
+        PolicyError,
+        'UNTRUSTED_SIGNER_ERROR'
+      );
+    });
+  });
+
+  describe('when the signer identity matches the policy', () => {
+    it('does not throw an error', () => {
+      expect(() => verifySubjectAlternativeName('foo', 'foo')).not.toThrow();
+    });
+  });
+});
+
+describe('verifyExtensions', () => {
+  describe('when the signer extensions are undefined', () => {
+    it('throws an error', () => {
+      expect(() =>
+        verifyExtensions({ issuer: 'foo' }, { issuer: undefined })
+      ).toThrowWithCode(PolicyError, 'UNTRUSTED_SIGNER_ERROR');
+    });
+  });
+
+  describe('when the signer extensions do not match the policy', () => {
+    it('throws an error', () => {
+      expect(() =>
+        verifyExtensions({ issuer: 'foo' }, { issuer: 'bar' })
+      ).toThrowWithCode(PolicyError, 'UNTRUSTED_SIGNER_ERROR');
+    });
+  });
+
+  describe('when the signer extensions match the policy', () => {
+    it('does not throw an error', () => {
+      expect(() =>
+        verifyExtensions({ issuer: 'foo' }, { issuer: 'foo' })
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/verify/src/policy.ts
+++ b/packages/verify/src/policy.ts
@@ -1,0 +1,31 @@
+import { PolicyError } from './error';
+import { CertificateExtensions } from './shared.types';
+
+export function verifySubjectAlternativeName(
+  policyIdentity: string,
+  signerIdentity: string | undefined
+): void {
+  if (signerIdentity === undefined || !signerIdentity.match(policyIdentity)) {
+    throw new PolicyError({
+      code: 'UNTRUSTED_SIGNER_ERROR',
+      message: `certificate identity error - expected ${policyIdentity}, got ${signerIdentity}`,
+    });
+  }
+}
+
+export function verifyExtensions(
+  policyExtensions: CertificateExtensions,
+  signerExtensions: CertificateExtensions
+): void {
+  if (policyExtensions.issuer) {
+    const policyIssuer = policyExtensions.issuer;
+    const signerIssuer = signerExtensions.issuer;
+
+    if (signerIssuer === undefined || signerIssuer !== policyIssuer) {
+      throw new PolicyError({
+        code: 'UNTRUSTED_SIGNER_ERROR',
+        message: `invalid certificate issuer - expected ${policyIssuer}, got ${signerIssuer}`,
+      });
+    }
+  }
+}

--- a/packages/verify/src/shared.types.ts
+++ b/packages/verify/src/shared.types.ts
@@ -17,12 +17,12 @@ import type { TransparencyLogEntry } from '@sigstore/bundle';
 import type { X509Certificate, crypto } from '@sigstore/core';
 
 export type CertificateExtensions = {
-  issuer: string;
+  issuer?: string;
 };
 
 export type CertificateIdentity = {
   subjectAlternativeName?: string;
-  extensions: Partial<CertificateExtensions>;
+  extensions: CertificateExtensions;
 };
 
 export type Signer = {


### PR DESCRIPTION
Updates the verifier with support for verifying the identity contained in the signing certificate. Given that not all Sigstore bundles contain a signing certificate, the `policy` argument containing the expected identity is marked as optional.