### PR TITLE
Fix body encoding in mock Rekor server

### DIFF
--- a/.changeset/thin-garlics-reflect.md
+++ b/.changeset/thin-garlics-reflect.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/mock': patch
+---
+
+Fix encoding of body field returned by mock Rekor server

--- a/packages/mock/src/rekor/tlog.test.ts
+++ b/packages/mock/src/rekor/tlog.test.ts
@@ -47,6 +47,7 @@ describe('TLog', () => {
 
       const entry = result[uuid];
       expect(entry.body).toBeDefined();
+      expect(typeof entry.body).toBe('string');
       expect(JSON.parse(Buffer.from(entry.body, 'base64').toString())).toEqual(
         proposedEntry
       );

--- a/packages/mock/src/rekor/tlog.ts
+++ b/packages/mock/src/rekor/tlog.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 import { LogEntry } from '@sigstore/rekor-types';
 import canonicalize from 'canonicalize';
 import crypto from 'crypto';
@@ -70,7 +70,7 @@ class TLogImpl implements TLog {
 
     return {
       [uuid]: {
-        body: body,
+        body: body.toString('base64'),
         integratedTime: timestamp,
         logID: logID.toString('hex'),
         logIndex: logIndex,


### PR DESCRIPTION
Fixes a bug in the mock Rekor server where the body of the log entry was not being encoded as a base64 string before being returned.