### PR TITLE
cli support for v0.3 bundles

### DIFF
--- a/.changeset/thick-buttons-tell.md
+++ b/.changeset/thick-buttons-tell.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/cli": minor
+---
+
+Update `verify` command to verify v0.3 Sigstore bundles

--- a/.changeset/warm-snakes-fetch.md
+++ b/.changeset/warm-snakes-fetch.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/cli": minor
+---
+
+Update `attest` command to generate v0.3 Sigstore bundles

--- a/package-lock.json
+++ b/package-lock.json
@@ -35454,10 +35454,12 @@
         "@oclif/color": "^1.0.13",
         "@oclif/core": "^3",
         "@oclif/plugin-help": "^6",
+        "@sigstore/bundle": "^2.3.1",
         "@sigstore/oci": "^0.3.0",
+        "@sigstore/sign": "^2.3.0",
         "open": "^8.4.2",
         "openid-client": "^5.6.5",
-        "sigstore": "^2.2.0"
+        "sigstore": "^2.3.0"
       },
       "bin": {
         "sigstore": "bin/run"
@@ -35472,9 +35474,20 @@
         "node": ">=18.0.0"
       }
     },
+    "packages/cli/node_modules/@sigstore/bundle": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.1.tgz",
+      "integrity": "sha512-eqV17lO3EIFqCWK3969Rz+J8MYrRZKw9IBHpSo6DEcEX2c+uzDFOgHE9f2MnyDpfs48LFO4hXmk9KhQ74JzU1g==",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.3.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "packages/client": {
       "name": "sigstore",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^2.3.1",
@@ -53480,14 +53493,26 @@
         "@oclif/color": "^1.0.13",
         "@oclif/core": "^3",
         "@oclif/plugin-help": "^6",
+        "@sigstore/bundle": "^2.3.1",
         "@sigstore/oci": "^0.3.0",
+        "@sigstore/sign": "^2.3.0",
         "make-fetch-happen": "^13.0.0",
         "oclif": "^4",
         "open": "^8.4.2",
         "openid-client": "^5.6.5",
-        "sigstore": "^2.2.0",
+        "sigstore": "^2.3.0",
         "ts-node": "^10.9.2",
         "tslib": "^2.6.1"
+      },
+      "dependencies": {
+        "@sigstore/bundle": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.1.tgz",
+          "integrity": "sha512-eqV17lO3EIFqCWK3969Rz+J8MYrRZKw9IBHpSo6DEcEX2c+uzDFOgHE9f2MnyDpfs48LFO4hXmk9KhQ74JzU1g==",
+          "requires": {
+            "@sigstore/protobuf-specs": "^0.3.1"
+          }
+        }
       }
     },
     "@sigstore/conformance": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,7 +9,7 @@ $ npm install -g @sigstore/cli
 $ sigstore COMMAND
 running command...
 $ sigstore (--version)
-@sigstore/cli/0.6.0 darwin-arm64 node-v18.12.1
+@sigstore/cli/0.7.1 darwin-arm64 node-v20.8.1
 $ sigstore --help [COMMAND]
 USAGE
   $ sigstore COMMAND
@@ -95,10 +95,10 @@ Display help for sigstore.
 
 ```
 USAGE
-  $ sigstore help [COMMAND] [-n]
+  $ sigstore help [COMMAND...] [-n]
 
 ARGUMENTS
-  COMMAND  Command to show help for.
+  COMMAND...  Command to show help for.
 
 FLAGS
   -n, --nested-commands  Include all nested commands in the output.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,10 +35,12 @@
     "@oclif/color": "^1.0.13",
     "@oclif/core": "^3",
     "@oclif/plugin-help": "^6",
+    "@sigstore/bundle": "^2.3.1",
     "@sigstore/oci": "^0.3.0",
+    "@sigstore/sign": "^2.3.0",
     "open": "^8.4.2",
     "openid-client": "^5.6.5",
-    "sigstore": "^2.2.0"
+    "sigstore": "^2.3.0"
   },
   "devDependencies": {
     "make-fetch-happen": "^13.0.0",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -7,7 +7,9 @@
   },
   "exclude": ["./dist"],
   "references": [
+    { "path": "../bundle" },
     { "path": "../client" },
-    { "path": "../oci" }
+    { "path": "../oci" },
+    { "path": "../sign" }
   ]
 }


### PR DESCRIPTION
Updates `@sigstore/cli` with support for generating and verify v0.3 Sigstore bundles.

Note that the `attest` command is no longer using the main `sigstore` client to do signing, instead opting to use the `@sigstore/sign` library directly. This change allows us to force the creation of v0.3 bundles (the default in the `sigstore` library is still to output v0.2 bundles to maintain compat with npm).