### PR TITLE
handle rekor checkpoints w/o timestamps

### DIFF
--- a/.changeset/shaggy-rats-decide.md
+++ b/.changeset/shaggy-rats-decide.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/verify": patch
+---
+
+Update Rekor verification to handle checkpoint values which do no include timestamps (https://github.com/sigstore/rekor/pull/1888)

--- a/packages/verify/src/timestamp/checkpoint.ts
+++ b/packages/verify/src/timestamp/checkpoint.ts
@@ -188,9 +188,9 @@ class LogCheckpoint {
   }
 
   static fromString(note: string): LogCheckpoint {
-    const lines = note.trim().split('\n');
+    const lines = note.trimEnd().split('\n');
 
-    if (lines.length < 4) {
+    if (lines.length < 3) {
       throw new VerificationError({
         code: 'TLOG_INCLUSION_PROOF_ERROR',
         message: 'too few lines in checkpoint header',


### PR DESCRIPTION
Updates tlog verification logic to properly handle checkpoint values which do NOT include timestamps. This data was never being used, but the verifier would throw an error if it was missing.

related: https://github.com/sigstore/rekor/pull/1888