### PR TITLE
default to generating v0.3 bundles

### DIFF
--- a/.changeset/four-suits-sleep.md
+++ b/.changeset/four-suits-sleep.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/bundle': major
+---
+
+`toDSSEBundle` and `toMessageSignatureBundle` generate v0.3 bundles by default

--- a/packages/bundle/src/__tests__/__snapshots__/build.test.ts.snap
+++ b/packages/bundle/src/__tests__/__snapshots__/build.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toDSSEBundle when the singleCertificate option is true when a certificate chain provided returns a valid DSSE bundle 1`] = `
+exports[`toDSSEBundle when the certificateChain option is true when a certificate chain provided returns a valid DSSE bundle 1`] = `
 {
   "dsseEnvelope": {
     "payload": "ZGF0YQ==",
@@ -12,20 +12,24 @@ exports[`toDSSEBundle when the singleCertificate option is true when a certifica
       },
     ],
   },
-  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+  "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.2",
   "verificationMaterial": {
-    "certificate": {
-      "rawBytes": "Y2VydGlmaWNhdGU=",
-    },
     "timestampVerificationData": {
       "rfc3161Timestamps": [],
     },
     "tlogEntries": [],
+    "x509CertificateChain": {
+      "certificates": [
+        {
+          "rawBytes": "Y2VydGlmaWNhdGU=",
+        },
+      ],
+    },
   },
 }
 `;
 
-exports[`toDSSEBundle when the singleCertificate option is true when a public key w/ hint is provided returns a valid DSSE bundle 1`] = `
+exports[`toDSSEBundle when the certificateChain option is true when a public key w/ hint is provided returns a valid DSSE bundle 1`] = `
 {
   "dsseEnvelope": {
     "payload": "ZGF0YQ==",
@@ -37,7 +41,7 @@ exports[`toDSSEBundle when the singleCertificate option is true when a public ke
       },
     ],
   },
-  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+  "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.2",
   "verificationMaterial": {
     "publicKey": {
       "hint": "hint",
@@ -50,7 +54,7 @@ exports[`toDSSEBundle when the singleCertificate option is true when a public ke
 }
 `;
 
-exports[`toDSSEBundle when the singleCertificate option is true when a public key w/o hint is provided returns a valid DSSE bundle 1`] = `
+exports[`toDSSEBundle when the certificateChain option is true when a public key w/o hint is provided returns a valid DSSE bundle 1`] = `
 {
   "dsseEnvelope": {
     "payload": "ZGF0YQ==",
@@ -62,7 +66,7 @@ exports[`toDSSEBundle when the singleCertificate option is true when a public ke
       },
     ],
   },
-  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+  "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.2",
   "verificationMaterial": {
     "publicKey": {
       "hint": "",
@@ -87,19 +91,15 @@ exports[`toDSSEBundle when the singleCertificate option is undefined/false when 
       },
     ],
   },
-  "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.2",
+  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
   "verificationMaterial": {
+    "certificate": {
+      "rawBytes": "Y2VydGlmaWNhdGU=",
+    },
     "timestampVerificationData": {
       "rfc3161Timestamps": [],
     },
     "tlogEntries": [],
-    "x509CertificateChain": {
-      "certificates": [
-        {
-          "rawBytes": "Y2VydGlmaWNhdGU=",
-        },
-      ],
-    },
   },
 }
 `;
@@ -116,7 +116,7 @@ exports[`toDSSEBundle when the singleCertificate option is undefined/false when 
       },
     ],
   },
-  "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.2",
+  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
   "verificationMaterial": {
     "publicKey": {
       "hint": "hint",
@@ -141,7 +141,7 @@ exports[`toDSSEBundle when the singleCertificate option is undefined/false when 
       },
     ],
   },
-  "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.2",
+  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
   "verificationMaterial": {
     "publicKey": {
       "hint": "",
@@ -154,29 +154,7 @@ exports[`toDSSEBundle when the singleCertificate option is undefined/false when 
 }
 `;
 
-exports[`toMessageSignatureBundle when the singleCertificate option is true returns a valid message signature bundle 1`] = `
-{
-  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
-  "messageSignature": {
-    "messageDigest": {
-      "algorithm": "SHA2_256",
-      "digest": "ZGlnZXN0",
-    },
-    "signature": "c2lnbmF0dXJl",
-  },
-  "verificationMaterial": {
-    "certificate": {
-      "rawBytes": "Y2VydGlmaWNhdGU=",
-    },
-    "timestampVerificationData": {
-      "rfc3161Timestamps": [],
-    },
-    "tlogEntries": [],
-  },
-}
-`;
-
-exports[`toMessageSignatureBundle when the singleCertificate option is undefined returns a valid message signature bundle 1`] = `
+exports[`toMessageSignatureBundle when the certificateChain option is true returns a valid message signature bundle 1`] = `
 {
   "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.2",
   "messageSignature": {
@@ -198,6 +176,28 @@ exports[`toMessageSignatureBundle when the singleCertificate option is undefined
         },
       ],
     },
+  },
+}
+`;
+
+exports[`toMessageSignatureBundle when the singleCertificate option is undefined returns a valid message signature bundle 1`] = `
+{
+  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+  "messageSignature": {
+    "messageDigest": {
+      "algorithm": "SHA2_256",
+      "digest": "ZGlnZXN0",
+    },
+    "signature": "c2lnbmF0dXJl",
+  },
+  "verificationMaterial": {
+    "certificate": {
+      "rawBytes": "Y2VydGlmaWNhdGU=",
+    },
+    "timestampVerificationData": {
+      "rfc3161Timestamps": [],
+    },
+    "tlogEntries": [],
   },
 }
 `;

--- a/packages/bundle/src/__tests__/build.test.ts
+++ b/packages/bundle/src/__tests__/build.test.ts
@@ -37,14 +37,14 @@ describe('toMessageSignatureBundle', () => {
     });
   });
 
-  describe('when the singleCertificate option is true', () => {
+  describe('when the certificateChain option is true', () => {
     it('returns a valid message signature bundle', () => {
       const b = toMessageSignatureBundle({
         digest,
         signature,
         certificate,
         keyHint,
-        singleCertificate: true,
+        certificateChain: true,
       });
 
       expect(b).toBeTruthy();
@@ -101,7 +101,7 @@ describe('toDSSEBundle', () => {
     });
   });
 
-  describe('when the singleCertificate option is true', () => {
+  describe('when the certificateChain option is true', () => {
     describe('when a public key w/ hint is provided', () => {
       it('returns a valid DSSE bundle', () => {
         const b = toDSSEBundle({
@@ -109,7 +109,7 @@ describe('toDSSEBundle', () => {
           artifactType,
           signature,
           keyHint,
-          singleCertificate: true,
+          certificateChain: true,
         });
 
         expect(b).toBeTruthy();
@@ -123,7 +123,7 @@ describe('toDSSEBundle', () => {
           artifact,
           artifactType,
           signature,
-          singleCertificate: true,
+          certificateChain: true,
         });
 
         expect(b).toBeTruthy();
@@ -138,7 +138,7 @@ describe('toDSSEBundle', () => {
           artifactType,
           signature,
           certificate,
-          singleCertificate: true,
+          certificateChain: true,
         });
 
         expect(b).toBeTruthy();

--- a/packages/bundle/src/build.ts
+++ b/packages/bundle/src/build.ts
@@ -29,10 +29,10 @@ type VerificationMaterialOptions = {
   certificate?: Buffer;
   keyHint?: string;
 
-  // When set to true, the bundle verification material will use the
-  // certifciate field instead of the x509CertificateChain field.
-  // When undefied/false, a v0.2 bundle will be created.
-  singleCertificate?: boolean;
+  // When set to true, the bundle verification material will populate the
+  // x509CertificateChain field and create a v0.2 bundle.
+  // When undefied/false, a v0.3 bundle will be created.
+  certificateChain?: boolean;
 };
 
 type MessageSignatureBundleOptions = {
@@ -51,9 +51,9 @@ export function toMessageSignatureBundle(
   options: MessageSignatureBundleOptions
 ): BundleWithMessageSignature {
   return {
-    mediaType: options.singleCertificate
-      ? BUNDLE_V03_MEDIA_TYPE
-      : BUNDLE_V02_MEDIA_TYPE,
+    mediaType: options.certificateChain
+      ? BUNDLE_V02_MEDIA_TYPE
+      : BUNDLE_V03_MEDIA_TYPE,
     content: {
       $case: 'messageSignature',
       messageSignature: {
@@ -74,9 +74,9 @@ export function toDSSEBundle(
   options: DSSEBundleOptions
 ): BundleWithDsseEnvelope {
   return {
-    mediaType: options.singleCertificate
-      ? BUNDLE_V03_MEDIA_TYPE
-      : BUNDLE_V02_MEDIA_TYPE,
+    mediaType: options.certificateChain
+      ? BUNDLE_V02_MEDIA_TYPE
+      : BUNDLE_V03_MEDIA_TYPE,
     content: {
       $case: 'dsseEnvelope',
       dsseEnvelope: toEnvelope(options),
@@ -116,17 +116,17 @@ function toKeyContent(
   options: VerificationMaterialOptions
 ): Bundle['verificationMaterial']['content'] {
   if (options.certificate) {
-    if (options.singleCertificate) {
-      return {
-        $case: 'certificate',
-        certificate: { rawBytes: options.certificate },
-      };
-    } else {
+    if (options.certificateChain) {
       return {
         $case: 'x509CertificateChain',
         x509CertificateChain: {
           certificates: [{ rawBytes: options.certificate }],
         },
+      };
+    } else {
+      return {
+        $case: 'certificate',
+        certificate: { rawBytes: options.certificate },
       };
     }
   } else {

--- a/packages/sign/src/bundler/bundle.ts
+++ b/packages/sign/src/bundler/bundle.ts
@@ -37,6 +37,7 @@ export function toMessageSignatureBundle(
         : undefined,
     keyHint:
       signature.key.$case === 'publicKey' ? signature.key.hint : undefined,
+    certificateChain: true,
   });
 }
 
@@ -56,6 +57,6 @@ export function toDSSEBundle(
         : undefined,
     keyHint:
       signature.key.$case === 'publicKey' ? signature.key.hint : undefined,
-    singleCertificate,
+    certificateChain: singleCertificate ? false : true,
   });
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Update the `toDSSEBundle` and `toMessageSignatureBundle` functions in the `bundle` package to generate Sigstore v0.3 bundles by default.

Previously, these functions would generate v0.2 bundles by default and you could force v0.3 by setting `singleCertificate: true`. Now we will default to v0.3 and you can force v0.2 by setting `certificateChain` to true.

This is a breaking change to the public interface and will result in a major version bump.