### PR TITLE
bump sigstore conformance action to v0.0.16

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -26,7 +26,7 @@ jobs:
       run: npm ci
     - name: Build sigstore-js
       run: npm run build
-    - uses: sigstore/sigstore-conformance@b0635d4101f11dbd18a50936568a1f7f55b17760 # v0.0.14
+    - uses: sigstore/sigstore-conformance@d658ea74a060aeabae78f8a379167f219dc38c38 # v0.0.16
       with:
         entrypoint: ${{ github.workspace }}/packages/conformance/bin/run
 
@@ -45,7 +45,7 @@ jobs:
       run: npm ci
     - name: Build sigstore-js
       run: npm run build
-    - uses: sigstore/sigstore-conformance@b0635d4101f11dbd18a50936568a1f7f55b17760 # v0.0.14
+    - uses: sigstore/sigstore-conformance@d658ea74a060aeabae78f8a379167f219dc38c38 # v0.0.16
       with:
         entrypoint: ${{ github.workspace }}/packages/conformance/bin/run
         environment: staging


### PR DESCRIPTION
Bump `sigstore/sigstore-conformance` from 0.0.14 to 0.0.16.

https://github.com/sigstore/sigstore-conformance/releases/tag/v0.0.16