### PR TITLE
fix bug in mediatype regex

### DIFF
--- a/.changeset/cyan-chairs-mate.md
+++ b/.changeset/cyan-chairs-mate.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/bundle": patch
+---
+
+Fix bug in regex for matching media types

--- a/packages/bundle/src/__tests__/validate.test.ts
+++ b/packages/bundle/src/__tests__/validate.test.ts
@@ -768,7 +768,7 @@ describe('assertBundleV02', () => {
 describe('assertBundleLatest', () => {
   describe('when verification material is a certificate chain', () => {
     const bundle: Bundle = fromPartial({
-      mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.3',
+      mediaType: 'application/vnd.dev.sigstore.bundle.v0.3+json',
       verificationMaterial: {
         content: {
           $case: 'x509CertificateChain',
@@ -801,7 +801,7 @@ describe('assertBundleLatest', () => {
 
   describe('when verification certificate is missing', () => {
     const bundle: Bundle = fromPartial({
-      mediaType: 'application/vnd.dev.sigstore.bundle+json;version=0.3',
+      mediaType: 'application/vnd.dev.sigstore.bundle.v0.3+json',
       verificationMaterial: {
         content: {
           $case: 'certificate',

--- a/packages/bundle/src/validate.ts
+++ b/packages/bundle/src/validate.ts
@@ -84,7 +84,7 @@ function validateBundleBase(b: ProtoBundle): string[] {
       /^application\/vnd\.dev\.sigstore\.bundle\+json;version=\d\.\d/
     ) &&
       !b.mediaType.match(
-        /^application\/vnd\.dev\.sigstore\.bundle\.v\d\.\d+json/
+        /^application\/vnd\.dev\.sigstore\.bundle\.v\d\.\d\+json/
       ))
   ) {
     invalidValues.push('mediaType');


### PR DESCRIPTION
Fixes a bug in the regular expression used to detect valid media types for sigstore bundles.

This bug impacts only media type values using the new format introduced with the v0.3 bundle type.