### PR TITLE
add legacyCompatibility to sign/attest functions

### DIFF
--- a/.changeset/nasty-mangos-appear.md
+++ b/.changeset/nasty-mangos-appear.md
@@ -1,0 +1,5 @@
+---
+'sigstore': major
+---
+
+Updates the `sign` and `attest` functions so that they generate v0.3 Sigstore bundles by default. To continue generating v0.2 bundles, use the new `legacyCompatibility` flag.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,4 +1,4 @@
-# sigstore &middot; [![npm version](https://img.shields.io/npm/v/sigstore.svg?style=flat)](https://www.npmjs.com/package/sigstore) [![CI Status](https://github.com/sigstore/sigstore-js/workflows/CI/badge.svg)](https://github.com/sigstore/sigstore-js/actions/workflows/ci.yml) [![Smoke Test Status](https://github.com/sigstore/sigstore-js/workflows/smoke-test/badge.svg)](https://github.com/sigstore/sigstore-js/actions/workflows/smoke-test.yml)
+# sigstore &middot; [![npm version](https://img.shields.io/npm/v/sigstore.svg?style=flat)](https://www.npmjs.com/package/sigstore) [![CI Status](https://github.com/sigstore/sigstore-js/workflows/CI/badge.svg)](https://github.com/sigstore/sigstore-js/actions/workflows/ci.yml) [![Smoke test](https://github.com/sigstore/sigstore-js/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/sigstore/sigstore-js/actions/workflows/smoke-test.yml)
 
 A JavaScript library for generating and verifying Sigstore signatures. One of
 the intended uses is to sign and verify npm packages but it can be used to sign
@@ -12,7 +12,7 @@ and verify any file.
 
 ## Prerequisites
 
-- Node.js version >= 16.14.0
+- Node.js version >= 18.17.0
 
 ## Installation
 
@@ -161,6 +161,7 @@ necessary to verify the signature.
   - `tlogUpload` `<boolean>`: Flag indicating whether or not the signature should be recorded on the Rekor transparency log. Defaults to `true`.
   - `identityToken` `<string>`: The OIDC token identifying the signer. If no explicit token is supplied, an attempt will be made to retrieve one from the environment. This config cannot be used with `identityProvider`.
   - `identityProvider` `<IdentityProvider>`: Object which implements `getToken: () => Promise<string>`. The supplied provider will be used to retrieve an OIDC token. If no provider is supplied, an attempt will be made to retrieve an OIDC token from the environment. This config cannot be used with `identityToken`.
+  - `legacyCompatibility` `<boolean>`: Flag indicating whether to enable legacy compatibility mode. When set to `true`, the returned bundle will use the Sigstore v0.2 bundle format. When unset or `false`, the returned bundle will be v0.3 or greater.
 
 ### attest(payload, payloadType[, options])
 
@@ -177,6 +178,7 @@ as well as the verification material necessary to verify the signature.
   - `tlogUpload` `<boolean>`: Flag indicating whether or not the signed statement should be recorded on the Rekor transparency log. Defaults to `true`.
   - `identityToken` `<string>`: The OIDC token identifying the signer. If no explicit token is supplied, an attempt will be made to retrieve one from the environment. This config cannot be used with `identityProvider`.
   - `identityProvider` `<IdentityProvider>`: Object which implements `getToken: () => Promise<string>`. The supplied provider will be used to retrieve an OIDC token. If no provider is supplied, an attempt will be made to retrieve an OIDC token from the environment. This config cannot be used with `identityToken`.
+  - `legacyCompatibility` `<boolean>`: Flag indicating whether to enable legacy compatibility mode. When set to `true`, any record written to the Rekor transparency log will use the "intoto" record type and the returned bundle will use the Sigstore v0.2 bundle format. When unset or `false`, the "dsse" Rekor type will be used and the returned bundle will be v0.3 or greater.
 
 ### verify(bundle[, payload][, options])
 

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -51,6 +51,7 @@ export type SignOptions = {
   rekorURL?: string;
   tlogUpload?: boolean;
   tsaServerURL?: string;
+  legacyCompatibility?: boolean;
 } & FetchOptions;
 
 export type VerifyOptions = {
@@ -95,7 +96,7 @@ export function createBundleBuilder(
     case 'dsseEnvelope':
       return new DSSEBundleBuilder({
         ...bundlerOptions,
-        certificateChain: true,
+        certificateChain: options.legacyCompatibility,
       });
   }
 }
@@ -170,7 +171,7 @@ function initWitnesses(options: SignOptions): Witness[] {
     witnesses.push(
       new RekorWitness({
         rekorBaseURL: options.rekorURL,
-        entryType: 'intoto',
+        entryType: options.legacyCompatibility ? 'intoto' : 'dsse',
         fetchOnConflict: false,
         retry: options.retry ?? DEFAULT_RETRY,
         timeout: options.timeout ?? DEFAULT_TIMEOUT,


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Updates the `sign` and `attest` functions to generate bundles using the v0.3 format by default. Also changes the default Rekor log entry type from "intoto" to "dsse".

The previous behavior (v0.2 bundles and the "intoto" Rekor type) can be enabled with the new `legacyCompatibility` flag.

This is a breaking change and will result in a major version bump.