### PR TITLE
promote new packages to v1.0.0

### DIFF
--- a/.changeset/forty-jars-sparkle.md
+++ b/.changeset/forty-jars-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/verify": major
+---
+
+Promote to 1.0.0

--- a/.changeset/hungry-teachers-mix.md
+++ b/.changeset/hungry-teachers-mix.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/core": major
+---
+
+Promote to 1.0.0


### PR DESCRIPTION
Promotes the `@sigstore/core` and `@sigstore/verify` packages to official 1.0.0 status