### PR TITLE
default to generating dsse rekor entries

### DIFF
--- a/.changeset/tame-clouds-sparkle.md
+++ b/.changeset/tame-clouds-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/sign': major
+---
+
+Default `RekorWitness` to generating "dsse" entries instead of "intoto"

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -170,6 +170,7 @@ function initWitnesses(options: SignOptions): Witness[] {
     witnesses.push(
       new RekorWitness({
         rekorBaseURL: options.rekorURL,
+        entryType: 'intoto',
         fetchOnConflict: false,
         retry: options.retry ?? DEFAULT_RETRY,
         timeout: options.timeout ?? DEFAULT_TIMEOUT,

--- a/packages/sign/src/__tests__/integration.test.ts
+++ b/packages/sign/src/__tests__/integration.test.ts
@@ -86,7 +86,7 @@ describe('artifact signing', () => {
 
       expect(bundle.verificationMaterial.tlogEntries).toHaveLength(1);
       expect(bundle.verificationMaterial.tlogEntries[0].kindVersion.kind).toBe(
-        'intoto'
+        'dsse'
       );
 
       expect(

--- a/packages/sign/src/__tests__/witness/tlog/entry.test.ts
+++ b/packages/sign/src/__tests__/witness/tlog/entry.test.ts
@@ -74,42 +74,16 @@ describe('toProposedEntry', () => {
       it('return a valid ProposedEntry entry', () => {
         const entry = toProposedEntry(sigBundle, publicKey);
 
-        assert(entry.apiVersion === '0.0.2');
-        assert(entry.kind === 'intoto');
+        assert(entry.apiVersion === '0.0.1');
+        assert(entry.kind === 'dsse');
         expect(entry.spec).toBeTruthy();
-        expect(entry.spec.content).toBeTruthy();
-        expect(entry.spec.content.envelope).toBeTruthy();
-
-        const e = entry.spec.content.envelope;
-        expect(e?.payloadType).toEqual(sigBundle.dsseEnvelope.payloadType);
-        expect(e?.payload).toEqual(
-          enc.base64Encode(sigBundle.dsseEnvelope.payload.toString('base64'))
+        expect(entry.spec.proposedContent).toBeTruthy();
+        expect(entry.spec.proposedContent?.envelope).toEqual(
+          JSON.stringify(envelopeToJSON(sigBundle.dsseEnvelope))
         );
-        expect(e?.signatures).toHaveLength(1);
-        expect(e?.signatures[0].keyid).toEqual(
-          sigBundle.dsseEnvelope.signatures[0].keyid
-        );
-        expect(e?.signatures[0].sig).toEqual(
-          enc.base64Encode(
-            sigBundle.dsseEnvelope.signatures[0].sig.toString('base64')
-          )
-        );
-        expect(e?.signatures[0].publicKey).toEqual(enc.base64Encode(publicKey));
-
-        expect(entry.spec.content.payloadHash).toBeTruthy();
-        expect(entry.spec.content.payloadHash?.algorithm).toBe('sha256');
-        expect(entry.spec.content.payloadHash?.value).toBe(
-          crypto
-            .digest('sha256', sigBundle.dsseEnvelope.payload)
-            .toString('hex')
-        );
-        expect(entry.spec.content.hash).toBeTruthy();
-        expect(entry.spec.content.hash?.algorithm).toBe('sha256');
-
-        // This hard-coded hash value helps us detect if we've unintentionally
-        // changed the hashing algorithm.
-        expect(entry.spec.content.hash?.value).toBe(
-          '37d47ab456ca63a84f6457be655dd49799542f2e1db5d05160b214fb0b9a7f55'
+        expect(entry.spec.proposedContent?.verifiers).toHaveLength(1);
+        expect(entry.spec.proposedContent?.verifiers[0]).toEqual(
+          enc.base64Encode(publicKey)
         );
       });
     });
@@ -125,7 +99,7 @@ describe('toProposedEntry', () => {
       };
 
       it('return a valid ProposedEntry entry', () => {
-        const entry = toProposedEntry(sigBundle, publicKey);
+        const entry = toProposedEntry(sigBundle, publicKey, 'intoto');
 
         assert(entry.apiVersion === '0.0.2');
         assert(entry.kind === 'intoto');
@@ -178,30 +152,52 @@ describe('toProposedEntry', () => {
         },
       };
 
-      it('return a valid ProposedEntry entry', () => {
-        const entry = toProposedEntry(sigBundle, publicKey);
+      describe('when asking for an intoto entry', () => {
+        it('return a valid ProposedEntry entry', () => {
+          const entry = toProposedEntry(sigBundle, publicKey, 'intoto');
 
-        assert(entry.apiVersion === '0.0.2');
-        assert(entry.kind === 'intoto');
+          assert(entry.apiVersion === '0.0.2');
+          assert(entry.kind === 'intoto');
 
-        // Check to ensure only the first signature is included in the envelope
-        const e = entry.spec.content.envelope;
-        expect(e?.signatures).toHaveLength(1);
-        expect(e?.signatures[0].keyid).toEqual(
-          sigBundle.dsseEnvelope.signatures[0].keyid
-        );
-        expect(e?.signatures[0].sig).toEqual(
-          enc.base64Encode(
-            sigBundle.dsseEnvelope.signatures[0].sig.toString('base64')
-          )
-        );
-        expect(e?.signatures[0].publicKey).toEqual(enc.base64Encode(publicKey));
+          // Check to ensure only the first signature is included in the envelope
+          const e = entry.spec.content.envelope;
+          expect(e?.signatures).toHaveLength(1);
+          expect(e?.signatures[0].keyid).toEqual(
+            sigBundle.dsseEnvelope.signatures[0].keyid
+          );
+          expect(e?.signatures[0].sig).toEqual(
+            enc.base64Encode(
+              sigBundle.dsseEnvelope.signatures[0].sig.toString('base64')
+            )
+          );
+          expect(e?.signatures[0].publicKey).toEqual(
+            enc.base64Encode(publicKey)
+          );
 
-        // This hard-coded hash value helps us detect if we've unintentionally
-        // changed the hashing algorithm.
-        expect(entry.spec.content.hash?.value).toBe(
-          '37d47ab456ca63a84f6457be655dd49799542f2e1db5d05160b214fb0b9a7f55'
-        );
+          // This hard-coded hash value helps us detect if we've unintentionally
+          // changed the hashing algorithm.
+          expect(entry.spec.content.hash?.value).toBe(
+            '37d47ab456ca63a84f6457be655dd49799542f2e1db5d05160b214fb0b9a7f55'
+          );
+        });
+      });
+
+      describe('when asking for a dsse entry', () => {
+        it('return a valid ProposedEntry entry', () => {
+          const entry = toProposedEntry(sigBundle, publicKey, 'dsse');
+
+          assert(entry.apiVersion === '0.0.1');
+          assert(entry.kind === 'dsse');
+
+          expect(entry.spec.proposedContent).toBeTruthy();
+          expect(entry.spec.proposedContent?.envelope).toEqual(
+            JSON.stringify(envelopeToJSON(sigBundle.dsseEnvelope))
+          );
+          expect(entry.spec.proposedContent?.verifiers).toHaveLength(1);
+          expect(entry.spec.proposedContent?.verifiers[0]).toEqual(
+            enc.base64Encode(publicKey)
+          );
+        });
       });
     });
   });
@@ -218,7 +214,7 @@ describe('toProposedEntry', () => {
       };
 
       it('return a valid ProposedEntry entry', () => {
-        const entry = toProposedEntry(sigBundle, publicKey, 'dsse');
+        const entry = toProposedEntry(sigBundle, publicKey);
 
         assert(entry.apiVersion === '0.0.1');
         assert(entry.kind === 'dsse');

--- a/packages/sign/src/witness/tlog/entry.ts
+++ b/packages/sign/src/witness/tlog/entry.ts
@@ -30,15 +30,15 @@ export function toProposedEntry(
   content: SignatureBundle,
   publicKey: string,
   // TODO: Remove this parameter once have completely switched to 'dsse' entries
-  entryType: 'dsse' | 'intoto' = 'intoto'
+  entryType: 'dsse' | 'intoto' = 'dsse'
 ): ProposedEntry {
   switch (content.$case) {
     case 'dsseEnvelope':
-      // TODO: Remove this conditional once have completely switched to 'dsse' entries
-      if (entryType === 'dsse') {
-        return toProposedDSSEEntry(content.dsseEnvelope, publicKey);
+      // TODO: Remove this conditional once have completely ditched "intoto" entries
+      if (entryType === 'intoto') {
+        return toProposedIntotoEntry(content.dsseEnvelope, publicKey);
       }
-      return toProposedIntotoEntry(content.dsseEnvelope, publicKey);
+      return toProposedDSSEEntry(content.dsseEnvelope, publicKey);
     case 'messageSignature':
       return toProposedHashedRekordEntry(content.messageSignature, publicKey);
   }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates `RekorWitness` so that it generates "dsse" entries instead of "intoto" entries by default. The user can still request an "intoto" entry by explicitly setting the `entryType` field.

This is a breaking API change and will result in a major version bump.