### PR TITLE
fix retry bug when calling oci apis

### DIFF
--- a/.changeset/tender-starfishes-turn.md
+++ b/.changeset/tender-starfishes-turn.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/oci": patch
+---
+
+Fix bug preventing failed API requests from being retried

--- a/package-lock.json
+++ b/package-lock.json
@@ -16798,7 +16798,8 @@
       "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "make-fetch-happen": "^13.0.1"
+        "make-fetch-happen": "^13.0.1",
+        "proc-log": "^4.2.0"
       },
       "devDependencies": {
         "@types/make-fetch-happen": "^10.0.4"

--- a/packages/oci/package.json
+++ b/packages/oci/package.json
@@ -29,7 +29,8 @@
     "@types/make-fetch-happen": "^10.0.4"
   },
   "dependencies": {
-    "make-fetch-happen": "^13.0.1"
+    "make-fetch-happen": "^13.0.1",
+    "proc-log": "^4.2.0"
   },
   "engines": {
     "node": "^16.14.0 || >=18.0.0"

--- a/packages/oci/src/__tests__/fetch.test.ts
+++ b/packages/oci/src/__tests__/fetch.test.ts
@@ -1,0 +1,280 @@
+/*
+Copyright 2024 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import nock from 'nock';
+import fetch from '../fetch';
+
+describe('fetch', () => {
+  const baseURL = 'https://example.com';
+  const path = '/foo/bar';
+  const url = `${baseURL}${path}`;
+  const responseBody = { greeting: 'hello' };
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('when the request is successful', () => {
+    let scope: nock.Scope;
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+    const body = JSON.stringify({ foo: 'bar' });
+
+    beforeEach(() => {
+      scope = nock(baseURL)
+        .post(path, body)
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('accept', 'application/json')
+
+        .reply(200, responseBody);
+    });
+
+    it('calls fetch with the correct arguments', async () => {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body,
+        retry: false,
+      });
+
+      expect(await response.json()).toEqual(responseBody);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('when there are no fetch options', () => {
+    let scope: nock.Scope;
+
+    beforeEach(() => {
+      scope = nock(baseURL).get(path).reply(200, responseBody);
+    });
+
+    it('calls fetch with the correct arguments', async () => {
+      const response = await fetch(url);
+
+      expect(await response.json()).toEqual(responseBody);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('when there is a 500 error with no retry option', () => {
+    let scope: nock.Scope;
+
+    beforeEach(() => {
+      scope = nock(baseURL).post(path).reply(500, { message: 'oops' });
+    });
+
+    it('returns the 500 response', async () => {
+      const response = await fetch(url, { method: 'POST' });
+      expect(response.status).toBe(500);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('when there is a 500 error with retry disabled', () => {
+    let scope: nock.Scope;
+
+    beforeEach(() => {
+      scope = nock(baseURL).post(path).reply(500, { message: 'oops' });
+    });
+
+    it('returns the 500 response', async () => {
+      const response = await fetch(url, { method: 'POST', retry: false });
+      expect(response.status).toBe(500);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('when there is a 408 error with a successful retry', () => {
+    let scope: nock.Scope;
+
+    beforeEach(() => {
+      scope = nock(baseURL)
+        .post(path)
+        .reply(408, {})
+        .post(path)
+        .reply(200, responseBody);
+    });
+
+    it('returns the response without error', async () => {
+      const response = await fetch(url, {
+        method: 'POST',
+        retry: { retries: 2, factor: 0 },
+      });
+      expect(await response.json()).toEqual(responseBody);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('when there is a non-retryable error', () => {
+    let scope: nock.Scope;
+
+    beforeEach(() => {
+      scope = nock(baseURL).post(path).reply(401, { message: 'unauthorized' });
+    });
+
+    it('returns the error response', async () => {
+      const response = await fetch(url, { method: 'POST', retry: true });
+      expect(response.status).toBe(401);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('when the request times-out after retry', () => {
+    let scope: nock.Scope;
+
+    beforeEach(() => {
+      scope = nock(baseURL)
+        .post(path)
+        .delay(1000)
+        .reply(200, responseBody)
+        .post(path)
+        .delay(1000)
+        .reply(200, responseBody);
+    });
+
+    it('throws an error', async () => {
+      await expect(
+        fetch(url, {
+          method: 'POST',
+          retry: { retries: 1, factor: 0, minTimeout: 0 },
+          timeout: 1,
+        })
+      ).rejects.toThrow(/network timeout/i);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('when the first request times-out but succeds on retry', () => {
+    let scope: nock.Scope;
+
+    beforeEach(() => {
+      scope = nock(baseURL)
+        .post(path)
+        .delay(1000)
+        .reply(200, responseBody)
+        .post(path)
+        .reply(200, responseBody);
+    });
+
+    it('returns the response without error', async () => {
+      const response = await fetch(url, {
+        method: 'POST',
+        retry: 2,
+        timeout: 500,
+      });
+      expect(await response.json()).toEqual(responseBody);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('when the request succeeds after a lot of retries', () => {
+    let scope: nock.Scope;
+
+    beforeEach(() => {
+      scope = nock(baseURL)
+        .post(path)
+        .replyWithError({ code: 'ECONNRESET' })
+        .post(path)
+        .reply(408, {})
+        .post(path)
+        .reply(501, {})
+        .post(path)
+        .reply(429, {})
+        .post(path)
+        .reply(200, responseBody);
+    });
+
+    it('returns the response without error', async () => {
+      const response = await fetch(url, {
+        method: 'POST',
+        retry: { retries: 4, factor: 0, minTimeout: 0 },
+      });
+      expect(await response.json()).toEqual(responseBody);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+});
+
+describe('fetch.defaults', () => {
+  const baseURL = 'https://example.com';
+  const path = '/foo/bar';
+  const url = `${baseURL}${path}`;
+  const responseBody = { greeting: 'hello' };
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('when some fetch params are defaulted', () => {
+    let scope: nock.Scope;
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+    const body = JSON.stringify({ foo: 'bar' });
+
+    beforeEach(() => {
+      scope = nock(baseURL)
+        .post(path, body)
+        .matchHeader('content-type', 'application/json')
+        .matchHeader('accept', 'application/json')
+        .reply(200, responseBody);
+    });
+
+    it('calls fetch with the correct arguments', async () => {
+      const f = fetch.defaults({ headers }).defaults({ method: 'POST' });
+      const response = await f(url, { body, retry: false });
+
+      expect(await response.json()).toEqual(responseBody);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('when all fetch params are defaulted', () => {
+    let scope: nock.Scope;
+
+    beforeEach(() => {
+      scope = nock(baseURL).get(path).reply(200, responseBody);
+    });
+
+    it('calls fetch with the correct arguments', async () => {
+      const f = fetch.defaults({ method: 'GET' });
+      const response = await f(url);
+
+      expect(await response.json()).toEqual(responseBody);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('when no fetch params are defaulted', () => {
+    let scope: nock.Scope;
+
+    beforeEach(() => {
+      scope = nock(baseURL).get(path).reply(200, responseBody);
+    });
+
+    it('calls fetch with the correct arguments', async () => {
+      const response = await fetch.defaults().defaults()(url);
+
+      expect(await response.json()).toEqual(responseBody);
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+});

--- a/packages/oci/src/error.ts
+++ b/packages/oci/src/error.ts
@@ -13,10 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import fetch from 'make-fetch-happen';
-
-// Convoluted way of getting at the Response type used by make-fetch-happen
-type Response = Awaited<ReturnType<typeof fetch>>;
+import type { Response } from './fetch';
 
 export class HTTPError extends Error {
   readonly statusCode: number;

--- a/packages/oci/src/fetch.ts
+++ b/packages/oci/src/fetch.ts
@@ -1,0 +1,109 @@
+/*
+Copyright 2024 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { constants as httpConstants } from 'http2';
+import fetch, { FetchOptions } from 'make-fetch-happen';
+import { log } from 'proc-log';
+import promiseRetry from 'promise-retry';
+
+const {
+  HTTP_STATUS_INTERNAL_SERVER_ERROR,
+  HTTP_STATUS_TOO_MANY_REQUESTS,
+  HTTP_STATUS_REQUEST_TIMEOUT,
+} = httpConstants;
+
+type Response = Awaited<ReturnType<typeof fetch>>;
+type Retry = FetchOptions['retry'];
+
+const fetchWithRetry = async (
+  url: string,
+  options: FetchOptions = {}
+): Promise<Response> => {
+  return promiseRetry<Response>(async (retry, attemptNum) => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const logRetry = (reason: any) => {
+      log.http(
+        'fetch',
+        `${options.method} ${url} attempt ${attemptNum} failed with ${reason}`
+      );
+    };
+
+    const response = await fetch(url, {
+      ...options,
+      retry: false, // We're handling retries ourselves
+    }).catch((reason) => {
+      logRetry(reason);
+      return retry(reason);
+    });
+
+    if (retryable(response.status)) {
+      logRetry(response.status);
+      return retry(response);
+    }
+
+    return response;
+  }, retryOpts(options.retry)).catch((err) => {
+    // If we got an actual error, throw it
+    if (err instanceof Error) {
+      throw err;
+    }
+
+    // Otherwise, return the response (this is simply a retry-able response for
+    // which we exceeded the retry limit)
+    return err;
+  });
+};
+
+// Returns a wrapped fetch function with default options
+fetchWithRetry.defaults = (
+  defaultOptions: FetchOptions = {},
+  wrappedFetch = fetchWithRetry
+) => {
+  const defaultedFetch = (url: string, options: FetchOptions = {}) => {
+    const finalOptions = {
+      ...defaultOptions,
+      ...options,
+      headers: { ...defaultOptions.headers, ...options.headers },
+    };
+    return wrappedFetch(url, finalOptions);
+  };
+
+  defaultedFetch.defaults = (newDefaults: FetchOptions = {}) =>
+    fetchWithRetry.defaults(newDefaults, defaultedFetch);
+
+  return defaultedFetch;
+};
+
+// Determine if a status code is retryable. This includes 5xx errors, 408, and
+// 429.
+const retryable = (status: number): boolean =>
+  [HTTP_STATUS_REQUEST_TIMEOUT, HTTP_STATUS_TOO_MANY_REQUESTS].includes(
+    status
+  ) || status >= HTTP_STATUS_INTERNAL_SERVER_ERROR;
+
+// Normalize the retry options to the format expected by promise-retry
+const retryOpts = (retry?: Retry): { retries: number } => {
+  if (typeof retry === 'boolean') {
+    return { retries: retry ? 1 : 0 };
+  } else if (typeof retry === 'number') {
+    return { retries: retry };
+  } else {
+    return { retries: 0, ...retry };
+  }
+};
+
+export default fetchWithRetry;
+export type FetchInterface = typeof fetchWithRetry;
+export type { FetchOptions, Response };

--- a/packages/oci/src/image.ts
+++ b/packages/oci/src/image.ts
@@ -21,9 +21,12 @@ import {
 import { Credentials } from './credentials';
 import { HTTPError, OCIError } from './error';
 import { ImageName } from './name';
-import { RegistryClient, UploadManifestResponse } from './registry';
+import {
+  RegistryFetchOptions as FetchOptions,
+  RegistryClient,
+  UploadManifestResponse,
+} from './registry';
 
-import type { FetchOptions } from 'make-fetch-happen';
 import type { Descriptor, ImageIndex, ImageManifest } from './types';
 
 const EMPTY_BLOB = Buffer.from('{}');

--- a/packages/oci/src/index.ts
+++ b/packages/oci/src/index.ts
@@ -17,7 +17,7 @@ import { Credentials } from './credentials';
 import { AddArtifactOptions, OCIImage } from './image';
 import { parseImageName } from './name';
 
-import type { FetchOptions } from 'make-fetch-happen';
+import type { RegistryFetchOptions as FetchOptions } from './registry';
 import type { Descriptor } from './types';
 
 export type { Credentials, Descriptor };

--- a/packages/oci/src/proc-log.d.ts
+++ b/packages/oci/src/proc-log.d.ts
@@ -1,0 +1,6 @@
+declare module 'proc-log' {
+  type Log = {
+    http(...args: unknown[]): void;
+  };
+  export const log: Log;
+}

--- a/packages/oci/src/registry.ts
+++ b/packages/oci/src/registry.ts
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import fetch, { FetchInterface, FetchOptions } from 'make-fetch-happen';
 import crypto from 'node:crypto';
 import {
   CONTENT_TYPE_OCI_INDEX,
@@ -33,6 +32,7 @@ import {
 } from './constants';
 import { Credentials, toBasicAuth } from './credentials';
 import { ensureStatus } from './error';
+import fetch, { FetchInterface, FetchOptions } from './fetch';
 
 import type { Descriptor } from './types';
 
@@ -55,12 +55,21 @@ export type GetManifestResponse = Descriptor & {
   readonly etag?: string;
 };
 
+export type RegistryFetchOptions = Pick<
+  FetchOptions,
+  'proxy' | 'noProxy' | 'retry' | 'timeout'
+>;
+
 export class RegistryClient {
   readonly #baseURL: string;
   readonly #repository: string;
   #fetch: FetchInterface;
 
-  constructor(registry: string, repository: string, opts?: FetchOptions) {
+  constructor(
+    registry: string,
+    repository: string,
+    opts?: RegistryFetchOptions
+  ) {
     this.#repository = repository;
     this.#fetch = fetch.defaults(opts);
 


### PR DESCRIPTION
To compensate for the fact that `make-fetch-happen` doesn't support retries for "POST" requests, this change introduces a wrapper around the fetcher which will retry requests to Fulcio/Rekor/TSA for network errors or for HTTP status codes of 408, 429, or 5xx.

This is similar to #1148 but implemented specifically for the `@sigstore/oci` package.