### PR TITLE
remove docker hub from oci artifact downgrade list

### DIFF
--- a/.changeset/large-beds-brush.md
+++ b/.changeset/large-beds-brush.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/oci": minor
+---
+
+Remove Docker Hub from list of registries which are not compatible with OCI v1.1.0 image spec

--- a/packages/oci/src/image.ts
+++ b/packages/oci/src/image.ts
@@ -28,7 +28,7 @@ import type { Descriptor, ImageIndex, ImageManifest } from './types';
 
 const EMPTY_BLOB = Buffer.from('{}');
 
-const DOWNGRADE_REGISTRIES = ['docker.io', 'amazonaws.com'];
+const DOWNGRADE_REGISTRIES = ['amazonaws.com'];
 
 export type AddArtifactOptions = {
   readonly artifact: Buffer;


### PR DESCRIPTION
Recent re-testing against the Docker Hub registry shows that it now supports OCI 1.1 compliant artifact management.

This change removes Docker Hub from the list of registries that would trigger a downgrade of the artifact manifest published when uploading an attestation bundle.