### PR TITLE
default to signing v0.3 bundles

### DIFF
--- a/.changeset/cold-icons-dream.md
+++ b/.changeset/cold-icons-dream.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/sign': major
+---
+
+Default `DSSEBundleBuilder` to generating v0.3 bundles

--- a/packages/cli/src/commands/attest.ts
+++ b/packages/cli/src/commands/attest.ts
@@ -191,5 +191,5 @@ const initBundleBuilder = (opts: SignOptions): BundleBuilder => {
 
   // Build the bundle with the singleCertificate option which will
   // trigger the creation of v0.3 DSSE bundles
-  return new DSSEBundleBuilder({ signer, witnesses, singleCertificate: true });
+  return new DSSEBundleBuilder({ signer, witnesses });
 };

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -93,7 +93,10 @@ export function createBundleBuilder(
     case 'messageSignature':
       return new MessageSignatureBundleBuilder(bundlerOptions);
     case 'dsseEnvelope':
-      return new DSSEBundleBuilder(bundlerOptions);
+      return new DSSEBundleBuilder({
+        ...bundlerOptions,
+        certificateChain: true,
+      });
   }
 }
 

--- a/packages/sign/src/__tests__/bundler/bundle.test.ts
+++ b/packages/sign/src/__tests__/bundler/bundle.test.ts
@@ -84,7 +84,7 @@ describe('toDSSEBundle', () => {
 
       expect(b).toBeTruthy();
       expect(b.mediaType).toEqual(
-        'application/vnd.dev.sigstore.bundle+json;version=0.2'
+        'application/vnd.dev.sigstore.bundle.v0.3+json'
       );
 
       assert(b.content?.$case === 'dsseEnvelope');
@@ -120,7 +120,7 @@ describe('toDSSEBundle', () => {
 
       expect(b).toBeTruthy();
       expect(b.mediaType).toEqual(
-        'application/vnd.dev.sigstore.bundle+json;version=0.2'
+        'application/vnd.dev.sigstore.bundle.v0.3+json'
       );
 
       assert(b.content?.$case === 'dsseEnvelope');
@@ -152,43 +152,6 @@ describe('toDSSEBundle', () => {
 
       expect(b).toBeTruthy();
       expect(b.mediaType).toEqual(
-        'application/vnd.dev.sigstore.bundle+json;version=0.2'
-      );
-
-      assert(b.content?.$case === 'dsseEnvelope');
-      expect(b.content.dsseEnvelope).toBeTruthy();
-      expect(b.content.dsseEnvelope.payloadType).toEqual(artifact.type);
-      expect(b.content.dsseEnvelope.payload).toEqual(artifact.data);
-      expect(b.content.dsseEnvelope.signatures).toHaveLength(1);
-      expect(b.content.dsseEnvelope.signatures[0].sig).toEqual(sigBytes);
-      expect(b.content.dsseEnvelope.signatures[0].keyid).toEqual('');
-
-      expect(b.verificationMaterial).toBeTruthy();
-      assert(b.verificationMaterial.content?.$case === 'x509CertificateChain');
-      expect(
-        b.verificationMaterial.content?.x509CertificateChain.certificates
-      ).toHaveLength(1);
-      expect(
-        b.verificationMaterial.content?.x509CertificateChain.certificates[0]
-          .rawBytes
-      ).toEqual(pem.toDER(certificate));
-    });
-  });
-
-  describe('when the single-certificate representation is requested', () => {
-    const signature = {
-      key: {
-        $case: 'x509Certificate',
-        certificate: certificate,
-      },
-      signature: sigBytes,
-    } satisfies Signature;
-
-    it('returns a valid DSSE bundle', () => {
-      const b = toDSSEBundle(artifact, signature, true);
-
-      expect(b).toBeTruthy();
-      expect(b.mediaType).toEqual(
         'application/vnd.dev.sigstore.bundle.v0.3+json'
       );
 
@@ -205,6 +168,40 @@ describe('toDSSEBundle', () => {
       expect(b.verificationMaterial.content?.certificate.rawBytes).toEqual(
         pem.toDER(certificate)
       );
+    });
+  });
+
+  describe('when the certificate chain representation is requested', () => {
+    const signature = {
+      key: {
+        $case: 'x509Certificate',
+        certificate: certificate,
+      },
+      signature: sigBytes,
+    } satisfies Signature;
+
+    it('returns a valid DSSE bundle', () => {
+      const b = toDSSEBundle(artifact, signature, true);
+
+      expect(b).toBeTruthy();
+      expect(b.mediaType).toEqual(
+        'application/vnd.dev.sigstore.bundle+json;version=0.2'
+      );
+
+      assert(b.content?.$case === 'dsseEnvelope');
+      expect(b.content.dsseEnvelope).toBeTruthy();
+      expect(b.content.dsseEnvelope.payloadType).toEqual(artifact.type);
+      expect(b.content.dsseEnvelope.payload).toEqual(artifact.data);
+      expect(b.content.dsseEnvelope.signatures).toHaveLength(1);
+      expect(b.content.dsseEnvelope.signatures[0].sig).toEqual(sigBytes);
+      expect(b.content.dsseEnvelope.signatures[0].keyid).toEqual('');
+
+      expect(b.verificationMaterial).toBeTruthy();
+      assert(b.verificationMaterial.content?.$case === 'x509CertificateChain');
+      expect(
+        b.verificationMaterial.content?.x509CertificateChain.certificates[0]
+          .rawBytes
+      ).toEqual(pem.toDER(certificate));
     });
   });
 });

--- a/packages/sign/src/__tests__/bundler/dsse.test.ts
+++ b/packages/sign/src/__tests__/bundler/dsse.test.ts
@@ -65,7 +65,7 @@ describe('DSSEBundleBuilder', () => {
 
         expect(b).toBeTruthy();
         expect(b.mediaType).toEqual(
-          'application/vnd.dev.sigstore.bundle+json;version=0.2'
+          'application/vnd.dev.sigstore.bundle.v0.3+json'
         );
 
         expect(b.content.dsseEnvelope).toBeTruthy();
@@ -106,7 +106,7 @@ describe('DSSEBundleBuilder', () => {
 
         expect(b).toBeTruthy();
         expect(b.mediaType).toEqual(
-          'application/vnd.dev.sigstore.bundle+json;version=0.2'
+          'application/vnd.dev.sigstore.bundle.v0.3+json'
         );
 
         expect(b.content.dsseEnvelope).toBeTruthy();
@@ -129,11 +129,11 @@ describe('DSSEBundleBuilder', () => {
       });
     });
 
-    describe('when a single-certificate bundle is requested', () => {
+    describe('when a certificate chain bundle is requested', () => {
       const subject = new DSSEBundleBuilder({
         signer: signer,
         witnesses: [],
-        singleCertificate: true,
+        certificateChain: true,
       });
       const artifact = {
         data: Buffer.from('artifact'),
@@ -152,7 +152,7 @@ describe('DSSEBundleBuilder', () => {
 
         expect(b).toBeTruthy();
         expect(b.mediaType).toEqual(
-          'application/vnd.dev.sigstore.bundle.v0.3+json'
+          'application/vnd.dev.sigstore.bundle+json;version=0.2'
         );
 
         expect(b.content.dsseEnvelope).toBeTruthy();

--- a/packages/sign/src/__tests__/integration.test.ts
+++ b/packages/sign/src/__tests__/integration.test.ts
@@ -81,12 +81,8 @@ describe('artifact signing', () => {
       expect(bundle.content.dsseEnvelope.payload).toBe(data);
       expect(bundle.content.dsseEnvelope.signatures).toHaveLength(1);
 
-      assert(
-        bundle.verificationMaterial.content.$case === 'x509CertificateChain'
-      );
-      expect(
-        bundle.verificationMaterial.content.x509CertificateChain.certificates
-      ).toHaveLength(1);
+      assert(bundle.verificationMaterial.content.$case === 'certificate');
+      expect(bundle.verificationMaterial.content.certificate).toBeDefined();
 
       expect(bundle.verificationMaterial.tlogEntries).toHaveLength(1);
       expect(bundle.verificationMaterial.tlogEntries[0].kindVersion.kind).toBe(

--- a/packages/sign/src/bundler/bundle.ts
+++ b/packages/sign/src/bundler/bundle.ts
@@ -45,7 +45,7 @@ export function toMessageSignatureBundle(
 export function toDSSEBundle(
   artifact: Required<Artifact>,
   signature: Signature,
-  singleCertificate?: boolean
+  certificateChain?: boolean
 ): sigstore.BundleWithDsseEnvelope {
   return sigstore.toDSSEBundle({
     artifact: artifact.data,
@@ -57,6 +57,6 @@ export function toDSSEBundle(
         : undefined,
     keyHint:
       signature.key.$case === 'publicKey' ? signature.key.hint : undefined,
-    certificateChain: singleCertificate ? false : true,
+    certificateChain,
   });
 }

--- a/packages/sign/src/bundler/dsse.ts
+++ b/packages/sign/src/bundler/dsse.ts
@@ -24,15 +24,15 @@ type DSSEBundleBuilderOptions = BundleBuilderOptions & {
   // When set to true, the bundle verification material will use the
   // certificate field instead of the x509CertificateChain field.
   // When undefied/false, a v0.2 bundle will be created.
-  singleCertificate?: boolean;
+  certificateChain?: boolean;
 };
 
 // BundleBuilder implementation for DSSE wrapped attestations
 export class DSSEBundleBuilder extends BaseBundleBuilder<BundleWithDsseEnvelope> {
-  private singleCertificate?: boolean;
+  private certificateChain?: boolean;
   constructor(options: DSSEBundleBuilderOptions) {
     super(options);
-    this.singleCertificate = options.singleCertificate ?? false;
+    this.certificateChain = options.certificateChain ?? false;
   }
 
   // DSSE requires the artifact to be pre-encoded with the payload type
@@ -50,7 +50,7 @@ export class DSSEBundleBuilder extends BaseBundleBuilder<BundleWithDsseEnvelope>
     return toDSSEBundle(
       artifactDefaults(artifact),
       signature,
-      this.singleCertificate
+      this.certificateChain
     );
   }
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Update the `DSSEBundleBuilder` class in the `sign` package to generate Sigstore v0.3 bundles by default.

Previously, this class would generate v0.2 bundles by default and you could force v0.3 by setting `singleCertificate: true`. Now we will default to v0.3 and you can force v0.2 by setting `certificateChain` to true.

This is a breaking change to the public interface and will result in a major version bump.