### PR TITLE
Support for `HttpHeaders` in Docker config

### DIFF
--- a/.changeset/odd-flowers-help.md
+++ b/.changeset/odd-flowers-help.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/oci': minor
+---
+
+Support for reading `HttpHeaders` from Docker configuration file.

--- a/packages/oci/src/__tests__/credentials.test.ts
+++ b/packages/oci/src/__tests__/credentials.test.ts
@@ -92,12 +92,14 @@ describe('getRegistryCredentials', () => {
   describe('when credentials exist for the registry', () => {
     const username = 'username';
     const password = 'password';
+    const headers = { 'X-Api-Key': 'apikey' };
     const dockerConfig = {
       auths: {
         [registryName]: {
           auth: Buffer.from(`${username}:${password}`).toString('base64'),
         },
       },
+      HttpHeaders: headers,
     };
 
     beforeEach(() => {
@@ -111,7 +113,7 @@ describe('getRegistryCredentials', () => {
     it('returns the credentials', () => {
       const creds = getRegistryCredentials(imageName);
 
-      expect(creds).toEqual({ username, password });
+      expect(creds).toEqual({ username, password, headers });
     });
   });
 

--- a/packages/oci/src/__tests__/image.test.ts
+++ b/packages/oci/src/__tests__/image.test.ts
@@ -36,9 +36,11 @@ describe('OCIImage', () => {
     path: 'path',
   };
 
+  const headers = { 'X-Custom-Auth': 'authtoken' };
   const creds: Credentials = {
     username: 'username',
     password: 'password',
+    headers,
   };
 
   describe('constructor', () => {
@@ -71,7 +73,7 @@ describe('OCIImage', () => {
 
     describe('when the registry supports referrers', () => {
       beforeEach(() => {
-        nock(`https://${registry}`)
+        nock(`https://${registry}`, { reqheaders: headers })
           .post(`/v2/${repo}/blobs/uploads/`)
           .reply(401, {}, { [HEADER_AUTHENTICATE]: challenge })
           .head(`/v2/${repo}/manifests/${imageDigest}`)
@@ -88,14 +90,14 @@ describe('OCIImage', () => {
           .matchHeader(HEADER_CONTENT_TYPE, CONTENT_TYPE_OCTET_STREAM)
           .reply(201);
 
-        nock(`https://${registry}`)
+        nock(`https://${registry}`, { reqheaders: headers })
           .filteringPath(/sha256:[0-9a-f]{64}/, artifactManifestDigest)
           .put(`/v2/${repo}/manifests/${artifactManifestDigest}`)
           .reply(201, undefined, {
             [HEADER_OCI_SUBJECT]: artifactManifestDigest,
           });
 
-        nock(`https://${registry}`)
+        nock(`https://${registry}`, { reqheaders: headers })
           .get(`/v2/${repo}/referrers/${ZERO_DIGEST}`)
           .reply(200);
       });
@@ -116,7 +118,7 @@ describe('OCIImage', () => {
 
     describe('when the registry does NOT support referrers', () => {
       beforeEach(() => {
-        nock(`https://${registry}`)
+        nock(`https://${registry}`, { reqheaders: headers })
           .post(`/v2/${repo}/blobs/uploads/`)
           .reply(401, {}, { [HEADER_AUTHENTICATE]: challenge })
           .head(`/v2/${repo}/manifests/${imageDigest}`)
@@ -135,7 +137,7 @@ describe('OCIImage', () => {
           .get(`/v2/${repo}/referrers/${ZERO_DIGEST}`)
           .reply(404);
 
-        nock(`https://${registry}`)
+        nock(`https://${registry}`, { reqheaders: headers })
           .filteringPath(/sha256:[0-9a-f]{64}/, artifactManifestDigest)
           .put(`/v2/${repo}/manifests/${artifactManifestDigest}`)
           .reply(201, undefined);
@@ -143,7 +145,7 @@ describe('OCIImage', () => {
 
       describe('when there is NO existing referrer index', () => {
         beforeEach(() => {
-          nock(`https://${registry}`)
+          nock(`https://${registry}`, { reqheaders: headers })
             .get(`/v2/${repo}/manifests/sha256-deadbeef`)
             .reply(404, undefined)
             .put(`/v2/${repo}/manifests/sha256-deadbeef`)
@@ -178,7 +180,7 @@ describe('OCIImage', () => {
         };
 
         beforeEach(() => {
-          nock(`https://${registry}`)
+          nock(`https://${registry}`, { reqheaders: headers })
             .get(`/v2/${repo}/manifests/sha256-deadbeef`)
             .reply(200, index, {
               [HEADER_CONTENT_TYPE]: CONTENT_TYPE_OCI_INDEX,
@@ -203,7 +205,7 @@ describe('OCIImage', () => {
 
       describe('when the referrer index is NOT the expected type', () => {
         beforeEach(() => {
-          nock(`https://${registry}`)
+          nock(`https://${registry}`, { reqheaders: headers })
             .get(`/v2/${repo}/manifests/sha256-deadbeef`)
             .reply(
               200,
@@ -228,7 +230,7 @@ describe('OCIImage', () => {
 
       describe('when there is an error retrieving the referrer index', () => {
         beforeEach(() => {
-          nock(`https://${registry}`)
+          nock(`https://${registry}`, { reqheaders: headers })
             .get(`/v2/${repo}/manifests/sha256-deadbeef`)
             .reply(418, undefined);
         });

--- a/packages/oci/src/__tests__/registry.test.ts
+++ b/packages/oci/src/__tests__/registry.test.ts
@@ -36,6 +36,7 @@ describe('RegistryClient', () => {
   const registryName = 'registry.example.com';
   const repoName = 'test';
   const registryURL = `https://${registryName}`;
+  const headers = { 'X-Custom-Auth': 'sometoken' };
   const subject = new RegistryClient(registryName, repoName, { retry: false });
 
   describe('checkVersion', () => {
@@ -67,11 +68,11 @@ describe('RegistryClient', () => {
   });
 
   describe('signIn', () => {
-    const creds = { username: 'username', password: 'password' };
+    const creds = { username: 'username', password: 'password', headers };
 
     describe('when the client is already signed in', () => {
       beforeEach(() => {
-        nock(registryURL)
+        nock(registryURL, { reqheaders: headers })
           .post(`/v2/${repoName}/blobs/uploads/`)
           .reply(200, undefined, {});
       });
@@ -141,8 +142,7 @@ describe('RegistryClient', () => {
       });
     });
 
-    describe('when the registry uses an bearer token returns an error', () => {
-       
+    describe('when the registry uses a bearer token and returns an error', () => {
       const creds = { username: '<token>', password: 'password' };
       const challenge =
         'Bearer realm="https://registry.example.com/oauth2/token";service="service";scope="scope"';

--- a/packages/oci/src/credentials.ts
+++ b/packages/oci/src/credentials.ts
@@ -21,10 +21,12 @@ import { parseImageName } from './name';
 export type Credentials = {
   readonly username: string;
   readonly password: string;
+  readonly headers?: { [key: string]: string };
 };
 
 type DockerConifg = {
   auths?: { [registry: string]: { auth: string; identitytoken?: string } };
+  HttpHeaders?: { [key: string]: string };
 };
 
 // Returns the credentials for a given registry by reading the Docker config
@@ -58,7 +60,7 @@ export const getRegistryCredentials = (imageName: string): Credentials => {
   // If the identitytoken is present, use it as the password (primarily for ACR)
   const pass = creds.identitytoken ? creds.identitytoken : password;
 
-  return { username, password: pass };
+  return { headers: dockerConfig.HttpHeaders, username, password: pass };
 };
 
 // Encode the username and password as base64-encoded basicauth value

--- a/packages/oci/src/registry.ts
+++ b/packages/oci/src/registry.ts
@@ -100,6 +100,9 @@ export class RegistryClient {
   // authenticate requests.
   // https://github.com/google/go-containerregistry/blob/main/pkg/authn/README.md#the-registry
   async signIn(creds: Credentials): Promise<void> {
+    // Ensure we include an auth headers if they are present
+    this.#fetch = this.#fetch.defaults({ headers: creds.headers });
+
     // Initiate a blob upload to get the auth challenge
     const probeResponse = await this.#fetch(
       `${this.#baseURL}/v2/${this.#repository}/blobs/uploads/`,


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Adds support for reading the `HttpHeaders` value from the Docker config file. These headers, if present, will be sent along with all requests to the OCI registry when attempting to attach an attestation to a container image.

