### PR TITLE
regen rekor types from sigstore/rekor 1.3.6

### DIFF
--- a/.changeset/hungry-mice-appear.md
+++ b/.changeset/hungry-mice-appear.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/rekor-types': patch
+---
+
+Regenerate rekor types from sigstore/rekor v1.3.6

--- a/packages/rekor-types/hack/generate-rekor-types
+++ b/packages/rekor-types/hack/generate-rekor-types
@@ -1,8 +1,8 @@
 #!/usr/bin/env sh
 set -ex
 
-# Check-out Rekor repo
-REF=576458cb53269ed54dccf8a43271ee02a785c191
+# Check-out Rekor repo (v1.3.6)
+REF=a6788566cd62facb0fb0450e9d2c2867f551e37c
 REKOR_DIR=/tmp/rekor
 
 rm -rf ${REKOR_DIR}

--- a/packages/rekor-types/src/__generated__/dsse.ts
+++ b/packages/rekor-types/src/__generated__/dsse.ts
@@ -12,12 +12,7 @@ export type DSSESchema = DSSEV001Schema;
 /**
  * Schema for DSSE envelopes
  */
-export type DSSEV001Schema = DSSEV001Schema1 & DSSEV001Schema2;
-export type DSSEV001Schema2 = {
-  [k: string]: unknown;
-};
-
-export interface DSSEV001Schema1 {
+export type DSSEV001Schema = {
   proposedContent?: {
     /**
      * DSSE envelope specified as a stringified JSON object
@@ -83,4 +78,6 @@ export interface DSSEV001Schema1 {
      */
     value: string;
   };
-}
+} & {
+  [k: string]: unknown;
+};

--- a/packages/rekor-types/src/__generated__/hashedrekord.ts
+++ b/packages/rekor-types/src/__generated__/hashedrekord.ts
@@ -43,9 +43,9 @@ export interface HashedRekorV001Schema {
       /**
        * The hashing function used to compute the hash value
        */
-      algorithm: "sha256";
+      algorithm: "sha256" | "sha384" | "sha512";
       /**
-       * The hash value for the content
+       * The hash value for the content, as represented by a lower case hexadecimal string
        */
       value: string;
     };

--- a/packages/rekor-types/src/__generated__/index.ts
+++ b/packages/rekor-types/src/__generated__/index.ts
@@ -1,3 +1,4 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */

--- a/packages/rekor-types/src/__generated__/models/ConsistencyProof.ts
+++ b/packages/rekor-types/src/__generated__/models/ConsistencyProof.ts
@@ -1,7 +1,7 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ConsistencyProof = {
     /**
      * The hash value stored at the root of the merkle tree at the time the proof was generated

--- a/packages/rekor-types/src/__generated__/models/Error.ts
+++ b/packages/rekor-types/src/__generated__/models/Error.ts
@@ -1,7 +1,7 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type Error = {
     code?: number;
     message?: string;

--- a/packages/rekor-types/src/__generated__/models/InactiveShardLogInfo.ts
+++ b/packages/rekor-types/src/__generated__/models/InactiveShardLogInfo.ts
@@ -1,7 +1,7 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type InactiveShardLogInfo = {
     /**
      * The current hash value stored at the root of the merkle tree

--- a/packages/rekor-types/src/__generated__/models/InclusionProof.ts
+++ b/packages/rekor-types/src/__generated__/models/InclusionProof.ts
@@ -1,7 +1,7 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type InclusionProof = {
     /**
      * The index of the entry in the transparency log

--- a/packages/rekor-types/src/__generated__/models/LogEntry.ts
+++ b/packages/rekor-types/src/__generated__/models/LogEntry.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { InclusionProof } from './InclusionProof';
-
 export type LogEntry = Record<string, {
     /**
      * This is the SHA256 hash of the DER-encoded public key for the log at the time the entry was included in the log
@@ -11,6 +10,9 @@ export type LogEntry = Record<string, {
     logID: string;
     logIndex: number;
     body: any;
+    /**
+     * The time the entry was added to the log as a Unix timestamp in seconds
+     */
     integratedTime: number;
     attestation?: {
         data?: any;

--- a/packages/rekor-types/src/__generated__/models/LogInfo.ts
+++ b/packages/rekor-types/src/__generated__/models/LogInfo.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { InactiveShardLogInfo } from './InactiveShardLogInfo';
-
 export type LogInfo = {
     /**
      * The current hash value stored at the root of the merkle tree

--- a/packages/rekor-types/src/__generated__/models/ProposedEntry.ts
+++ b/packages/rekor-types/src/__generated__/models/ProposedEntry.ts
@@ -1,7 +1,7 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type ProposedEntry = {
     kind: string;
 };

--- a/packages/rekor-types/src/__generated__/models/SearchIndex.ts
+++ b/packages/rekor-types/src/__generated__/models/SearchIndex.ts
@@ -1,7 +1,7 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 export type SearchIndex = {
     email?: string;
     publicKey?: {

--- a/packages/rekor-types/src/__generated__/models/SearchLogQuery.ts
+++ b/packages/rekor-types/src/__generated__/models/SearchLogQuery.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 export type SearchLogQuery = {
     entryUUIDs?: Array<string>;
     logIndexes?: Array<number>;

--- a/packages/rekor-types/src/__generated__/models/alpine.ts
+++ b/packages/rekor-types/src/__generated__/models/alpine.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 /**
  * Alpine package
  */

--- a/packages/rekor-types/src/__generated__/models/cose.ts
+++ b/packages/rekor-types/src/__generated__/models/cose.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 /**
  * COSE object
  */

--- a/packages/rekor-types/src/__generated__/models/dsse.ts
+++ b/packages/rekor-types/src/__generated__/models/dsse.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 /**
  * DSSE envelope
  */

--- a/packages/rekor-types/src/__generated__/models/hashedrekord.ts
+++ b/packages/rekor-types/src/__generated__/models/hashedrekord.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 /**
  * Hashed Rekord object
  */

--- a/packages/rekor-types/src/__generated__/models/helm.ts
+++ b/packages/rekor-types/src/__generated__/models/helm.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 /**
  * Helm chart
  */

--- a/packages/rekor-types/src/__generated__/models/intoto.ts
+++ b/packages/rekor-types/src/__generated__/models/intoto.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 /**
  * Intoto object
  */

--- a/packages/rekor-types/src/__generated__/models/jar.ts
+++ b/packages/rekor-types/src/__generated__/models/jar.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 /**
  * Java Archive (JAR)
  */

--- a/packages/rekor-types/src/__generated__/models/rekord.ts
+++ b/packages/rekor-types/src/__generated__/models/rekord.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 /**
  * Rekord object
  */

--- a/packages/rekor-types/src/__generated__/models/rfc3161.ts
+++ b/packages/rekor-types/src/__generated__/models/rfc3161.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 /**
  * RFC3161 Timestamp
  */

--- a/packages/rekor-types/src/__generated__/models/rpm.ts
+++ b/packages/rekor-types/src/__generated__/models/rpm.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 /**
  * RPM package
  */

--- a/packages/rekor-types/src/__generated__/models/tuf.ts
+++ b/packages/rekor-types/src/__generated__/models/tuf.ts
@@ -1,9 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-
 import type { ProposedEntry } from './ProposedEntry';
-
 /**
  * TUF metadata
  */


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Regenerate the rekor types from the `sigstore/rekor` repository version 1.3.6.