### PR TITLE
remove `hash` function in core package

### DIFF
--- a/.changeset/large-zoos-buy.md
+++ b/.changeset/large-zoos-buy.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/core': major
+---
+
+Remove `hash` function in core package

--- a/packages/core/src/__tests__/crypto.test.ts
+++ b/packages/core/src/__tests__/crypto.test.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { bufferEqual, createPublicKey, hash } from '../crypto';
+import { bufferEqual, createPublicKey, digest } from '../crypto';
 
 describe('createPublicKey', () => {
   it('should create a public key from a PEM string', () => {
@@ -39,11 +39,11 @@ rkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==
   });
 });
 
-describe('hash', () => {
+describe('digest', () => {
   it('returns the SHA256 digest of the blob', () => {
     const blob = Buffer.from('hello world');
-    const digest = hash(blob);
-    expect(digest.toString('hex')).toBe(
+    const d = digest('sha256', blob);
+    expect(d.toString('hex')).toBe(
       'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'
     );
   });

--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -16,8 +16,6 @@ limitations under the License.
 import crypto, { BinaryLike } from 'crypto';
 export type { KeyObject } from 'crypto';
 
-const SHA256_ALGORITHM = 'sha256';
-
 export function createPublicKey(
   key: string | Buffer,
   type: 'spki' | 'pkcs1' = 'spki'
@@ -31,15 +29,6 @@ export function createPublicKey(
 
 export function digest(algorithm: string, ...data: BinaryLike[]): Buffer {
   const hash = crypto.createHash(algorithm);
-  for (const d of data) {
-    hash.update(d);
-  }
-  return hash.digest();
-}
-
-// TODO: deprecate this in favor of digest()
-export function hash(...data: BinaryLike[]): Buffer {
-  const hash = crypto.createHash(SHA256_ALGORITHM);
   for (const d of data) {
     hash.update(d);
   }

--- a/packages/sign/src/__tests__/bundler/base.test.ts
+++ b/packages/sign/src/__tests__/bundler/base.test.ts
@@ -124,7 +124,7 @@ describe('BaseBundleBuilder', () => {
           messageSignature: {
             messageDigest: {
               algorithm: HashAlgorithm.SHA2_256,
-              digest: crypto.hash(artifact.data),
+              digest: crypto.digest('sha256', artifact.data),
             },
             signature: expect.anything(),
           },
@@ -160,7 +160,7 @@ describe('BaseBundleBuilder', () => {
           bundle.content.messageSignature?.messageDigest?.algorithm
         ).toEqual(HashAlgorithm.SHA2_256);
         expect(bundle.content.messageSignature?.messageDigest?.digest).toEqual(
-          crypto.hash(artifact.data)
+          crypto.digest('sha256', artifact.data)
         );
 
         // VerificationMaterial - Content
@@ -216,7 +216,7 @@ describe('BaseBundleBuilder', () => {
           messageSignature: {
             messageDigest: {
               algorithm: HashAlgorithm.SHA2_256,
-              digest: crypto.hash(artifact.data),
+              digest: crypto.digest('sha256', artifact.data),
             },
             signature: expect.anything(),
           },
@@ -252,7 +252,7 @@ describe('BaseBundleBuilder', () => {
           bundle.content.messageSignature?.messageDigest?.algorithm
         ).toEqual(HashAlgorithm.SHA2_256);
         expect(bundle.content.messageSignature?.messageDigest?.digest).toEqual(
-          crypto.hash(artifact.data)
+          crypto.digest('sha256', artifact.data)
         );
 
         // VerificationMaterial - Content

--- a/packages/sign/src/__tests__/bundler/bundle.test.ts
+++ b/packages/sign/src/__tests__/bundler/bundle.test.ts
@@ -52,7 +52,7 @@ describe('toMessageSignatureBundle', () => {
       HashAlgorithm.SHA2_256
     );
     expect(b.content.messageSignature.messageDigest.digest).toEqual(
-      crypto.hash(artifact.data)
+      crypto.digest('sha256', artifact.data)
     );
     expect(b.content.messageSignature.signature).toEqual(sigBytes);
 

--- a/packages/sign/src/__tests__/bundler/message.test.ts
+++ b/packages/sign/src/__tests__/bundler/message.test.ts
@@ -77,7 +77,7 @@ describe('MessageSignatureBundleBuilder', () => {
         HashAlgorithm.SHA2_256
       );
       expect(b.content.messageSignature.messageDigest.digest).toEqual(
-        crypto.hash(artifact.data)
+        crypto.digest('sha256', artifact.data)
       );
       expect(b.content.messageSignature.signature).toEqual(sigBytes);
 

--- a/packages/sign/src/__tests__/witness/tlog/entry.test.ts
+++ b/packages/sign/src/__tests__/witness/tlog/entry.test.ts
@@ -99,7 +99,9 @@ describe('toProposedEntry', () => {
         expect(entry.spec.content.payloadHash).toBeTruthy();
         expect(entry.spec.content.payloadHash?.algorithm).toBe('sha256');
         expect(entry.spec.content.payloadHash?.value).toBe(
-          crypto.hash(sigBundle.dsseEnvelope.payload).toString('hex')
+          crypto
+            .digest('sha256', sigBundle.dsseEnvelope.payload)
+            .toString('hex')
         );
         expect(entry.spec.content.hash).toBeTruthy();
         expect(entry.spec.content.hash?.algorithm).toBe('sha256');
@@ -148,7 +150,9 @@ describe('toProposedEntry', () => {
         expect(entry.spec.content.payloadHash).toBeTruthy();
         expect(entry.spec.content.payloadHash?.algorithm).toBe('sha256');
         expect(entry.spec.content.payloadHash?.value).toBe(
-          crypto.hash(sigBundle.dsseEnvelope.payload).toString('hex')
+          crypto
+            .digest('sha256', sigBundle.dsseEnvelope.payload)
+            .toString('hex')
         );
         expect(entry.spec.content.hash).toBeTruthy();
         expect(entry.spec.content.hash?.algorithm).toBe('sha256');

--- a/packages/sign/src/__tests__/witness/tsa/client.test.ts
+++ b/packages/sign/src/__tests__/witness/tsa/client.test.ts
@@ -35,7 +35,7 @@ describe('TSAClient', () => {
     const signature = Buffer.from('signature');
 
     const request = {
-      artifactHash: crypto.hash(signature).toString('base64'),
+      artifactHash: crypto.digest('sha256', signature).toString('base64'),
       hashAlgorithm: 'sha256',
     };
 

--- a/packages/sign/src/bundler/bundle.ts
+++ b/packages/sign/src/bundler/bundle.ts
@@ -26,7 +26,7 @@ export function toMessageSignatureBundle(
   artifact: Artifact,
   signature: Signature
 ): sigstore.BundleWithMessageSignature {
-  const digest = crypto.hash(artifact.data);
+  const digest = crypto.digest('sha256', artifact.data);
 
   return sigstore.toMessageSignatureBundle({
     digest,

--- a/packages/sign/src/witness/tlog/entry.ts
+++ b/packages/sign/src/witness/tlog/entry.ts
@@ -24,6 +24,8 @@ import type {
 } from '../../external/rekor';
 import type { SignatureBundle } from '../witness';
 
+const SHA256_ALGORITHM = 'sha256';
+
 export function toProposedEntry(
   content: SignatureBundle,
   publicKey: string,
@@ -58,7 +60,7 @@ function toProposedHashedRekordEntry(
     spec: {
       data: {
         hash: {
-          algorithm: 'sha256',
+          algorithm: SHA256_ALGORITHM,
           value: hexDigest,
         },
       },
@@ -100,7 +102,9 @@ function toProposedIntotoEntry(
   publicKey: string
 ): ProposedIntotoEntry {
   // Calculate the value for the payloadHash field in the Rekor entry
-  const payloadHash = crypto.hash(envelope.payload).toString('hex');
+  const payloadHash = crypto
+    .digest(SHA256_ALGORITHM, envelope.payload)
+    .toString('hex');
 
   // Calculate the value for the hash field in the Rekor entry
   const envelopeHash = calculateDSSEHash(envelope, publicKey);
@@ -134,8 +138,8 @@ function toProposedIntotoEntry(
     spec: {
       content: {
         envelope: dsse,
-        hash: { algorithm: 'sha256', value: envelopeHash },
-        payloadHash: { algorithm: 'sha256', value: payloadHash },
+        hash: { algorithm: SHA256_ALGORITHM, value: envelopeHash },
+        payloadHash: { algorithm: SHA256_ALGORITHM, value: payloadHash },
       },
     },
   };
@@ -162,5 +166,7 @@ function calculateDSSEHash(envelope: Envelope, publicKey: string): string {
     dsse.signatures[0].keyid = envelope.signatures[0].keyid;
   }
 
-  return crypto.hash(json.canonicalize(dsse)).toString('hex');
+  return crypto
+    .digest(SHA256_ALGORITHM, json.canonicalize(dsse))
+    .toString('hex');
 }

--- a/packages/sign/src/witness/tsa/client.ts
+++ b/packages/sign/src/witness/tsa/client.ts
@@ -19,6 +19,8 @@ import { crypto } from '../../util';
 
 import type { FetchOptions } from '../../types/fetch';
 
+const SHA256_ALGORITHM = 'sha256';
+
 export interface TSA {
   createTimestamp: (signature: Buffer) => Promise<Buffer>;
 }
@@ -40,8 +42,10 @@ export class TSAClient implements TSA {
 
   public async createTimestamp(signature: Buffer): Promise<Buffer> {
     const request = {
-      artifactHash: crypto.hash(signature).toString('base64'),
-      hashAlgorithm: 'sha256',
+      artifactHash: crypto
+        .digest(SHA256_ALGORITHM, signature)
+        .toString('base64'),
+      hashAlgorithm: SHA256_ALGORITHM,
     };
 
     try {

--- a/packages/verify/src/__tests__/bundle/dsse.test.ts
+++ b/packages/verify/src/__tests__/bundle/dsse.test.ts
@@ -47,7 +47,7 @@ describe('DSSESignatureContent', () => {
     });
 
     describe('when the digest matches the payload hash', () => {
-      const expectedDigest = core.hash(env.payload);
+      const expectedDigest = core.digest('sha256', env.payload);
 
       it('returns true', () => {
         expect(subject.compareDigest(expectedDigest)).toBe(true);

--- a/packages/verify/src/__tests__/bundle/message.test.ts
+++ b/packages/verify/src/__tests__/bundle/message.test.ts
@@ -23,7 +23,7 @@ import type { MessageSignature } from '@sigstore/bundle';
 describe('MessageSignatureContent', () => {
   const key = crypto.generateKeyPairSync('ec', { namedCurve: 'secp256k1' });
   const message = Buffer.from('message');
-  const messageDigest = core.hash(message);
+  const messageDigest = core.digest('sha256', message);
 
   const messageSignature: MessageSignature = {
     messageDigest: { digest: messageDigest, algorithm: HashAlgorithm.SHA2_256 },

--- a/packages/verify/src/__tests__/key/index.test.ts
+++ b/packages/verify/src/__tests__/key/index.test.ts
@@ -52,7 +52,7 @@ describe('verifyCertificate', () => {
   };
 
   const ctlogAuthority: TLogAuthority = {
-    logID: crypto.hash(keyBytes),
+    logID: crypto.digest('sha256', keyBytes),
     publicKey: crypto.createPublicKey(keyBytes),
     validFor: { start: new Date(0), end: new Date('2100-01-01') },
   };

--- a/packages/verify/src/__tests__/timestamp/checkpoint.test.ts
+++ b/packages/verify/src/__tests__/timestamp/checkpoint.test.ts
@@ -26,7 +26,7 @@ describe('verifyCheckpoint', () => {
     'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==',
     'base64'
   );
-  const keyID = crypto.hash(keyBytes);
+  const keyID = crypto.digest('sha256', keyBytes);
 
   const tlogInstance: TLogAuthority = {
     publicKey: crypto.createPublicKey(keyBytes),
@@ -243,7 +243,7 @@ describe('verifyCheckpoint', () => {
       'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDODRU688UYGuy54mNUlaEBiQdTE9nYLr0lg6RXowI/QV/RE1azBn4Eg5/2uTOMbhB1/gfcHzijzFi9Tk+g1Prg==',
       'base64'
     );
-    const keyID = crypto.hash(keyBytes);
+    const keyID = crypto.digest('sha256', keyBytes);
 
     const tlogInstance: TLogAuthority = {
       publicKey: crypto.createPublicKey(keyBytes),

--- a/packages/verify/src/__tests__/timestamp/index.test.ts
+++ b/packages/verify/src/__tests__/timestamp/index.test.ts
@@ -32,7 +32,7 @@ describe('verifyTLogTimestamp', () => {
     'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==',
     'base64'
   );
-  const keyID = crypto.hash(keyBytes);
+  const keyID = crypto.digest('sha256', keyBytes);
 
   const validTLog: TLogAuthority = {
     logID: keyID,

--- a/packages/verify/src/__tests__/timestamp/merkle.test.ts
+++ b/packages/verify/src/__tests__/timestamp/merkle.test.ts
@@ -199,7 +199,7 @@ describe('verifyMerkleInclusion', () => {
         hashes: [],
         treeSize: '1',
         logIndex: '0',
-        rootHash: crypto.hash(Buffer.from([0x00]), body),
+        rootHash: crypto.digest('sha256', Buffer.from([0x00]), body),
       },
     });
 

--- a/packages/verify/src/__tests__/timestamp/set.test.ts
+++ b/packages/verify/src/__tests__/timestamp/set.test.ts
@@ -27,7 +27,7 @@ describe('verifyTLogSET', () => {
     'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwrkBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==',
     'base64'
   );
-  const keyID = crypto.hash(keyBytes);
+  const keyID = crypto.digest('sha256', keyBytes);
 
   const validTLog: TLogAuthority = {
     logID: keyID,

--- a/packages/verify/src/bundle/dsse.ts
+++ b/packages/verify/src/bundle/dsse.ts
@@ -26,7 +26,10 @@ export class DSSESignatureContent implements SignatureContent {
   }
 
   public compareDigest(digest: Buffer): boolean {
-    return crypto.bufferEqual(digest, crypto.hash(this.env.payload));
+    return crypto.bufferEqual(
+      digest,
+      crypto.digest('sha256', this.env.payload)
+    );
   }
 
   public compareSignature(signature: Buffer): boolean {

--- a/packages/verify/src/key/sct.ts
+++ b/packages/verify/src/key/sct.ts
@@ -71,7 +71,7 @@ export function verifySCTs(
   const preCert = new ByteStream();
 
   // Calculate hash of the issuer's public key
-  const issuerId = crypto.hash(issuer.publicKey);
+  const issuerId = crypto.digest('sha256', issuer.publicKey);
   preCert.appendView(issuerId);
 
   // Re-encodes the certificate to DER after removing the SCT extension

--- a/packages/verify/src/timestamp/merkle.ts
+++ b/packages/verify/src/timestamp/merkle.ts
@@ -119,9 +119,9 @@ function bitLength(n: bigint): number {
 // Hashing logic according to RFC6962.
 // https://datatracker.ietf.org/doc/html/rfc6962#section-2
 function hashChildren(left: Buffer, right: Buffer): Buffer {
-  return crypto.hash(RFC6962_NODE_HASH_PREFIX, left, right);
+  return crypto.digest('sha256', RFC6962_NODE_HASH_PREFIX, left, right);
 }
 
 function hashLeaf(leaf: Buffer): Buffer {
-  return crypto.hash(RFC6962_LEAF_HASH_PREFIX, leaf);
+  return crypto.digest('sha256', RFC6962_LEAF_HASH_PREFIX, leaf);
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Remove the `hash` function in the `core` package. Change all uses of `hash` to the new `digest` function.

This is a breaking change and will result in a major version bump.