### PR TITLE
Detect registries with referrers API support

### DIFF
--- a/.changeset/chilled-frogs-sort.md
+++ b/.changeset/chilled-frogs-sort.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/oci': patch
+---
+
+Fix bug when detecting support for the referrers API

--- a/packages/oci/src/__tests__/image.test.ts
+++ b/packages/oci/src/__tests__/image.test.ts
@@ -27,6 +27,7 @@ import {
 import { Credentials } from '../credentials';
 import { OCIImage } from '../image';
 import { ImageName } from '../name';
+import { ZERO_DIGEST } from '../registry';
 import { ImageIndex } from '../types';
 
 describe('OCIImage', () => {
@@ -93,6 +94,10 @@ describe('OCIImage', () => {
           .reply(201, undefined, {
             [HEADER_OCI_SUBJECT]: artifactManifestDigest,
           });
+
+        nock(`https://${registry}`)
+          .get(`/v2/${repo}/referrers/${ZERO_DIGEST}`)
+          .reply(200);
       });
 
       it('adds an artifact', async () => {
@@ -126,7 +131,9 @@ describe('OCIImage', () => {
           })
           .put(`/v2/${repo}/blobs/uploads/123?digest=${artifactDigest}`)
           .matchHeader(HEADER_CONTENT_TYPE, CONTENT_TYPE_OCTET_STREAM)
-          .reply(201);
+          .reply(201)
+          .get(`/v2/${repo}/referrers/${ZERO_DIGEST}`)
+          .reply(404);
 
         nock(`https://${registry}`)
           .filteringPath(/sha256:[0-9a-f]{64}/, artifactManifestDigest)

--- a/packages/oci/src/__tests__/index.test.ts
+++ b/packages/oci/src/__tests__/index.test.ts
@@ -30,6 +30,7 @@ import {
   HEADER_DIGEST,
   HEADER_OCI_SUBJECT,
 } from '../constants';
+import { ZERO_DIGEST } from '../registry';
 
 describe('attachArtifactToImage', () => {
   const registry = 'my-registry';
@@ -77,6 +78,10 @@ describe('attachArtifactToImage', () => {
         .reply(201, undefined, {
           [HEADER_OCI_SUBJECT]: artifactManifestDigest,
         });
+
+      nock(`https://${registry}`)
+        .get(`/v2/${repo}/referrers/${ZERO_DIGEST}`)
+        .reply(200, {});
     });
 
     it('should return the artifact digest', async () => {

--- a/packages/oci/src/registry.ts
+++ b/packages/oci/src/registry.ts
@@ -45,6 +45,9 @@ const ALL_MANIFEST_MEDIA_TYPES = [
   CONTENT_TYPE_DOCKER_MANIFEST_LIST,
 ].join(',');
 
+export const ZERO_DIGEST =
+  'sha256:0000000000000000000000000000000000000000000000000000000000000000';
+
 export type UploadBlobResponse = Descriptor;
 
 export type UploadManifestOptions = {
@@ -269,6 +272,15 @@ export class RegistryClient {
       size: manifest.length,
       subjectDigest,
     };
+  }
+
+  // Returns true if the registry supports the referrers API
+  async pingReferrers(): Promise<boolean> {
+    const response = await this.#fetch(
+      `${this.#baseURL}/v2/${this.#repository}/referrers/${ZERO_DIGEST}`
+    );
+
+    return response.status === 200;
   }
 
   async #fetchDistributionToken(


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the `attachArtifactToImage` function in the `@sigstore/oci` package to better detect registries which support the OCI referrers API.

Previously we were depending on the presence of the [`OCI-Subject`](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-manifests-with-subject) header in response to uploading the artifact manifest to determine if the registry supported the referrers API. This was not a reliable method as some registries (AWS ECR) will return this header even when they do NOT support the referrers API.

As a fix, we're now pinging the referrers API directly to see if we get a 200 response. If we do, we can be confident that the registry supports the referrers API.