### PR TITLE
tweak encoded structure of mock tsa timestamps

### DIFF
--- a/.changeset/rude-meals-tap.md
+++ b/.changeset/rude-meals-tap.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/mock": patch
+---
+
+Remove extra level of OCTET STRING nesting in mocked RFC3161 timestamp response

--- a/packages/mock/src/timestamp/tsa.ts
+++ b/packages/mock/src/timestamp/tsa.ts
@@ -164,13 +164,11 @@ class TSAImpl implements TSA {
   ): Promise<pkijs.SignedData> {
     const encapContent = new pkijs.EncapsulatedContentInfo({
       eContentType: OID_TSTINFO_CONTENT_TYPE,
-      eContent: new asn1js.OctetString({
-        valueHex: tstInfo.toSchema().toBER(false),
-        // The isConstructed flag makes the encoding of the
-        // EncapsulatedContentInfo look more like what the real TSA returns,
-        // however, it results in a reponse that is not parseable by openssl.
-        // idBlock: { isConstructed: true },
-      }),
+    });
+    // Avoid passing eContent to the constructor to circumvent the logic which
+    // splits the eContent into chunks and introduces a new OCTET STRING
+    encapContent.eContent = new asn1js.OctetString({
+      valueHex: tstInfo.toSchema().toBER(false),
     });
 
     const tstInfoDigest = await this.crypto.digest(


### PR DESCRIPTION
Minor change to the structure of the RFC3161 timestamps generated by the mock TSA to remove an unnecessary level of OCTET STRING encoding. The resulting timestamp looks more like ones which are generated by the real TSA service.

Before
<img width="605" alt="image" src="https://github.com/sigstore/sigstore-js/assets/398027/2ed5f22c-e079-4238-991d-799151610e76">

After
<img width="581" alt="image" src="https://github.com/sigstore/sigstore-js/assets/398027/2ba2e20a-c99e-4acb-bb06-a636d9e36acb">
