### PR TITLE
Add more robust handling of generated certs in mock server

### DIFF
--- a/packages/mock/src/fulcio/__snapshots__/handler.test.ts.snap
+++ b/packages/mock/src/fulcio/__snapshots__/handler.test.ts.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fulcioHandler #fn when invoked returns a certificate with github extension 1`] = `
+Extensions [
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 2.5.29.15
+  BOOLEAN : getValue() {
+          return this.valueBlock.value;
+      }
+  OCTET STRING :
+    BIT STRING : 1",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 2.5.29.37
+  OCTET STRING :
+    SEQUENCE :
+      OBJECT IDENTIFIER : 1.3.6.1.5.5.7.3.3",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 2.5.29.17
+  BOOLEAN : getValue() {
+          return this.valueBlock.value;
+      }
+  OCTET STRING :
+    SEQUENCE :
+      PRIMITIVE : ",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 2.5.29.35
+  OCTET STRING :
+    SEQUENCE :
+      PRIMITIVE : ",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.1
+  OCTET STRING : 68747470733a2f2f746f6b656e2e616374696f6e732e67697468756275736572636f6e74656e742e636f6d",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.8
+  OCTET STRING :
+    UTF8String : 'https://token.actions.githubusercontent.com'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.2
+  OCTET STRING : 776f726b666c6f775f6469737061746368",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.3
+  OCTET STRING : 38326133626665366464353066653963373164363331356561653636646131353330373835366366",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.4
+  OCTET STRING : 45787472656d656c792064616e6765726f7573204f49444320626561636f6e",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.5
+  OCTET STRING : 73696773746f72652d636f6e666f726d616e63652f65787472656d656c792d64616e6765726f75732d7075626c69632d6f6964632d626561636f6e",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.6
+  OCTET STRING : 726566732f68656164732f6d61696e",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.9
+  OCTET STRING :
+    UTF8String : 'https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.10
+  OCTET STRING :
+    UTF8String : '82a3bfe6dd50fe9c71d6315eae66da15307856cf'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.11
+  OCTET STRING :
+    UTF8String : 'github-hosted'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.12
+  OCTET STRING :
+    UTF8String : 'https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.13
+  OCTET STRING :
+    UTF8String : '82a3bfe6dd50fe9c71d6315eae66da15307856cf'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.14
+  OCTET STRING :
+    UTF8String : 'refs/heads/main'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.15
+  OCTET STRING :
+    UTF8String : '632596897'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.16
+  OCTET STRING :
+    UTF8String : 'https://github.com/sigstore-conformance'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.17
+  OCTET STRING :
+    UTF8String : '131804563'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.18
+  OCTET STRING :
+    UTF8String : 'https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.19
+  OCTET STRING :
+    UTF8String : '82a3bfe6dd50fe9c71d6315eae66da15307856cf'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.20
+  OCTET STRING :
+    UTF8String : 'workflow_dispatch'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.21
+  OCTET STRING :
+    UTF8String : 'https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/actions/runs/11566574533/attempts/1'",
+  "SEQUENCE :
+  OBJECT IDENTIFIER : 1.3.6.1.4.1.57264.1.22
+  OCTET STRING :
+    UTF8String : 'public'",
+]
+`;

--- a/packages/mock/src/fulcio/ca.ts
+++ b/packages/mock/src/fulcio/ca.ts
@@ -44,7 +44,7 @@ export interface CertificateRequestOptions {
   extensions?: ExtensionValue[];
 }
 
-interface ExtensionValue {
+export interface ExtensionValue {
   oid: string;
   value: string;
   legacy?: boolean;

--- a/packages/mock/src/fulcio/handler.test.ts
+++ b/packages/mock/src/fulcio/handler.test.ts
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { generateKeyPairSync } from 'crypto';
+import { generateKeyPairSync, subtle } from 'crypto';
 import { generateKeyPair } from '../util/key';
 import { CA, initializeCA } from './ca';
 import { fulcioHandler } from './handler';
+import x509 from '@peculiar/x509';
 
 describe('fulcioHandler', () => {
   const keyPair = generateKeyPair('prime256v1');
@@ -95,6 +96,131 @@ describe('fulcioHandler', () => {
           const resp = await fn(JSON.stringify(certRequest));
           expect(resp.statusCode).toBe(400);
         });
+      });
+
+      it('errors when given both csr and pkr', async () => {
+        const ca = await initializeCA(keyPair);
+        const { fn } = fulcioHandler(ca);
+
+        const req = {
+          ...certRequest,
+          certificateSigningRequest: {},
+        };
+        const resp = await fn(JSON.stringify(req));
+        expect(resp.statusCode).toBe(400);
+        expect(resp.response.toString()).toEqual(
+          'Invalid request -- cannot specify both CSR and public key'
+        );
+      });
+
+      it('errors when missing both csr and pkr', async () => {
+        const ca = await initializeCA(keyPair);
+        const { fn } = fulcioHandler(ca);
+
+        const resp = await fn(JSON.stringify({}));
+        expect(resp.statusCode).toBe(400);
+        expect(resp.response.toString()).toEqual(
+          'Invalid request -- must specify either CSR or public key'
+        );
+      });
+
+      it('errors when missing oidcIdentityToken', async () => {
+        const ca = await initializeCA(keyPair);
+        const { fn } = fulcioHandler(ca);
+
+        const resp = await fn(
+          JSON.stringify({
+            ...certRequest,
+            credentials: {},
+          })
+        );
+        expect(resp.statusCode).toBe(400);
+        expect(resp.response.toString()).toEqual(
+          'Invalid request -- missing OIDC identity token'
+        );
+      });
+
+      it('returns a certificate with github extension', async () => {
+        const kp2 = await subtle.generateKey(
+          { name: 'ecdsa', namedCurve: 'P-256' },
+          true,
+          ['sign', 'verify']
+        );
+        const csr = await x509.Pkcs10CertificateRequestGenerator.create({
+          signingAlgorithm: {
+            name: 'ECDSA',
+            hash: 'SHA-256',
+          },
+          keys: kp2,
+        });
+
+        const claims = {
+          jti: '1fa628c1-c044-482b-a350-0efe250f852b',
+          sub: 'repo:sigstore-conformance/extremely-dangerous-public-oidc-beacon:ref:refs/heads/main',
+          aud: 'sigstore',
+          ref: 'refs/heads/main',
+          sha: '82a3bfe6dd50fe9c71d6315eae66da15307856cf',
+          repository:
+            'sigstore-conformance/extremely-dangerous-public-oidc-beacon',
+          repository_owner: 'sigstore-conformance',
+          repository_owner_id: '131804563',
+          run_id: '11566574533',
+          run_number: '171745',
+          run_attempt: '1',
+          repository_visibility: 'public',
+          repository_id: '632596897',
+          actor_id: '41898282',
+          actor: 'github-actions[bot]',
+          workflow: 'Extremely dangerous OIDC beacon',
+          head_ref: '',
+          base_ref: '',
+          event_name: 'workflow_dispatch',
+          ref_protected: 'true',
+          ref_type: 'branch',
+          workflow_ref:
+            'sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main',
+          workflow_sha: '82a3bfe6dd50fe9c71d6315eae66da15307856cf',
+          job_workflow_ref:
+            'sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main',
+          job_workflow_sha: '82a3bfe6dd50fe9c71d6315eae66da15307856cf',
+          runner_environment: 'github-hosted',
+          iss: 'https://token.actions.githubusercontent.com',
+          nbf: 1730170833,
+          exp: 1730171733,
+          iat: 1730171433,
+        };
+        const jwt = jwtify(claims);
+
+        const certRequest = {
+          credentials: {
+            oidcIdentityToken: jwt,
+          },
+          certificateSigningRequest: csr.toString(),
+        };
+
+        const ca = await initializeCA(keyPair);
+        const { fn } = fulcioHandler(ca);
+
+        // Make a request
+        const resp = await fn(JSON.stringify(certRequest));
+        expect(resp.statusCode).toBe(201);
+
+        const certs = JSON.parse(resp.response.toString());
+        expect(certs).toBeDefined();
+        expect(certs.signedCertificateEmbeddedSct).toBeDefined();
+        expect(certs.signedCertificateEmbeddedSct.chain).toBeDefined();
+        expect(
+          certs.signedCertificateEmbeddedSct.chain.certificates
+        ).toBeDefined();
+
+        const { extensions } = new x509.X509Certificate(
+          certs.signedCertificateEmbeddedSct.chain.certificates[0]
+        );
+        expect(
+          extensions
+            .filter((e) => e.type !== '2.5.29.14')
+            .map((e) => e.toString('asn'))
+        ).toMatchSnapshot();
       });
     });
   });

--- a/packages/mock/src/fulcio/handler.ts
+++ b/packages/mock/src/fulcio/handler.ts
@@ -18,7 +18,8 @@ import assert from 'assert';
 import { generateKeyPairSync } from 'crypto';
 import * as jose from 'jose';
 import type { Handler, HandlerFn, HandlerFnResult } from '../shared.types';
-import type { CA } from './ca';
+import type { CA, ExtensionValue } from './ca';
+import x509 from '@peculiar/x509';
 
 const CREATE_SIGNING_CERT_PATH = '/api/v2/signingCert';
 const DEFAULT_SUBJECT = 'NO-SUBJECT';
@@ -52,18 +53,95 @@ function createSigningCertHandler(
   return async (body: string): Promise<HandlerFnResult> => {
     try {
       // Extract relevant fields from the request
-      const { subject, issuer, publicKey } = strict
+      const { subject, issuer, publicKey, claims } = strict
         ? parseBody(body, subjectClaim)
         : stubBody();
+
+      const extensions: ExtensionValue[] = [
+        { oid: ISSUER_EXT_OID_V1, value: issuer, legacy: true },
+        { oid: ISSUER_EXT_OID_V2, value: issuer },
+      ];
+
+      switch (issuer) {
+        case 'https://token.actions.githubusercontent.com': {
+          const server_url = 'https://github.com/';
+          extensions.push(
+            {
+              oid: '1.3.6.1.4.1.57264.1.2',
+              value: claims['event_name'],
+              legacy: true,
+            },
+            {
+              oid: '1.3.6.1.4.1.57264.1.3',
+              value: claims['sha'],
+              legacy: true,
+            },
+            {
+              oid: '1.3.6.1.4.1.57264.1.4',
+              value: claims['workflow'],
+              legacy: true,
+            },
+            {
+              oid: '1.3.6.1.4.1.57264.1.5',
+              value: claims['repository'],
+              legacy: true,
+            },
+            {
+              oid: '1.3.6.1.4.1.57264.1.6',
+              value: claims['ref'],
+              legacy: true,
+            },
+            {
+              oid: '1.3.6.1.4.1.57264.1.9',
+              value: server_url + claims['job_workflow_ref'],
+            },
+            {
+              oid: '1.3.6.1.4.1.57264.1.10',
+              value: claims['job_workflow_sha'],
+            },
+            {
+              oid: '1.3.6.1.4.1.57264.1.11',
+              value: claims['runner_environment'],
+            },
+            {
+              oid: '1.3.6.1.4.1.57264.1.12',
+              value: server_url + claims['repository'],
+            },
+            { oid: '1.3.6.1.4.1.57264.1.13', value: claims['sha'] },
+            { oid: '1.3.6.1.4.1.57264.1.14', value: claims['ref'] },
+            { oid: '1.3.6.1.4.1.57264.1.15', value: claims['repository_id'] },
+            {
+              oid: '1.3.6.1.4.1.57264.1.16',
+              value: server_url + claims['repository_owner'],
+            },
+            {
+              oid: '1.3.6.1.4.1.57264.1.17',
+              value: claims['repository_owner_id'],
+            },
+            {
+              oid: '1.3.6.1.4.1.57264.1.18',
+              value: server_url + claims['workflow_ref'],
+            },
+            { oid: '1.3.6.1.4.1.57264.1.19', value: claims['workflow_sha'] },
+            { oid: '1.3.6.1.4.1.57264.1.20', value: claims['event_name'] },
+            {
+              oid: '1.3.6.1.4.1.57264.1.21',
+              value: `${server_url}${claims.repository}/actions/runs/${claims.run_id}/attempts/${claims.run_attempt}`,
+            },
+            {
+              oid: '1.3.6.1.4.1.57264.1.22',
+              value: claims.repository_visibility,
+            }
+          );
+          break;
+        }
+      }
 
       // Request certificate from CA
       const cert = await ca.issueCertificate({
         publicKey: fromPEM(publicKey),
         subjectAltName: subject,
-        extensions: [
-          { oid: ISSUER_EXT_OID_V1, value: issuer, legacy: true },
-          { oid: ISSUER_EXT_OID_V2, value: issuer },
-        ],
+        extensions,
       });
 
       // Format the response
@@ -80,24 +158,53 @@ function createSigningCertHandler(
 function parseBody(
   body: string,
   subjectClaim: string
-): { subject: string; issuer: string; publicKey: string } {
+): {
+  subject: string;
+  issuer: string;
+  publicKey: string;
+  claims: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+} {
   const json = JSON.parse(body.toString());
-  const oidc = json.credentials.oidcIdentityToken;
-  const pem = json.publicKeyRequest.publicKey.content;
+  const { certificateSigningRequest, credentials, publicKeyRequest } = json;
+  if (certificateSigningRequest && publicKeyRequest) {
+    throw new Error(
+      'Invalid request -- cannot specify both CSR and public key'
+    );
+  } else if (!certificateSigningRequest && !publicKeyRequest) {
+    throw new Error('Invalid request -- must specify either CSR or public key');
+  } else if (!credentials || !credentials.oidcIdentityToken) {
+    throw new Error('Invalid request -- missing OIDC identity token');
+  }
+
+  const pem = (() => {
+    if (certificateSigningRequest) {
+      const csr = new x509.Pkcs10CertificateRequest(certificateSigningRequest);
+      return csr.publicKey.toString('pem');
+    } else {
+      return publicKeyRequest.publicKey.content;
+    }
+  })();
+  const oidc = credentials.oidcIdentityToken;
 
   // Decode the JWT
   /* eslint-disable @typescript-eslint/no-explicit-any */
-  const claims = jose.decodeJwt(oidc) as any;
+  const claims = jose.decodeJwt(oidc) as Record<string, any>;
 
   /* istanbul ignore next */
   return {
     subject: claims[subjectClaim] || DEFAULT_SUBJECT,
     issuer: claims['iss'] || DEFAULT_ISSUER,
     publicKey: pem,
+    claims,
   };
 }
 
-function stubBody(): { subject: string; issuer: string; publicKey: string } {
+function stubBody(): {
+  subject: string;
+  issuer: string;
+  publicKey: string;
+  claims: Record<string, any>;
+} {
   const { publicKey } = generateKeyPairSync('ec', {
     namedCurve: 'P-256',
   });
@@ -105,6 +212,10 @@ function stubBody(): { subject: string; issuer: string; publicKey: string } {
     subject: DEFAULT_SUBJECT,
     issuer: DEFAULT_ISSUER,
     publicKey: publicKey.export({ format: 'pem', type: 'spki' }).toString(),
+    claims: {
+      sub: DEFAULT_SUBJECT,
+      iss: DEFAULT_ISSUER,
+    },
   };
 }
 

--- a/packages/mock/src/rekor/handler.test.ts
+++ b/packages/mock/src/rekor/handler.test.ts
@@ -68,6 +68,7 @@ describe('rekorHandler', () => {
 
         const entry = body[uuid];
         expect(entry.body).toBeDefined();
+        expect(typeof entry.body).toBe('string');
         expect(
           JSON.parse(Buffer.from(entry.body, 'base64').toString())
         ).toEqual(proposedEntry);

--- a/packages/mock/src/rekor/tlog.ts
+++ b/packages/mock/src/rekor/tlog.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 import { LogEntry } from '@sigstore/rekor-types';
 import canonicalize from 'canonicalize';
 import crypto from 'crypto';
@@ -70,7 +70,7 @@ class TLogImpl implements TLog {
 
     return {
       [uuid]: {
-        body: body,
+        body: body.toString('base64'),
         integratedTime: timestamp,
         logID: logID.toString('hex'),
         logIndex: logIndex,


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Adds support for CSRs in mock server, also correctly translates GH Actions claims to x509 extensions.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
