### PR TITLE
support verify by digest in conformance suite

### DIFF
--- a/.changeset/tame-wasps-decide.md
+++ b/.changeset/tame-wasps-decide.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/conformance': minor
+---
+
+Support verification by artifact OR artifact digest

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -26,7 +26,7 @@ jobs:
       run: npm ci
     - name: Build sigstore-js
       run: npm run build
-    - uses: sigstore/sigstore-conformance@ee4de0e602873beed74cf9e49d5332529fe69bf6 # v0.0.11
+    - uses: sigstore/sigstore-conformance@6bd1c54e236c9517da56f7344ad16cc00439fe19 # v0.0.13
       with:
         entrypoint: ${{ github.workspace }}/packages/conformance/bin/run
         xfail: "test_verify_with_trust_root"
@@ -46,7 +46,7 @@ jobs:
       run: npm ci
     - name: Build sigstore-js
       run: npm run build
-    - uses: sigstore/sigstore-conformance@ee4de0e602873beed74cf9e49d5332529fe69bf6 # v0.0.11
+    - uses: sigstore/sigstore-conformance@6bd1c54e236c9517da56f7344ad16cc00439fe19 # v0.0.13
       with:
         entrypoint: ${{ github.workspace }}/packages/conformance/bin/run
         environment: staging

--- a/package-lock.json
+++ b/package-lock.json
@@ -5432,6 +5432,16 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
+      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "dev": true,
@@ -5447,6 +5457,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/elliptic": {
+      "version": "6.4.18",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.18.tgz",
+      "integrity": "sha512-UseG6H5vjRiNpQvrhy4VF/JXdA3V/Fp5amvveaL+fs28BZ6xIKJBPnUPRlEaZpysD9MbpfaLi8lbl7PGUAkpWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/bn.js": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -6243,6 +6263,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "license": "MIT",
@@ -6298,6 +6324,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.23.0",
@@ -7047,6 +7079,21 @@
       "version": "1.4.749",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -8163,6 +8210,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "license": "MIT",
@@ -8180,6 +8237,17 @@
       "dependencies": {
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/html-escaper": {
@@ -10596,6 +10664,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "9.0.5",
@@ -13180,12 +13260,14 @@
         "@sigstore/bundle": "^3.0.0",
         "@sigstore/protobuf-specs": "^0.3.2",
         "@sigstore/verify": "^2.0.0",
+        "elliptic": "^6.6.1",
         "sigstore": "^3.0.0"
       },
       "bin": {
         "sigstore": "bin/run"
       },
       "devDependencies": {
+        "@types/elliptic": "^6.4.18",
         "oclif": "^4",
         "tslib": "^2.8.1"
       },

--- a/packages/conformance/package.json
+++ b/packages/conformance/package.json
@@ -21,9 +21,11 @@
     "@sigstore/bundle": "^3.0.0",
     "@sigstore/protobuf-specs": "^0.3.2",
     "@sigstore/verify": "^2.0.0",
+    "elliptic": "^6.6.1",
     "sigstore": "^3.0.0"
   },
   "devDependencies": {
+    "@types/elliptic": "^6.4.18",
     "oclif": "^4",
     "tslib": "^2.8.1"
   },


### PR DESCRIPTION
Updates the CLI for the Sigstore conformance test suite to allow verification of bundles by artifact OR artifact digest.

The most recent release of the Sigstore conformance test suite ([v0.0.12](https://github.com/sigstore/sigstore-conformance/releases/tag/v0.0.12)) includes verification tests which supply only the digest of the signed artifact instead of supplying the artifact itself. The native nodejs crypto library does NOT support signature verification by digest (you must supply the original artifact and the digest is calculated internally). 

To work-around this, I've added a custom implementation of the `SignatureContent` type which uses a third-party library (`elliptic`) to perform the signature verification by digest. This new library is integrated ONLY with the conformance CLI and is not part of the `@sigstore/verify` library.