### PR TITLE
Fixes for TSA-generated timestamps in mock package

### DIFF
--- a/.changeset/nine-donuts-marry.md
+++ b/.changeset/nine-donuts-marry.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/mock": patch
+---
+
+Introduce intermediate certificate for issuing RFC3161 timestamps

--- a/.changeset/tricky-owls-relax.md
+++ b/.changeset/tricky-owls-relax.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/mock": patch
+---
+
+Fix encoding for TSA-issued timestamps

--- a/packages/mock-server/src/index.ts
+++ b/packages/mock-server/src/index.ts
@@ -133,15 +133,17 @@ function assembleTrustedRoot({
 }): TrustedRoot {
   return {
     mediaType: 'application/vnd.dev.sigstore.trustedroot+json;version=0.1',
-    certificateAuthorities: [certificateAuthority(ca.rootCertificate, url)],
+    certificateAuthorities: [certificateAuthority([ca.rootCertificate], url)],
     ctlogs: [transparencyLogInstance(ctlog.publicKey, url)],
     tlogs: [transparencyLogInstance(tlog.publicKey, url)],
-    timestampAuthorities: [certificateAuthority(tsa.rootCertificate, url)],
+    timestampAuthorities: [
+      certificateAuthority([tsa.rootCertificate, tsa.intCertificate], url),
+    ],
   };
 }
 
 function certificateAuthority(
-  certificate: Buffer,
+  certificates: Buffer[],
   url: string
 ): CertificateAuthority {
   return {
@@ -151,7 +153,9 @@ function certificateAuthority(
     },
     uri: url,
     certChain: {
-      certificates: [{ rawBytes: certificate }],
+      certificates: certificates.map((certificate) => ({
+        rawBytes: certificate,
+      })),
     },
     validFor: { start: new Date() },
   };

--- a/packages/mock/src/timestamp/tsa.test.ts
+++ b/packages/mock/src/timestamp/tsa.test.ts
@@ -24,6 +24,7 @@ const OID_SHA256_ALGO_ID = '2.16.840.1.101.3.4.2.1';
 describe('TSA', () => {
   const keyPair = generateKeyPair('prime256v1');
   const clock = new Date();
+
   describe('rootCertificate', () => {
     it('returns the root certificate', async () => {
       const tsa = await initializeTSA(keyPair, clock);
@@ -34,6 +35,23 @@ describe('TSA', () => {
       const cert = pkijs.Certificate.fromBER(root);
       expect(cert.issuer.typesAndValues[0].value.valueBlock.value).toBe('tsa');
       expect(cert.issuer.typesAndValues[1].value.valueBlock.value).toBe(
+        'sigstore.mock'
+      );
+    });
+  });
+
+  describe('intCertificate', () => {
+    it('returns the intermediate certificate', async () => {
+      const tsa = await initializeTSA(keyPair, clock);
+      const der = tsa.intCertificate;
+
+      expect(der).toBeDefined();
+
+      const cert = pkijs.Certificate.fromBER(der);
+      expect(cert.subject.typesAndValues[0].value.valueBlock.value).toBe(
+        'tsa signing'
+      );
+      expect(cert.subject.typesAndValues[1].value.valueBlock.value).toBe(
         'sigstore.mock'
       );
     });

--- a/packages/mock/src/util/ess-cert-id.test.ts
+++ b/packages/mock/src/util/ess-cert-id.test.ts
@@ -1,0 +1,34 @@
+import * as asn1js from 'asn1js';
+import * as pkijs from 'pkijs';
+import { ESSCertIDv2 } from './ess-cert-id';
+
+describe('ESSCertIDv2', () => {
+  describe('constructor', () => {
+    describe('when no parameters are provided', () => {
+      it('should set the certHash and issuerSerial to empty buffers', () => {
+        const essCertIDv2 = new ESSCertIDv2();
+        expect(essCertIDv2).toBeDefined();
+      });
+    });
+
+    describe('when parameters are provided', () => {
+      it('should set the certHash and issuerSerial', () => {
+        const certHash = new asn1js.OctetString({
+          valueHex: new ArrayBuffer(0),
+        });
+        const issuerSerial = new pkijs.IssuerSerial({
+          issuer: new pkijs.GeneralNames({
+            names: [
+              new pkijs.GeneralName({ type: 4, value: new ArrayBuffer(0) }),
+            ],
+          }),
+          serialNumber: new asn1js.Integer({ value: 888 }),
+        });
+        const essCertIDv2 = new ESSCertIDv2({ certHash, issuerSerial });
+
+        expect(essCertIDv2.certHash).toBe(certHash);
+        expect(essCertIDv2.issuerSerial).toBe(issuerSerial);
+      });
+    });
+  });
+});

--- a/packages/mock/src/util/ess-cert-id.ts
+++ b/packages/mock/src/util/ess-cert-id.ts
@@ -1,0 +1,54 @@
+import * as asn1js from 'asn1js';
+import * as pkijs from 'pkijs';
+import * as pvutils from 'pvutils';
+
+const CERT_HASH = 'certHash';
+const ISSUER_SERIAL = 'issuerSerial';
+
+interface IESSCertIDv2 {
+  certHash: asn1js.OctetString;
+  issuerSerial: pkijs.IssuerSerial;
+}
+
+type ESSCertIDv2Parameters = pkijs.PkiObjectParameters & Partial<IESSCertIDv2>;
+
+// https://datatracker.ietf.org/doc/html/rfc5035#section-4
+export class ESSCertIDv2 extends pkijs.PkiObject implements IESSCertIDv2 {
+  public static override CLASS_NAME = 'ESSCertIDv2';
+
+  public certHash!: asn1js.OctetString;
+  public issuerSerial!: pkijs.IssuerSerial;
+
+  constructor(parameters: ESSCertIDv2Parameters = {}) {
+    super();
+
+    this.certHash = pvutils.getParametersValue(
+      parameters,
+      CERT_HASH,
+      new asn1js.OctetString()
+    );
+    this.issuerSerial = pvutils.getParametersValue(
+      parameters,
+      ISSUER_SERIAL,
+      new pkijs.IssuerSerial()
+    );
+  }
+
+  public override toSchema(): asn1js.Sequence {
+    const result = new asn1js.Sequence({
+      value: [this.certHash, this.issuerSerial.toSchema()],
+    });
+
+    return result;
+  }
+
+  /* istanbul ignore next */
+  public override fromSchema(): void {
+    throw new Error('Not implemented');
+  }
+
+  /* istanbul ignore next */
+  public override toJSON(): IESSCertIDv2 {
+    throw new Error('Not implemented');
+  }
+}

--- a/packages/mock/src/util/signing-cert.test.ts
+++ b/packages/mock/src/util/signing-cert.test.ts
@@ -1,0 +1,38 @@
+import * as asn1js from 'asn1js';
+import * as pkijs from 'pkijs';
+import { ESSCertIDv2 } from './ess-cert-id';
+import { SigningCertificateV2 } from './signing-cert';
+
+describe('SigningCertificateV2', () => {
+  describe('constructor', () => {
+    describe('when no parameters are provided', () => {
+      it('should set the certs to an empty array', () => {
+        const signingCertificateV2 = new SigningCertificateV2();
+        expect(signingCertificateV2).toBeDefined();
+      });
+    });
+
+    describe('when parameters are provided', () => {
+      it('should set the certs', () => {
+        const certHash = new asn1js.OctetString({
+          valueHex: new ArrayBuffer(0),
+        });
+        const issuerSerial = new pkijs.IssuerSerial({
+          issuer: new pkijs.GeneralNames({
+            names: [
+              new pkijs.GeneralName({ type: 4, value: new ArrayBuffer(0) }),
+            ],
+          }),
+          serialNumber: new asn1js.Integer({ value: 888 }),
+        });
+        const essCertIDv2 = new ESSCertIDv2({ certHash, issuerSerial });
+        const signingCertificateV2 = new SigningCertificateV2({
+          certs: [essCertIDv2],
+        });
+
+        expect(signingCertificateV2.certs).toHaveLength(1);
+        expect(signingCertificateV2.certs[0]).toBe(essCertIDv2);
+      });
+    });
+  });
+});

--- a/packages/mock/src/util/signing-cert.ts
+++ b/packages/mock/src/util/signing-cert.ts
@@ -1,0 +1,45 @@
+import * as asn1js from 'asn1js';
+import * as pkijs from 'pkijs';
+import * as pvutils from 'pvutils';
+import { ESSCertIDv2 } from './ess-cert-id';
+
+const CERTS = 'certs';
+
+interface ISigningCertificateV2 {
+  certs: ESSCertIDv2[];
+}
+
+type SigningCertificateV2Parameters = pkijs.PkiObjectParameters &
+  Partial<ISigningCertificateV2>;
+
+// https://datatracker.ietf.org/doc/html/rfc5035#section-3
+export class SigningCertificateV2
+  extends pkijs.PkiObject
+  implements ISigningCertificateV2
+{
+  public static override CLASS_NAME = 'SigningCertificateV2';
+
+  public certs!: ESSCertIDv2[];
+
+  constructor(parameters: SigningCertificateV2Parameters = {}) {
+    super();
+
+    this.certs = pvutils.getParametersValue(parameters, CERTS, []);
+  }
+
+  public override toSchema(): asn1js.Sequence {
+    return new asn1js.Sequence({
+      value: Array.from(this.certs, (o) => o.toSchema()),
+    });
+  }
+
+  /* istanbul ignore next */
+  public override fromSchema(): void {
+    throw new Error('Not implemented');
+  }
+
+  /* istanbul ignore next */
+  public override toJSON(): ISigningCertificateV2 {
+    throw new Error('Not implemented');
+  }
+}


### PR DESCRIPTION
Updates to the `@sigstore/mock` package so that the mock TSA instance can issue verifiable timestamps. 

The timestamps which were generated by the mock TSA previously were missing some critical fields which made them unverifiable. The signed timestamp now includes the necessary information about the certificate which was used to do the signing. This is used in the verification process to look-up the correct cert.

This change also introduces a new intermediate certificate with the "Time Stamping" key usage extension which is necessary for generating a valid timestamp (the verification process checks that the issuing certificate has this usage listed).

With these changes I was able to use `openssl ts -verify` to successfully verify a timestamp generated by the mock TSA instance.