### PR TITLE
bug fix for referrers api detection

### DIFF
--- a/.changeset/lovely-numbers-run.md
+++ b/.changeset/lovely-numbers-run.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/oci': patch
+---
+
+Bugfix when detecting support for the referrers API with OCI registries

--- a/packages/oci/src/image.ts
+++ b/packages/oci/src/image.ts
@@ -101,7 +101,7 @@ export class OCIImage {
       const referrersSupported = await this.#client.pingReferrers();
 
       // Manually update the referrers list if the referrers API is not supported.
-      if (!referrersSupported) {
+      if (!artifactDescriptor.subjectDigest || !referrersSupported) {
         // Strip subjectDigest from the artifact descriptor (in case it was returned)
         /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
         const { subjectDigest, ...descriptor } = artifactDescriptor;


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the logic used to detect whether an OCI registry supports the referrers API. It appears that some registries will return a false 200 response when hitting the `/referrers` endpoint even though the referrers API is not supported.

To ensure that we are correctly detecting support for the referrers API, this PR updates the logic to check for the presence of the `subjectDigest` in the artifact descriptor before checking the response from the `/referrers` endpoint.