### PR TITLE
bump tuf-js from 3.0.0 to 3.0.1

### DIFF
--- a/.changeset/spicy-peas-clap.md
+++ b/.changeset/spicy-peas-clap.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/tuf': patch
+---
+
+Bump tuf-js from 3.0.0 to 3.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -4147,13 +4147,17 @@
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
+      "integrity": "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==",
       "license": "MIT",
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/@tufjs/models": {
-      "version": "3.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tufjs/models/-/models-3.0.1.tgz",
+      "integrity": "sha512-UUYHISyhCU3ZgN8yaear3cGATHb3SMuKHsQ/nVbHXcmnBf+LzQ/cQfhNG+rfaSHgqGKNEm2cOCLVLELStUQ1JA==",
       "license": "MIT",
       "dependencies": {
         "@tufjs/canonical-json": "2.0.0",
@@ -4164,10 +4168,12 @@
       }
     },
     "node_modules/@tufjs/repo-mock": {
-      "version": "3.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@tufjs/repo-mock/-/repo-mock-3.0.1.tgz",
+      "integrity": "sha512-9as4Bg7trZ06+qQ4aqPcYWY0TUYuewG0e7kPsrAVokdBJh35TTqPR68o9L8ojyJcBM5xgSIDvLy0XPM1RCZdJA==",
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "3.0.0",
+        "@tufjs/models": "3.0.1",
         "nock": "^13.5.5"
       },
       "engines": {
@@ -11364,10 +11370,12 @@
       "license": "0BSD"
     },
     "node_modules/tuf-js": {
-      "version": "3.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-3.0.1.tgz",
+      "integrity": "sha512-+68OP1ZzSF84rTckf3FA95vJ1Zlx/uaXyiiKyPd1pA4rZNkpEvDAKmsu1xUSmbF/chCRYgZ6UZkDwC7PmzmAyA==",
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "3.0.0",
+        "@tufjs/models": "3.0.1",
         "debug": "^4.3.6",
         "make-fetch-happen": "^14.0.1"
       },
@@ -11877,7 +11885,7 @@
         "@sigstore/jest": "^0.0.0",
         "@sigstore/mock": "^0.7.4",
         "@sigstore/rekor-types": "^2.0.0",
-        "@tufjs/repo-mock": "^3.0.0",
+        "@tufjs/repo-mock": "^3.0.1",
         "@types/make-fetch-happen": "^10.0.4"
       },
       "engines": {
@@ -11960,7 +11968,7 @@
         "@oclif/color": "^1.0.13",
         "@oclif/core": "^4",
         "@sigstore/mock": "^0.7.4",
-        "@tufjs/repo-mock": "^3.0.0",
+        "@tufjs/repo-mock": "^3.0.1",
         "express": "4.21.0"
       },
       "bin": {
@@ -12031,11 +12039,11 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.3.2",
-        "tuf-js": "^3.0.0"
+        "tuf-js": "^3.0.1"
       },
       "devDependencies": {
         "@sigstore/jest": "^0.0.0",
-        "@tufjs/repo-mock": "^3.0.0",
+        "@tufjs/repo-mock": "^3.0.1",
         "@types/make-fetch-happen": "^10.0.4"
       },
       "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,7 @@
     "@sigstore/rekor-types": "^2.0.0",
     "@sigstore/jest": "^0.0.0",
     "@sigstore/mock": "^0.7.4",
-    "@tufjs/repo-mock": "^3.0.0",
+    "@tufjs/repo-mock": "^3.0.1",
     "@types/make-fetch-happen": "^10.0.4"
   },
   "dependencies": {

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -21,7 +21,7 @@
     "@oclif/color": "^1.0.13",
     "@oclif/core": "^4",
     "@sigstore/mock": "^0.7.4",
-    "@tufjs/repo-mock": "^3.0.0",
+    "@tufjs/repo-mock": "^3.0.1",
     "express": "4.21.0"
   },
   "devDependencies": {

--- a/packages/tuf/package.json
+++ b/packages/tuf/package.json
@@ -28,12 +28,12 @@
   },
   "devDependencies": {
     "@sigstore/jest": "^0.0.0",
-    "@tufjs/repo-mock": "^3.0.0",
+    "@tufjs/repo-mock": "^3.0.1",
     "@types/make-fetch-happen": "^10.0.4"
   },
   "dependencies": {
     "@sigstore/protobuf-specs": "^0.3.2",
-    "tuf-js": "^3.0.0"
+    "tuf-js": "^3.0.1"
   },
   "engines": {
     "node": "^18.17.0 || >=20.5.0"


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Bumps the `tuf-js` dependency from 3.0.0 to 3.0.1