### PR TITLE
include subject/artifactType in ECR manifest

### DIFF
--- a/.changeset/clean-chefs-impress.md
+++ b/.changeset/clean-chefs-impress.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/oci": minor
+---
+
+Include `subject` and `artifactType` fields in artifact manifest for AWS ECR

--- a/packages/oci/src/image.ts
+++ b/packages/oci/src/image.ts
@@ -90,20 +90,15 @@ export class OCIImage {
 
       /* istanbul ignore if */
       if (this.#downgrade) {
-        delete manifest.subject;
-        delete manifest.artifactType;
-
         // ECR can't handle media types with parameters, so we need to strip the
         // version parameter from the Sigstore bundle media type.
+        manifest.artifactType = manifest.artifactType
+          ? manifest.artifactType.replace(/;.*/, '')
+          : undefined;
         manifest.layers[0].mediaType = manifest.layers[0].mediaType.replace(
           /;.*/,
           ''
         );
-
-        // ECR can't handle the "application/vnd.oci.empty.v1+json" media type
-        // for the config blob defined in OCI 1.1, so we need to use the Docker
-        // V2 API media type
-        manifest.config.mediaType = 'application/vnd.oci.image.config.v1+json';
       }
 
       // Upload artifact manifest


### PR DESCRIPTION
Updates the AWS ECR specific code for pushing artifacts into the registry. Previously, we had to dumb-down the artifact manifest when pushing to ECR due to compatibility issues with this registry. It seems that some of the previous issues have been resolved and we can add back fields like `subject` and `artifactType` to the manifest.

The issue of ECR not accepting content types which contain a `;` character remains so we still need to do some transformation of the Sigstore bundle type before uploading the manifest to ECR.