### PR TITLE
update to @sigstore/protobuf-specs@0.3.0

### DIFF
--- a/.changeset/chilly-pugs-grow.md
+++ b/.changeset/chilly-pugs-grow.md
@@ -1,0 +1,11 @@
+---
+"@sigstore/bundle": patch
+"@sigstore/conformance": patch
+"sigstore": patch
+"@sigstore/mock": patch
+"@sigstore/sign": patch
+"@sigstore/tuf": patch
+"@sigstore/verify": patch
+---
+
+Bump @sigstore/protobuf-specs from 0.2.1 to 0.3.0

--- a/.changeset/chilly-swans-applaud.md
+++ b/.changeset/chilly-swans-applaud.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/bundle": minor
+---
+
+Support for validating v0.3 bundles

--- a/.changeset/seven-countries-ring.md
+++ b/.changeset/seven-countries-ring.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/verify": minor
+---
+
+Support for verifying v0.3 bundles

--- a/package-lock.json
+++ b/package-lock.json
@@ -4400,9 +4400,9 @@
       "link": true
     },
     "node_modules/@sigstore/protobuf-specs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.2.1.tgz",
-      "integrity": "sha512-XTWVxnWJu+c1oCshMLwnKvz8ZQJJDVOlciMfgpJBQbThVjKTCG8dwyhgLngBD2KN0ap9F/gOV8rFDEx8uh7R2A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.0.tgz",
+      "integrity": "sha512-zxiQ66JFOjVvP9hbhGj/F/qNdsZfkGb/dVXSanNRNuAzMlr4MC95voPUBX8//ZNnmv3uSYzdfR/JSkrgvZTGxA==",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -16160,7 +16160,7 @@
       "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.2.1"
+        "@sigstore/protobuf-specs": "^0.3.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -16197,7 +16197,7 @@
       "dependencies": {
         "@sigstore/bundle": "^2.1.1",
         "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "@sigstore/sign": "^2.2.2",
         "@sigstore/tuf": "^2.3.0",
         "@sigstore/verify": "^1.0.0"
@@ -16219,7 +16219,7 @@
       "dependencies": {
         "@oclif/core": "^3",
         "@sigstore/bundle": "^2.1.1",
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "@sigstore/verify": "^1.0.0",
         "sigstore": "^2.2.1"
       },
@@ -16265,7 +16265,7 @@
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.5",
         "@peculiar/x509": "^1.9.7",
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "asn1js": "^3.0.5",
         "bytestreamjs": "^2.0.1",
         "canonicalize": "^2.0.0",
@@ -16380,7 +16380,7 @@
       "dependencies": {
         "@sigstore/bundle": "^2.1.1",
         "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "make-fetch-happen": "^13.0.0"
       },
       "devDependencies": {
@@ -16398,7 +16398,7 @@
       "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "tuf-js": "^2.2.0"
       },
       "devDependencies": {
@@ -16417,7 +16417,7 @@
       "dependencies": {
         "@sigstore/bundle": "^2.1.1",
         "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.2.1"
+        "@sigstore/protobuf-specs": "^0.3.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -19985,7 +19985,7 @@
     "@sigstore/bundle": {
       "version": "file:packages/bundle",
       "requires": {
-        "@sigstore/protobuf-specs": "^0.2.1"
+        "@sigstore/protobuf-specs": "^0.3.0"
       }
     },
     "@sigstore/cli": {
@@ -20007,7 +20007,7 @@
       "requires": {
         "@oclif/core": "^3",
         "@sigstore/bundle": "^2.1.1",
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "@sigstore/verify": "^1.0.0",
         "oclif": "^4",
         "sigstore": "^2.2.1",
@@ -20028,7 +20028,7 @@
       "requires": {
         "@peculiar/webcrypto": "^1.4.5",
         "@peculiar/x509": "^1.9.7",
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "@sigstore/rekor-types": "^2.0.0",
         "asn1js": "^3.0.5",
         "bytestreamjs": "^2.0.1",
@@ -20061,9 +20061,9 @@
       }
     },
     "@sigstore/protobuf-specs": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.2.1.tgz",
-      "integrity": "sha512-XTWVxnWJu+c1oCshMLwnKvz8ZQJJDVOlciMfgpJBQbThVjKTCG8dwyhgLngBD2KN0ap9F/gOV8rFDEx8uh7R2A=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.0.tgz",
+      "integrity": "sha512-zxiQ66JFOjVvP9hbhGj/F/qNdsZfkGb/dVXSanNRNuAzMlr4MC95voPUBX8//ZNnmv3uSYzdfR/JSkrgvZTGxA=="
     },
     "@sigstore/rekor-types": {
       "version": "file:packages/rekor-types",
@@ -20079,7 +20079,7 @@
         "@sigstore/core": "^1.0.0",
         "@sigstore/jest": "^0.0.0",
         "@sigstore/mock": "^0.6.4",
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "@sigstore/rekor-types": "^2.0.0",
         "@types/make-fetch-happen": "^10.0.4",
         "make-fetch-happen": "^13.0.0"
@@ -20089,7 +20089,7 @@
       "version": "file:packages/tuf",
       "requires": {
         "@sigstore/jest": "^0.0.0",
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "@tufjs/repo-mock": "^2.0.0",
         "@types/make-fetch-happen": "^10.0.4",
         "tuf-js": "^2.2.0"
@@ -20100,7 +20100,7 @@
       "requires": {
         "@sigstore/bundle": "^2.1.1",
         "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.2.1"
+        "@sigstore/protobuf-specs": "^0.3.0"
       }
     },
     "@sinclair/typebox": {
@@ -27441,7 +27441,7 @@
         "@sigstore/core": "^1.0.0",
         "@sigstore/jest": "^0.0.0",
         "@sigstore/mock": "^0.6.4",
-        "@sigstore/protobuf-specs": "^0.2.1",
+        "@sigstore/protobuf-specs": "^0.3.0",
         "@sigstore/rekor-types": "^2.0.0",
         "@sigstore/sign": "^2.2.2",
         "@sigstore/tuf": "^2.3.0",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -27,7 +27,7 @@
     "provenance": true
   },
   "dependencies": {
-    "@sigstore/protobuf-specs": "^0.2.1"
+    "@sigstore/protobuf-specs": "^0.3.0"
   },
   "engines": {
     "node": "^16.14.0 || >=18.0.0"

--- a/packages/bundle/src/__tests__/__snapshots__/serialized.test.ts.snap
+++ b/packages/bundle/src/__tests__/__snapshots__/serialized.test.ts.snap
@@ -1,0 +1,170 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`bundleToJSON SerializedDSSEBundle (v0.3) matches the snapshot 1`] = `
+{
+  "dsseEnvelope": {
+    "payload": "cGF5bG9hZA==",
+    "payloadType": "application/vnd.in-toto+json",
+    "signatures": [
+      {
+        "keyid": "keyid",
+        "sig": "c2lnbmF0dXJl",
+      },
+    ],
+  },
+  "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.3",
+  "verificationMaterial": {
+    "certificate": {
+      "rawBytes": "Y2VydGlmaWNhdGU=",
+    },
+    "timestampVerificationData": {
+      "rfc3161Timestamps": [
+        {
+          "signedTimestamp": "c2lnbmVkVGltZXN0YW1w",
+        },
+      ],
+    },
+    "tlogEntries": [
+      {
+        "canonicalizedBody": "Ym9keQ==",
+        "inclusionPromise": {
+          "signedEntryTimestamp": "aW5jbHVzaW9uUHJvbWlzZQ==",
+        },
+        "inclusionProof": {
+          "checkpoint": {
+            "envelope": "checkpoint",
+          },
+          "hashes": [
+            "aGFzaA==",
+          ],
+          "logIndex": "0",
+          "rootHash": "cm9vdEhhc2g=",
+          "treeSize": "0",
+        },
+        "integratedTime": "2021-01-01T00:00:00Z",
+        "kindVersion": {
+          "kind": "kind",
+          "version": "version",
+        },
+        "logId": {
+          "keyId": "bG9nSWQ=",
+        },
+        "logIndex": "0",
+      },
+    ],
+  },
+}
+`;
+
+exports[`bundleToJSON SerializedDSSEBundle matches the snapshot 1`] = `
+{
+  "dsseEnvelope": {
+    "payload": "cGF5bG9hZA==",
+    "payloadType": "application/vnd.in-toto+json",
+    "signatures": [
+      {
+        "keyid": "keyid",
+        "sig": "c2lnbmF0dXJl",
+      },
+    ],
+  },
+  "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.1",
+  "verificationMaterial": {
+    "timestampVerificationData": {
+      "rfc3161Timestamps": [
+        {
+          "signedTimestamp": "c2lnbmVkVGltZXN0YW1w",
+        },
+      ],
+    },
+    "tlogEntries": [
+      {
+        "canonicalizedBody": "Ym9keQ==",
+        "inclusionPromise": {
+          "signedEntryTimestamp": "aW5jbHVzaW9uUHJvbWlzZQ==",
+        },
+        "inclusionProof": {
+          "checkpoint": {
+            "envelope": "checkpoint",
+          },
+          "hashes": [
+            "aGFzaA==",
+          ],
+          "logIndex": "0",
+          "rootHash": "cm9vdEhhc2g=",
+          "treeSize": "0",
+        },
+        "integratedTime": "2021-01-01T00:00:00Z",
+        "kindVersion": {
+          "kind": "kind",
+          "version": "version",
+        },
+        "logId": {
+          "keyId": "bG9nSWQ=",
+        },
+        "logIndex": "0",
+      },
+    ],
+    "x509CertificateChain": {
+      "certificates": [
+        {
+          "rawBytes": "Y2VydGlmaWNhdGU=",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`bundleToJSON SerializedMessageSignatureBundle matches the snapshot 1`] = `
+{
+  "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.1",
+  "messageSignature": {
+    "messageDigest": {
+      "algorithm": "SHA2_256",
+      "digest": "ZGlnZXN0",
+    },
+    "signature": "c2lnbmF0dXJl",
+  },
+  "verificationMaterial": {
+    "publicKey": {
+      "hint": "pki-hint",
+    },
+    "timestampVerificationData": {
+      "rfc3161Timestamps": [
+        {
+          "signedTimestamp": "c2lnbmVkVGltZXN0YW1w",
+        },
+      ],
+    },
+    "tlogEntries": [
+      {
+        "canonicalizedBody": "Ym9keQ==",
+        "inclusionPromise": {
+          "signedEntryTimestamp": "aW5jbHVzaW9uUHJvbWlzZQ==",
+        },
+        "inclusionProof": {
+          "checkpoint": {
+            "envelope": "checkpoint",
+          },
+          "hashes": [
+            "aGFzaA==",
+          ],
+          "logIndex": "0",
+          "rootHash": "cm9vdEhhc2g=",
+          "treeSize": "0",
+        },
+        "integratedTime": "2021-01-01T00:00:00Z",
+        "kindVersion": {
+          "kind": "kind",
+          "version": "version",
+        },
+        "logId": {
+          "keyId": "bG9nSWQ=",
+        },
+        "logIndex": "0",
+      },
+    ],
+  },
+}
+`;

--- a/packages/bundle/src/__tests__/index.test.ts
+++ b/packages/bundle/src/__tests__/index.test.ts
@@ -17,6 +17,7 @@ import { fromPartial } from '@total-typescript/shoehorn';
 import {
   BUNDLE_V01_MEDIA_TYPE,
   BUNDLE_V02_MEDIA_TYPE,
+  BUNDLE_V03_MEDIA_TYPE,
   Bundle,
   BundleLatest,
   BundleV01,
@@ -43,6 +44,7 @@ import {
   assertBundle,
   assertBundleLatest,
   assertBundleV01,
+  assertBundleV02,
   bundleFromJSON,
   bundleToJSON,
   envelopeFromJSON,
@@ -148,6 +150,7 @@ describe('public interface', () => {
     expect(assertBundle).toBeDefined();
     expect(assertBundleLatest).toBeDefined();
     expect(assertBundleV01).toBeDefined();
+    expect(assertBundleV02).toBeDefined();
   });
 
   it('exports serialization functions', () => {
@@ -160,6 +163,7 @@ describe('public interface', () => {
   it('exports constants', () => {
     expect(BUNDLE_V01_MEDIA_TYPE).toBeDefined();
     expect(BUNDLE_V02_MEDIA_TYPE).toBeDefined();
+    expect(BUNDLE_V03_MEDIA_TYPE).toBeDefined();
   });
 
   it('exports errors', () => {

--- a/packages/bundle/src/bundle.ts
+++ b/packages/bundle/src/bundle.ts
@@ -28,6 +28,9 @@ export const BUNDLE_V01_MEDIA_TYPE =
 export const BUNDLE_V02_MEDIA_TYPE =
   'application/vnd.dev.sigstore.bundle+json;version=0.2';
 
+export const BUNDLE_V03_MEDIA_TYPE =
+  'application/vnd.dev.sigstore.bundle+json;version=0.3';
+
 // Extract types that are not explicitly defined in the protobuf specs.
 type DsseEnvelopeContent = Extract<
   ProtoBundle['content'],

--- a/packages/bundle/src/index.ts
+++ b/packages/bundle/src/index.ts
@@ -17,6 +17,7 @@ export { toDSSEBundle, toMessageSignatureBundle } from './build';
 export {
   BUNDLE_V01_MEDIA_TYPE,
   BUNDLE_V02_MEDIA_TYPE,
+  BUNDLE_V03_MEDIA_TYPE,
   isBundleWithCertificateChain,
   isBundleWithDsseEnvelope,
   isBundleWithMessageSignature,
@@ -33,6 +34,7 @@ export {
   assertBundle,
   assertBundleLatest,
   assertBundleV01,
+  assertBundleV02,
   isBundleV01,
 } from './validate';
 

--- a/packages/bundle/src/serialized.ts
+++ b/packages/bundle/src/serialized.ts
@@ -14,19 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { Envelope, Bundle as ProtoBundle } from '@sigstore/protobuf-specs';
-import { BUNDLE_V01_MEDIA_TYPE, Bundle } from './bundle';
-import { assertBundle, assertBundleLatest, assertBundleV01 } from './validate';
+import { BUNDLE_V01_MEDIA_TYPE, BUNDLE_V02_MEDIA_TYPE, Bundle } from './bundle';
+import {
+  assertBundleLatest,
+  assertBundleV01,
+  assertBundleV02,
+} from './validate';
 
 import type { OneOf } from './utility';
 
 export const bundleFromJSON = (obj: unknown): Bundle => {
   const bundle = ProtoBundle.fromJSON(obj);
-  assertBundle(bundle);
-
-  if (bundle.mediaType === BUNDLE_V01_MEDIA_TYPE) {
-    assertBundleV01(bundle);
-  } else {
-    assertBundleLatest(bundle);
+  switch (bundle.mediaType) {
+    case BUNDLE_V01_MEDIA_TYPE:
+      assertBundleV01(bundle);
+      break;
+    case BUNDLE_V02_MEDIA_TYPE:
+      assertBundleV02(bundle);
+      break;
+    default:
+      assertBundleLatest(bundle);
+      break;
   }
 
   return bundle;
@@ -106,6 +114,7 @@ export type SerializedBundle = {
     | OneOf<{
         x509CertificateChain: { certificates: { rawBytes: string }[] };
         publicKey: { hint: string };
+        certificate: { rawBytes: string };
       }>
     | undefined
   ) & {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@sigstore/bundle": "^2.1.1",
     "@sigstore/core": "^1.0.0",
-    "@sigstore/protobuf-specs": "^0.2.1",
+    "@sigstore/protobuf-specs": "^0.3.0",
     "@sigstore/sign": "^2.2.2",
     "@sigstore/tuf": "^2.3.0",
     "@sigstore/verify": "^1.0.0"

--- a/packages/client/src/__tests__/__fixtures__/bundles/valid.ts
+++ b/packages/client/src/__tests__/__fixtures__/bundles/valid.ts
@@ -206,6 +206,75 @@ export const v2 = {
   },
 };
 
+export const v3 = {
+  messageSignature: {
+    withSigningCert: {
+      mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.3',
+      verificationMaterial: {
+        certificate: {
+          rawBytes:
+            'MIICoDCCAiagAwIBAgIUevae+nLQ8mg6OyOB43MKJ10F2CEwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjIxMTA5MDEzMzA5WhcNMjIxMTA5MDE0MzA5WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9DbYBIMQLtWb6J5gtL69jgRwwEfdtQtKvvG4+o3ZzlOroJplpXaVgF6wBDob++rNG9/AzSaBmApkEwI52XBjWqOCAUUwggFBMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUVIIFc08z6uV9Y96S+v5oDbbmHEYwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERYnJpYW5AZGVoYW1lci5jb20wLAYKKwYBBAGDvzABAQQeaHR0cHM6Ly9naXRodWIuY29tL2xvZ2luL29hdXRoMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGEWgUGQwAABAMARzBFAiEAlKycMBC2q+QM+mct60RNENxpURHes6vgOBWdx71XcXgCIAtnMzw/cBw5h0hrYJ8b1PJjoxn3k1N2TdgofqvMhbSTMAoGCCqGSM49BAMDA2gAMGUCMQC2KLFYSiD/+S1WEsyf9czf52w+E577Hi77r8pGUM1rQ/Bzg1aGvQs0/kAg3S/JSDgCMEdN5dIS0tRm1SOMbOFcW+1yzR+OiCVJ7DVFwUdI3D/7ERxtN9e/LJ6uaRnR/Sanrw==',
+        },
+        tlogEntries: [
+          {
+            logIndex: '6757503',
+            logId: { keyId: 'wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0=' },
+            kindVersion: { kind: 'hashedrekord', version: '0.0.1' },
+            integratedTime: '1667957590',
+            inclusionProof: {
+              logIndex: '2594072',
+              rootHash: 'kAnoYYy8iB3NjC5tE2l6pGBqY3uw3CBJ6x2cBBQXu0U=',
+              treeSize: '22954907',
+              hashes: [
+                'qEpgYkIiW7jVzbHp54MraVJQ1AE72Zvr5XSohvcdBN4=',
+                'wtdXKmzwBO1Lr1bY5gOXpVUiP0OxYRRa9ZodfVYRKw8=',
+                'ikD2dl7XVH3EKAPc6k21SYog5TYdwp/8DayXZ8Eedtw=',
+                '3oHeiTXTqKZMOpundZhKh4c6dznt7SdFj88Gog5DCYY=',
+                '4By9NfYQqHZOn5CusfRqIGw9/NeQr5E1nG4ICulNnUo=',
+                'p3BgRy0uSg6SRAqcKt8qXUIDhhJhox1tCAIaHdT5tac=',
+                'lJvUc0jjih3wNA1S7cbtw1q5HYX3JxYY5fO9ytPIKLU=',
+                '5vWL6hRP9EBDNAuXS3E236YUwutNv6qvIWTfcdzywFA=',
+                '1ODC3wToc5Hqky2sJQ2w3mBFggDWdZROOAv4MXWWLw0=',
+                'QqwionvWKT5a3Kqsx1UWIYDsBIMK7H+pvKZNon1g4A4=',
+                '9Ckxujk8Sg094zTRpBWmwd4ZWNT7W72H/S2JPKbZiBY=',
+                '/gKT0/YRP2WbANUct+sWMGGQ2a9lQlNFBb/XYAhb/j8=',
+                'f+eeYNJFCZRAI6IKsab+xTmMUl9g6Km2h6KUztMHpxM=',
+                'P8eLjDLaNzX9cTdqiFIKYjyVJv4cNwxPBh1Ppg8eDvM=',
+                '7NR456rTv4HEGWxCwUOTYm7ze69yMkqG4f8MbhE43oU=',
+                'Ul2YswjUyBqbJ3eka2zE0MI0QxT4ez8sCJ1Z3+vvMw8=',
+                'ucRPSmGLhm/SyHL7chQ5vBEFull08HzsqtAC0TQ91tY=',
+                'EiS8ntcvGnB1xcGZg9Cf3fTkV1wBcJNVtSWKIYVZqAU=',
+                'Mx1LEx7szsPd62CGkL6HM+NWkOy9YwZTwukJEVgH7Cw=',
+                's2Z13KVYurVY6F1AUhr8Uby4RE3RXW1XEC2tWWdzCjI=',
+                'QRfYxLEHh/FwMZqWnxNNW+x3lY7o3LM86BW+z0MpMN4=',
+                'J0dGjQ7V5bETi7p7eWg2ephCQ32QBLMWY5HxFcuGfR4=',
+                'uFGzOQorMYmYZ2yumLpgr1tvXvZaL+tTTCqaXa7Hdds=',
+                'Lksw/hm/y+1p33SaEF8/60gPvFVNkueBpDWJ1tAVcAo=',
+                'o4Smg8NUiGzxKxvvvgjtH2NV82EZSBLcUDUo9IpzS0Y=',
+              ],
+              checkpoint: {
+                envelope:
+                  'rekor.sigstore.dev - 2605736670972794746\n22954907\nkAnoYYy8iB3NjC5tE2l6pGBqY3uw3CBJ6x2cBBQXu0U=\nTimestamp: 1689107716054191855\n\n— rekor.sigstore.dev wNI9ajBFAiEA8OpuifHq4iqd6ZJSRiVQbe00eTdZllaQ51fgfAVxAPkCIDC64vV4bCtkn3S8CyMaTHHWgD2E/a+nm0eFBADK/LFP\n',
+              },
+            },
+            canonicalizedBody:
+              'eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI2OGU2NTZiMjUxZTY3ZTgzNThiZWY4NDgzYWIwZDUxYzY2MTlmM2U3YTFhOWYwZTc1ODM4ZDQxZmYzNjhmNzI4In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJSHM1YVV1bHExSHBSK2Z3bVNLcExrL29Bd3E1TzlDRE5GSGhaQUtmRzVHbUFpQndjVm5mMm9ienNDR1ZsZjBBSXZidkhyMjFOWHQ3dHBMQmw0K0JyaDZPS0E9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTnZSRU5EUVdsaFowRjNTVUpCWjBsVlpYWmhaU3R1VEZFNGJXYzJUM2xQUWpRelRVdEtNVEJHTWtORmQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1RucEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWpSM1NFRlpSRlpSVVVSRmVGWjZZVmRrZW1SSE9YbGFVekZ3WW01U2JBcGpiVEZzV2tkc2FHUkhWWGRJYUdOT1RXcEplRTFVUVRWTlJFVjZUWHBCTlZkb1kwNU5ha2w0VFZSQk5VMUVSVEJOZWtFMVYycEJRVTFHYTNkRmQxbElDa3R2V2tsNmFqQkRRVkZaU1V0dldrbDZhakJFUVZGalJGRm5RVVU1UkdKWlFrbE5VVXgwVjJJMlNqVm5kRXcyT1dwblVuZDNSV1prZEZGMFMzWjJSelFLSzI4elducHNUM0p2U25Cc2NGaGhWbWRHTm5kQ1JHOWlLeXR5VGtjNUwwRjZVMkZDYlVGd2EwVjNTVFV5V0VKcVYzRlBRMEZWVlhkblowWkNUVUUwUndwQk1WVmtSSGRGUWk5M1VVVkJkMGxJWjBSQlZFSm5UbFpJVTFWRlJFUkJTMEpuWjNKQ1owVkdRbEZqUkVGNlFXUkNaMDVXU0ZFMFJVWm5VVlZXU1VsR0NtTXdPSG8yZFZZNVdUazJVeXQyTlc5RVltSnRTRVZaZDBoM1dVUldVakJxUWtKbmQwWnZRVlV6T1ZCd2VqRlphMFZhWWpWeFRtcHdTMFpYYVhocE5Ga0tXa1E0ZDBoM1dVUldVakJTUVZGSUwwSkNWWGRGTkVWU1dXNUtjRmxYTlVGYVIxWnZXVmN4YkdOcE5XcGlNakIzVEVGWlMwdDNXVUpDUVVkRWRucEJRZ3BCVVZGbFlVaFNNR05JVFRaTWVUbHVZVmhTYjJSWFNYVlpNamwwVERKNGRsb3liSFZNTWpsb1pGaFNiMDFKUjB0Q1oyOXlRbWRGUlVGa1dqVkJaMUZEQ2tKSWQwVmxaMEkwUVVoWlFUTlVNSGRoYzJKSVJWUktha2RTTkdOdFYyTXpRWEZLUzFoeWFtVlFTek12YURSd2VXZERPSEEzYnpSQlFVRkhSVmRuVlVjS1VYZEJRVUpCVFVGU2VrSkdRV2xGUVd4TGVXTk5Ra015Y1N0UlRTdHRZM1EyTUZKT1JVNTRjRlZTU0dWek5uWm5UMEpYWkhnM01WaGpXR2REU1VGMGJncE5lbmN2WTBKM05XZ3dhSEpaU2poaU1WQkthbTk0YmpOck1VNHlWR1JuYjJaeGRrMW9ZbE5VVFVGdlIwTkRjVWRUVFRRNVFrRk5SRUV5WjBGTlIxVkRDazFSUXpKTFRFWlpVMmxFTHl0VE1WZEZjM2xtT1dONlpqVXlkeXRGTlRjM1NHazNOM0k0Y0VkVlRURnlVUzlDZW1jeFlVZDJVWE13TDJ0Qlp6TlRMMG9LVTBSblEwMUZaRTQxWkVsVE1IUlNiVEZUVDAxaVQwWmpWeXN4ZVhwU0swOXBRMVpLTjBSV1JuZFZaRWt6UkM4M1JWSjRkRTQ1WlM5TVNqWjFZVkp1VWdvdlUyRnVjbmM5UFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PSJ9fX19',
+          },
+        ],
+        timestampVerificationData: { rfc3161Timestamps: [] },
+      },
+      messageSignature: {
+        messageDigest: {
+          algorithm: 'SHA2_256',
+          digest: 'aOZWslHmfoNYvvhIOrDVHGYZ8+ehqfDnWDjUH/No9yg=',
+        },
+        signature:
+          'MEQCIHs5aUulq1HpR+fwmSKpLk/oAwq5O9CDNFHhZAKfG5GmAiBwcVnf2obzsCGVlf0AIvbvHr21NXt7tpLBl4+Brh6OKA==',
+      },
+    },
+  },
+};
+
 export const artifact = Buffer.from('hello, world!');
 
 export const publicKeys: Record<string, string> = {

--- a/packages/client/src/__tests__/sigstore.test.ts
+++ b/packages/client/src/__tests__/sigstore.test.ts
@@ -187,6 +187,19 @@ describe('#verify', () => {
     });
   });
 
+  describe('when the bundle is a valid v0.3 message signature bundle with signing certificate', () => {
+    const bundle: SerializedBundle = fromPartial(
+      validBundles.v3.messageSignature.withSigningCert
+    );
+    const artifact = validBundles.artifact;
+
+    it('does not throw an error', async () => {
+      await expect(verify(bundle, artifact, tufOptions)).resolves.toBe(
+        undefined
+      );
+    });
+  });
+
   describe('when there is a signature mismatch', () => {
     const bundle: SerializedBundle = fromPartial(
       validBundles.v1.messageSignature.withSigningCert
@@ -213,12 +226,12 @@ describe('#verify', () => {
     });
   });
 
-  describe('when the bundle is newer then v0.2', () => {
-    // Check a theoretical v0.3 bundle that is the same shape as a v0.2 bundle
+  describe('when the bundle is newer then v0.3', () => {
+    // Check a theoretical v0.4 bundle that is the same shape as a v0.3 bundle
     const bundle: SerializedBundle = fromPartial({
-      ...validBundles.v2.messageSignature.withSigningCert,
+      ...validBundles.v3.messageSignature.withSigningCert,
     });
-    bundle.mediaType = 'application/vnd.dev.sigstore.bundle+json;version=0.3';
+    bundle.mediaType = 'application/vnd.dev.sigstore.bundle+json;version=0.4';
 
     const artifact = validBundles.artifact;
 

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@oclif/core": "^3",
     "@sigstore/bundle": "^2.1.1",
-    "@sigstore/protobuf-specs": "^0.2.1",
+    "@sigstore/protobuf-specs": "^0.3.0",
     "@sigstore/verify": "^1.0.0",
     "sigstore": "^2.2.1"
   },

--- a/packages/conformance/src/commands/verify.ts
+++ b/packages/conformance/src/commands/verify.ts
@@ -69,6 +69,7 @@ function toBundle(
       x509CertificateChain: {
         certificates: [{ rawBytes: certBytes.toString('base64') }],
       },
+      certificate: undefined,
       publicKey: undefined,
       tlogEntries: [],
       timestampVerificationData: undefined,

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@peculiar/webcrypto": "^1.4.5",
     "@peculiar/x509": "^1.9.7",
-    "@sigstore/protobuf-specs": "^0.2.1",
+    "@sigstore/protobuf-specs": "^0.3.0",
     "asn1js": "^3.0.5",
     "bytestreamjs": "^2.0.1",
     "canonicalize": "^2.0.0",

--- a/packages/sign/package.json
+++ b/packages/sign/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@sigstore/bundle": "^2.1.1",
     "@sigstore/core": "^1.0.0",
-    "@sigstore/protobuf-specs": "^0.2.1",
+    "@sigstore/protobuf-specs": "^0.3.0",
     "make-fetch-happen": "^13.0.0"
   },
   "engines": {

--- a/packages/tuf/package.json
+++ b/packages/tuf/package.json
@@ -32,7 +32,7 @@
     "@types/make-fetch-happen": "^10.0.4"
   },
   "dependencies": {
-    "@sigstore/protobuf-specs": "^0.2.1",
+    "@sigstore/protobuf-specs": "^0.3.0",
     "tuf-js": "^2.2.0"
   },
   "engines": {

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -26,7 +26,7 @@
     "provenance": true
   },
   "dependencies": {
-    "@sigstore/protobuf-specs": "^0.2.1",
+    "@sigstore/protobuf-specs": "^0.3.0",
     "@sigstore/bundle": "^2.1.1",
     "@sigstore/core": "^1.0.0"
   },

--- a/packages/verify/src/__tests__/__fixtures__/bundles.ts
+++ b/packages/verify/src/__tests__/__fixtures__/bundles.ts
@@ -187,6 +187,39 @@ export const V1 = {
   },
 };
 
+export const V3 = {
+  MESSAGE_SIGNATURE: {
+    WITH_SIGNING_CERT: {
+      mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.3',
+      verificationMaterial: {
+        certificate: {
+          rawBytes:
+            'MIICoDCCAiagAwIBAgIUevae+nLQ8mg6OyOB43MKJ10F2CEwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjIxMTA5MDEzMzA5WhcNMjIxMTA5MDE0MzA5WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9DbYBIMQLtWb6J5gtL69jgRwwEfdtQtKvvG4+o3ZzlOroJplpXaVgF6wBDob++rNG9/AzSaBmApkEwI52XBjWqOCAUUwggFBMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUVIIFc08z6uV9Y96S+v5oDbbmHEYwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wHwYDVR0RAQH/BBUwE4ERYnJpYW5AZGVoYW1lci5jb20wLAYKKwYBBAGDvzABAQQeaHR0cHM6Ly9naXRodWIuY29tL2xvZ2luL29hdXRoMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGEWgUGQwAABAMARzBFAiEAlKycMBC2q+QM+mct60RNENxpURHes6vgOBWdx71XcXgCIAtnMzw/cBw5h0hrYJ8b1PJjoxn3k1N2TdgofqvMhbSTMAoGCCqGSM49BAMDA2gAMGUCMQC2KLFYSiD/+S1WEsyf9czf52w+E577Hi77r8pGUM1rQ/Bzg1aGvQs0/kAg3S/JSDgCMEdN5dIS0tRm1SOMbOFcW+1yzR+OiCVJ7DVFwUdI3D/7ERxtN9e/LJ6uaRnR/Sanrw==',
+        },
+        publicKey: undefined,
+        tlogEntries: [],
+        timestampVerificationData: {
+          rfc3161Timestamps: [
+            {
+              signedTimestamp:
+                'MIICGzADAgEAMIICEgYJKoZIhvcNAQcCoIICAzCCAf8CAQMxDzANBglghkgBZQMEAgEFADB0BgsqhkiG9w0BCRABBKBlBGMwYQIBAQYJKwYBBAGDvzACMC8wCwYJYIZIAWUDBAIBBCDmiqdzQcICC79XXKmJ6Tio5Y2InXXhHYJiPWa1wH41jwIE3q2+7xgPMjAyMjExMDkwMTMzMTBaMAMCAQECBEmWAtKgADGCAW8wggFrAgEBMCswJjEMMAoGA1UEAxMDdHNhMRYwFAYDVQQKEw1zaWdzdG9yZS5tb2NrAgECMA0GCWCGSAFlAwQCAQUAoIHVMBoGCSqGSIb3DQEJAzENBgsqhkiG9w0BCRABBDAcBgkqhkiG9w0BCQUxDxcNMjIxMTA5MDEzMzEwWjAvBgkqhkiG9w0BCQQxIgQgZx9+Ame0IZus+o96m68edvjYBYiaQv7TwAl1ho90DGUwaAYLKoZIhvcNAQkQAi8xWTBXMFUwUwQg7xanBUbnZqL3LxnHaWKqwHet5zHHqi3CPzwetDjqMeswLzAqpCgwJjEMMAoGA1UEAxMDdHNhMRYwFAYDVQQKEw1zaWdzdG9yZS5tb2NrAgECMAoGCCqGSM49BAMCBEYwRAIgeu0BWwKYClpH2YaA7A4wPkj6atP+m1piVZArHQ7S7YcCIHFZVJbexBdMjBTyNZwaAd12M6Ks0VSm87uT2iGoXFN7',
+            },
+          ],
+        },
+      },
+      messageSignature: {
+        messageDigest: {
+          algorithm: 'SHA2_256',
+          digest: 'aOZWslHmfoNYvvhIOrDVHGYZ8+ehqfDnWDjUH/No9yg=',
+        },
+        signature:
+          'MEQCIHs5aUulq1HpR+fwmSKpLk/oAwq5O9CDNFHhZAKfG5GmAiBwcVnf2obzsCGVlf0AIvbvHr21NXt7tpLBl4+Brh6OKA==',
+      },
+      dsseEnvelope: undefined,
+    },
+  },
+};
+
 // Public key material for verifying the key-signed bundles
 export const PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9DbYBIMQLtWb6J5gtL69jgRwwEfd

--- a/packages/verify/src/__tests__/bundle/index.test.ts
+++ b/packages/verify/src/__tests__/bundle/index.test.ts
@@ -74,4 +74,23 @@ describe('toSignedEntity', () => {
       expect(entity.timestamps).toHaveLength(2);
     });
   });
+
+  describe('when the bundle is v03', () => {
+    const bundle = bundleFromJSON(
+      bundles.V3.MESSAGE_SIGNATURE.WITH_SIGNING_CERT
+    );
+
+    it('returns a SignedEntity', () => {
+      const entity = toSignedEntity(bundle);
+
+      expect(entity).toBeDefined();
+
+      assert(entity.key.$case === 'certificate');
+      expect(entity.key.certificate).toBeInstanceOf(X509Certificate);
+
+      expect(entity.signature).toBeDefined();
+      expect(entity.tlogEntries).toHaveLength(0);
+      expect(entity.timestamps).toHaveLength(1);
+    });
+  });
 });

--- a/packages/verify/src/__tests__/verifier.test.ts
+++ b/packages/verify/src/__tests__/verifier.test.ts
@@ -86,6 +86,22 @@ describe('Verifier', () => {
       });
     });
 
+    describe('when the certificate-signed message signature v3 bundle is valid', () => {
+      const subject = new Verifier(trustMaterial, {
+        ctlogThreshold: 1,
+        tlogThreshold: 0,
+        tsaThreshold: 1,
+      });
+      const bundle = bundleFromJSON(
+        bundles.V3.MESSAGE_SIGNATURE.WITH_SIGNING_CERT
+      );
+      const signedEntity = toSignedEntity(bundle, bundles.ARTIFACT);
+
+      it('returns without error', () => {
+        subject.verify(signedEntity);
+      });
+    });
+
     describe('when the a matching policy is specified', () => {
       const bundle = bundleFromJSON(
         bundles.V1.MESSAGE_SIGNATURE.WITH_SIGNING_CERT

--- a/packages/verify/src/bundle/index.ts
+++ b/packages/verify/src/bundle/index.ts
@@ -85,5 +85,12 @@ function key(bundle: Bundle): VerificationKey {
             .certificates[0].rawBytes
         ),
       };
+    case 'certificate':
+      return {
+        $case: 'certificate',
+        certificate: X509Certificate.parse(
+          bundle.verificationMaterial.content.certificate.rawBytes
+        ),
+      };
   }
 }


### PR DESCRIPTION
Add support for the new v0.3 bundle version (see https://github.com/sigstore/protobuf-specs/pull/213).

This change will ensure that we can verify v0.3 bundles, but does not yet generate v0.3 bundles.