### PR TITLE
add tufForceCache to client and CLI

### DIFF
--- a/.changeset/long-jobs-explain.md
+++ b/.changeset/long-jobs-explain.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/cli": minor
+---
+
+Add `tuf-force-cache` flag to `verify` command

--- a/.changeset/polite-numbers-wait.md
+++ b/.changeset/polite-numbers-wait.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/cli": minor
+---
+
+Add `cache-path` flag to `initialize` command

--- a/.changeset/poor-radios-sleep.md
+++ b/.changeset/poor-radios-sleep.md
@@ -1,0 +1,5 @@
+---
+"sigstore": minor
+---
+
+Add `tufForceCache` flag to `VerifyOptions` type

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,7 +9,7 @@ $ npm install -g @sigstore/cli
 $ sigstore COMMAND
 running command...
 $ sigstore (--version)
-@sigstore/cli/0.3.0 darwin-arm64 node-v18.12.1
+@sigstore/cli/0.5.0 darwin-arm64 node-v18.12.1
 $ sigstore --help [COMMAND]
 USAGE
   $ sigstore COMMAND
@@ -37,18 +37,19 @@ ARGUMENTS
   FILE  file to attest
 
 FLAGS
-  -o, --output-file=<value>     write output to file
-  -t, --payload-type=<value>    [default: application/vnd.in-toto+json] MIME or content type to apply to the DSSE
-                                envelope
-  --fulcio-url=<value>          [default: https://fulcio.sigstore.dev] URL to the Sigstore PKI server
-  --oidc-client-id=<value>      [default: sigstore] OIDC client ID for application
-  --oidc-client-secret=<value>  OIDC client secret for application
-  --oidc-issuer=<value>         [default: https://oauth2.sigstore.dev/auth] OIDC provider to be used to issue ID token
-  --oidc-redirect-url=<value>   OIDC redirect URL
-  --rekor-url=<value>           [default: https://rekor.sigstore.dev] URL to the Rekor transparency log
-  --timeout=<value>             [default: 5] timeout in seconds for API requests
-  --[no-]tlog-upload            whether or not to upload entry to the transparency log
-  --tsa-server-url=<value>      URL to the Timestamping Authority
+  -o, --output-file=<value>         write output to file
+  -t, --payload-type=<value>        [default: application/vnd.in-toto+json] MIME or content type to apply to the DSSE
+                                    envelope
+      --fulcio-url=<value>          [default: https://fulcio.sigstore.dev] URL to the Sigstore PKI server
+      --oidc-client-id=<value>      [default: sigstore] OIDC client ID for application
+      --oidc-client-secret=<value>  OIDC client secret for application
+      --oidc-issuer=<value>         [default: https://oauth2.sigstore.dev/auth] OIDC provider to be used to issue ID
+                                    token
+      --oidc-redirect-url=<value>   OIDC redirect URL
+      --rekor-url=<value>           [default: https://rekor.sigstore.dev] URL to the Rekor transparency log
+      --timeout=<value>             [default: 5] timeout in seconds for API requests
+      --[no-]tlog-upload            whether or not to upload entry to the transparency log
+      --tsa-server-url=<value>      URL to the Timestamping Authority
 
 GLOBAL FLAGS
   --json  Format output as json.
@@ -88,12 +89,13 @@ initialize the Sigstore TUF root to retrieve trusted certificates and keys for v
 
 ```
 USAGE
-  $ sigstore initialize [--mirror <value>] [--root <value>] [--force]
+  $ sigstore initialize [--mirror <value>] [--root <value>] [--cache-path <value>] [--force]
 
 FLAGS
-  --force           force initialization even if the cache already exists
-  --mirror=<value>  [default: https://tuf-repo-cdn.sigstore.dev] URL to the Sigstore TUF repository
-  --root=<value>    path to the initial trusted root. Defaults to the embedded root.
+  --cache-path=<value>  Absolute path to the directory to be used for caching downloaded TUF metadata and targets
+  --force               force initialization even if the cache already exists
+  --mirror=<value>      [default: https://tuf-repo-cdn.sigstore.dev] URL to the Sigstore TUF repository
+  --root=<value>        path to the initial trusted root. Defaults to the embedded root.
 
 DESCRIPTION
   initialize the Sigstore TUF root to retrieve trusted certificates and keys for verification
@@ -114,13 +116,33 @@ verify the supplied .sigstore bundle file
 ```
 USAGE
   $ sigstore verify BUNDLE [--json] [--tlog-threshold <value>] [--ctlog-threshold <value>]
+    [--certificate-identity-email <value> --certificate-issuer <value>] [--certificate-identity-uri <value> ]
+    [--tuf-mirror-url <value>] [--tuf-root-path <value>] [--tuf-cache-path <value>] [--tuf-force-cache] [--blob-file
+    <value> | --blob <value>]
 
 ARGUMENTS
   BUNDLE  bundle to verify
 
 FLAGS
-  --ctlog-threshold=<value>  [default: 1] number of certificate transparency log entries required to verify
-  --tlog-threshold=<value>   [default: 1] number of transparency log entries required to verify
+  --blob=<value>                        Base64 encoded data to verify. Only required if bundle was not signed using
+                                        attest
+  --blob-file=<value>                   File containing data to verify. Only required if bundle was not signed using
+                                        attest
+  --certificate-identity-email=<value>  Email address which must appear in the signing certificate's Subject Alternative
+                                        Name (SAN) extension. Not verified if no value is supplied
+  --certificate-identity-uri=<value>    URI which must appear in the signing certificate's Subject Alternative Name
+                                        (SAN) extension. Not verified if no value is supplied
+  --certificate-issuer=<value>          Value that must appear in the signing certificate's issuer extension (OID
+                                        1.3.6.1.4.1.57264.1.1 or 1.3.6.1.4.1.57264.1.8). Not verified if no value is
+                                        supplied
+  --ctlog-threshold=<value>             [default: 1] number of certificate transparency log entries required to verify
+  --tlog-threshold=<value>              [default: 1] number of transparency log entries required to verify
+  --tuf-cache-path=<value>              Absolute path to the directory to be used for caching downloaded TUF metadata
+                                        and targets
+  --tuf-force-cache                     Whether to give precedence to cached, un-expired TUF metadata and targets over
+                                        remote versions
+  --tuf-mirror-url=<value>              Base URL for the Sigstore TUF repository
+  --tuf-root-path=<value>               Path to the initial trust root for the TUF repository
 
 GLOBAL FLAGS
   --json  Format output as json.

--- a/packages/cli/src/commands/initialize.ts
+++ b/packages/cli/src/commands/initialize.ts
@@ -16,6 +16,10 @@ export default class Initialize extends Command {
       description:
         'path to the initial trusted root. Defaults to the embedded root.',
     }),
+    'cache-path': Flags.directory({
+      description:
+        'Absolute path to the directory to be used for caching downloaded TUF metadata and targets',
+    }),
     force: Flags.boolean({
       description: 'force initialization even if the cache already exists',
       default: false,
@@ -28,6 +32,7 @@ export default class Initialize extends Command {
     await initTUF({
       mirrorURL: flags.mirror,
       rootPath: flags.root,
+      cachePath: flags['cache-path'],
       force: flags.force,
     });
   }

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -47,6 +47,12 @@ export default class Verify extends Command {
       description:
         'Absolute path to the directory to be used for caching downloaded TUF metadata and targets',
     }),
+    'tuf-force-cache': Flags.boolean({
+      description:
+        'Whether to give precedence to cached, un-expired TUF metadata and targets over remote versions',
+      default: false,
+      required: false,
+    }),
     'blob-file': Flags.file({
       description:
         'File containing data to verify. Only required if bundle was not signed using attest',
@@ -80,6 +86,7 @@ export default class Verify extends Command {
       tufMirrorURL: flags['tuf-mirror-url'],
       tufRootPath: flags['tuf-root-path'],
       tufCachePath: flags['tuf-cache-path'],
+      tufForceCache: flags['tuf-force-cache'],
     };
 
     const bundle = await fs

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -64,6 +64,7 @@ export type VerifyOptions = {
   tufMirrorURL?: string;
   tufRootPath?: string;
   tufCachePath?: string;
+  tufForceCache?: boolean;
 } & FetchOptions;
 
 export const DEFAULT_RETRY: Retry = { retries: 2 };

--- a/packages/client/src/sigstore.ts
+++ b/packages/client/src/sigstore.ts
@@ -86,6 +86,7 @@ export async function createVerifier(
     mirrorURL: options.tufMirrorURL,
     rootPath: options.tufRootPath,
     cachePath: options.tufCachePath,
+    forceCache: options.tufForceCache,
     retry: options.retry ?? config.DEFAULT_RETRY,
     timeout: options.timeout ?? config.DEFAULT_TIMEOUT,
   });


### PR DESCRIPTION
A couple of `client` and `cli` updates related to the new `forceCache` option added to the `@sigstore/tuf` client:

* Updates the `verify` function in the client with a new `tufForceCache` option.
* Updates the `verify` command in the CLI with a new `--tuf-force-cache` flag.
* Updates the `initialize` command in the CLI with a new `--cache-path` flag.