### PR TITLE
fix missing await in addArtifact

### DIFF
--- a/.changeset/happy-beans-run.md
+++ b/.changeset/happy-beans-run.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/oci": patch
+---
+
+Fix missing await in addArtifact

--- a/packages/oci/src/image.ts
+++ b/packages/oci/src/image.ts
@@ -174,7 +174,7 @@ export class OCIImage {
       // Add the artifact to the index
       referrerManifest.manifests.push(opts.artifact);
 
-      this.#client.uploadManifest(JSON.stringify(referrerManifest), {
+      await this.#client.uploadManifest(JSON.stringify(referrerManifest), {
         mediaType: CONTENT_TYPE_OCI_INDEX,
         reference: referrerTag,
         etag,


### PR DESCRIPTION
Fix a missing `await` in `OCIImage.addArtifact` which may cause the function to return before the referrers manifest has been uploaded.