### PR TITLE
add new attach command to cli

### DIFF
--- a/.changeset/wet-spoons-end.md
+++ b/.changeset/wet-spoons-end.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/cli": minor
+---
+
+Add new `attach` command for pushing attestations to an OCI registry

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,7 +9,7 @@ $ npm install -g @sigstore/cli
 $ sigstore COMMAND
 running command...
 $ sigstore (--version)
-@sigstore/cli/0.5.0 darwin-arm64 node-v18.12.1
+@sigstore/cli/0.6.0 darwin-arm64 node-v18.12.1
 $ sigstore --help [COMMAND]
 USAGE
   $ sigstore COMMAND
@@ -18,10 +18,36 @@ USAGE
 <!-- usagestop -->
 # Commands
 <!-- commands -->
+* [`sigstore attach IMAGE-URI`](#sigstore-attach-image-uri)
 * [`sigstore attest FILE`](#sigstore-attest-file)
-* [`sigstore help [COMMANDS]`](#sigstore-help-commands)
+* [`sigstore help [COMMAND]`](#sigstore-help-command)
 * [`sigstore initialize`](#sigstore-initialize)
 * [`sigstore verify BUNDLE`](#sigstore-verify-bundle)
+
+## `sigstore attach IMAGE-URI`
+
+attach an attestation to a container image
+
+```
+USAGE
+  $ sigstore attach IMAGE-URI --attestation <value> [-u <value> -p <value>]
+
+ARGUMENTS
+  IMAGE-URI  fully qualified URI to the image
+
+FLAGS
+  -p, --password=<value>     password for the registry
+  -u, --username=<value>     username for the registry
+      --attestation=<value>  (required) attestation bundle to attach
+
+DESCRIPTION
+  attach an attestation to a container image
+
+EXAMPLES
+  $ sigstore attach --attestation <file> <name>{:<tag>|@<digest>}
+```
+
+
 
 ## `sigstore attest FILE`
 
@@ -63,16 +89,16 @@ EXAMPLES
 
 
 
-## `sigstore help [COMMANDS]`
+## `sigstore help [COMMAND]`
 
 Display help for sigstore.
 
 ```
 USAGE
-  $ sigstore help [COMMANDS] [-n]
+  $ sigstore help [COMMAND] [-n]
 
 ARGUMENTS
-  COMMANDS  Command to show help for.
+  COMMAND  Command to show help for.
 
 FLAGS
   -n, --nested-commands  Include all nested commands in the output.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
     "@oclif/color": "^1.0.13",
     "@oclif/core": "^3",
     "@oclif/plugin-help": "^6",
+    "@sigstore/oci": "^0.1.0",
     "open": "^8.4.2",
     "openid-client": "^5.6.5",
     "sigstore": "^2.2.0"

--- a/packages/cli/src/__tests__/oci/name.test.ts
+++ b/packages/cli/src/__tests__/oci/name.test.ts
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { parseImageName } from '../../oci/name';
+
+describe('parseImageName', () => {
+  it('parses a fully-quallified image names', () => {
+    let name = parseImageName('ghcr.io/owner/repo:latest');
+    expect(name.name).toEqual('ghcr.io/owner/repo');
+    expect(name.tag).toEqual('latest');
+    expect(name.digest).toBeUndefined();
+
+    name = parseImageName(
+      'ghcr.io/repo@sha1:f99c369892016a1f48a2eee9e69eaf96614b7281'
+    );
+    expect(name.name).toEqual('ghcr.io/repo');
+    expect(name.digest).toEqual(
+      'sha1:f99c369892016a1f48a2eee9e69eaf96614b7281'
+    );
+    expect(name.tag).toBeUndefined();
+
+    name = parseImageName('localhost:8080/repo:_foo');
+    expect(name.name).toEqual('localhost:8080/repo');
+    expect(name.tag).toEqual('_foo');
+    expect(name.digest).toBeUndefined();
+
+    name = parseImageName(
+      'a/b/c/d@sha256:62ce42bde6b4ba3aa0c42aa375025015b639b142c9b4daf89fcd422fc75f4a13'
+    );
+    expect(name.name).toEqual('a/b/c/d');
+    expect(name.digest).toEqual(
+      'sha256:62ce42bde6b4ba3aa0c42aa375025015b639b142c9b4daf89fcd422fc75f4a13'
+    );
+    expect(name.tag).toBeUndefined();
+  });
+
+  it('raises an error when the image name is invalid', () => {
+    expect(() => parseImageName('repo')).toThrow();
+    expect(() => parseImageName('')).toThrow();
+    expect(() => parseImageName('a/b/c/d:-000')).toThrow();
+    expect(() => parseImageName('a/b/c/d:.')).toThrow();
+    expect(() =>
+      parseImageName('a/b/c/d:sha1:f99c369892016a1f48a2eee9e69eaf96614b7281')
+    ).toThrow();
+  });
+});

--- a/packages/cli/src/commands/attach.ts
+++ b/packages/cli/src/commands/attach.ts
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { Args, Command, Flags } from '@oclif/core';
+import { bundleFromJSON } from '@sigstore/bundle';
+import {
+  Credentials,
+  attachArtifactToImage,
+  getImageDigest,
+  getRegistryCredentials,
+} from '@sigstore/oci';
+import * as fs from 'fs/promises';
+import { ImageRef, parseImageName } from '../oci/name';
+
+export default class Attach extends Command {
+  static override description = 'attach an attestation to a container image';
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> --attestation <file> <name>{:<tag>|@<digest>}',
+  ];
+
+  static override flags = {
+    attestation: Flags.file({
+      description: 'attestation bundle to attach',
+      required: true,
+      allowStdin: true,
+    }),
+    username: Flags.string({
+      description: 'username for the registry',
+      required: false,
+      char: 'u',
+      dependsOn: ['password'],
+    }),
+    password: Flags.string({
+      description: 'password for the registry',
+      required: false,
+      char: 'p',
+      dependsOn: ['username'],
+    }),
+  };
+
+  static override args = {
+    'image-uri': Args.string({
+      description: 'fully qualified URI to the image',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<void> {
+    const { args, flags } = await this.parse(Attach);
+
+    // Grab the attestation
+    const artifact = await fs.readFile(flags['attestation']);
+    const bundle = bundleFromJSON(JSON.parse(artifact.toString()));
+
+    // Parse the image reference
+    const imageRef = parseImageName(args['image-uri']);
+
+    // Collect credentials either from flags or from the Docker config
+    const credentials =
+      flags['username'] && flags['password']
+        ? { username: flags['username'], password: flags['password'] }
+        : this.getRegistryCredentials(imageRef.name);
+
+    const imageDigest = await this.getImageDigest(imageRef, credentials);
+
+    const descriptor = await attachArtifactToImage({
+      imageName: imageRef.name,
+      imageDigest,
+      credentials,
+      artifact,
+      mediaType: bundle.mediaType,
+    });
+
+    this.logToStderr('Artifact attached to image:', descriptor.digest);
+  }
+
+  private getRegistryCredentials(imageName: string): Credentials {
+    try {
+      const credentials = getRegistryCredentials(imageName);
+
+      if (!credentials.username || !credentials.password) {
+        throw new Error('No credentials found for registry');
+      }
+      return credentials;
+    } catch (err) {
+      throw new Error(
+        'Error getting registry credentials. Make sure you are authenticated.'
+      );
+    }
+  }
+
+  private async getImageDigest(
+    imageRef: ImageRef,
+    credentials: Credentials
+  ): Promise<string> {
+    if (imageRef.digest) {
+      return imageRef.digest;
+    } else if (imageRef.tag) {
+      return getImageDigest({
+        credentials,
+        imageName: imageRef.name,
+        imageTag: imageRef.tag,
+      });
+    } else {
+      throw new Error('No digest found for image');
+    }
+  }
+}

--- a/packages/cli/src/oci/name.ts
+++ b/packages/cli/src/oci/name.ts
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export type ImageRef = {
+  name: string;
+  tag?: string;
+  digest?: string;
+};
+
+const expression = (...res: string[]): string => res.join('');
+const group = (...res: string[]): string => `(?:${expression(...res)})`;
+const repeated = (...res: string[]): string => `${group(expression(...res))}+`;
+const optional = (...res: string[]): string => `${group(expression(...res))}?`;
+const capture = (...res: string[]): string => `(${expression(...res)})`;
+const anchored = (...res: string[]): string => `^${expression(...res)}$`;
+
+// Lower case letters, numbers
+const ALPHA_NUMERIC_RE = '[a-z0-9]+';
+
+// Separators allowed to be embedded in name components. This allows one period,
+// one or two underscore or multiple dashes.
+const SEPARATOR_RE = group('\\.|_|__|-+');
+
+const TAG_RE = '[\\w][\\w.-]{0,127}';
+
+const DIGEST_RE =
+  '[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][A-Fa-f0-9]{32,}';
+
+// Registry path component names to start with at least one letter or number,
+// with following parts able to be separated by one period, one or two
+// underscores or multiple dashes.
+const NAME_COMPONENT_RE = expression(
+  ALPHA_NUMERIC_RE,
+  optional(repeated(SEPARATOR_RE, ALPHA_NUMERIC_RE))
+);
+
+const NAME_RE = expression(
+  NAME_COMPONENT_RE,
+  repeated(optional('\\/', NAME_COMPONENT_RE))
+);
+
+// Component of the registry domain must be at least one letter or number, with
+// following parts able to be separated by a dash.
+const DOMAIN_COMPONENT_RE = group(
+  '[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]'
+);
+
+// Restricts the registry domain to be one or more period separated components
+// followed by an optional port.
+const DOMAIN_RE = expression(
+  DOMAIN_COMPONENT_RE,
+  optional(repeated('\\.', DOMAIN_COMPONENT_RE)),
+  optional(':[0-9]+')
+);
+
+const ANCHORED_IMAGE_REF_RE = anchored(
+  capture(expression(DOMAIN_RE, '\\/', NAME_RE)),
+  optional('[:]' + capture(TAG_RE)),
+  optional('[@]' + capture(DIGEST_RE))
+);
+
+// Parses a fully qualified image name into its registry and path components.
+export const parseImageName = (image: string): ImageRef => {
+  const matches = image.match(ANCHORED_IMAGE_REF_RE);
+
+  if (!matches) {
+    throw new Error(`Invalid image name: ${image}`);
+  }
+
+  return {
+    name: matches[1],
+    tag: matches[2],
+    digest: matches[3],
+  };
+};

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "exclude": ["./dist"],
   "references": [
-    { "path": "../client" }
+    { "path": "../client" },
+    { "path": "../oci" }
   ]
 }


### PR DESCRIPTION
Adds a new `attach` command to the CLI which can be used to push a Sigstore attestation bundle to an OCI registry and associated it with a container image.