### PR TITLE
drop node 16 support in rekor-types package

### DIFF
--- a/.changeset/unlucky-baboons-suffer.md
+++ b/.changeset/unlucky-baboons-suffer.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/rekor-types': major
+---
+
+Drop support for node 16

--- a/package-lock.json
+++ b/package-lock.json
@@ -13217,7 +13217,7 @@
         "openapi-typescript-codegen": "^0.29.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "packages/sign": {

--- a/packages/rekor-types/package.json
+++ b/packages/rekor-types/package.json
@@ -32,6 +32,6 @@
     "openapi-typescript-codegen": "^0.29.0"
   },
   "engines": {
-    "node": "^16.14.0 || >=18.0.0"
+    "node": "^18.17.0 || >=20.5.0"
   }
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Drop node 16 support in the `rekor-types` package.

This is a breaking change and will result in a major version bump.