### PR TITLE
load TUF seeds via require not require.resolve

### DIFF
--- a/.changeset/lovely-waves-hug.md
+++ b/.changeset/lovely-waves-hug.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/tuf": patch
+---
+
+Load TUF seeds via `require` instead of `require.resolve`

--- a/packages/tuf/src/client.ts
+++ b/packages/tuf/src/client.ts
@@ -23,7 +23,6 @@ import type { MakeFetchHappenOptions } from 'make-fetch-happen';
 
 export type Retry = MakeFetchHappenOptions['retry'];
 
-const TUF_SEEDS_PATH = require.resolve('../seeds.json');
 const TARGETS_DIR_NAME = 'targets';
 
 type RepoSeed = {
@@ -125,10 +124,8 @@ function seedCache({
     if (tufRootPath) {
       fs.copyFileSync(tufRootPath, cachedRootPath);
     } else {
-      // Load the embedded repo seeds
-      const seeds: RepoSeeds = JSON.parse(
-        fs.readFileSync(TUF_SEEDS_PATH).toString('utf-8')
-      );
+      /* eslint-disable @typescript-eslint/no-var-requires */
+      const seeds: RepoSeeds = require('../seeds.json');
       const repoSeed = seeds[mirrorURL];
 
       if (!repoSeed) {


### PR DESCRIPTION
Closes #989 

This pull request includes changes to how the TUF seeds are loaded in the `packages/tuf/src/client.ts` file. The most important change is the switch from using `require.resolve` to using `require` to load the seeds. 
