### PR TITLE
regexp support for policy subjectAlternativeName verifier

### DIFF
--- a/packages/verify/src/__tests__/policty.test.ts
+++ b/packages/verify/src/__tests__/policty.test.ts
@@ -38,6 +38,12 @@ describe('verifySubjectAlternativeName', () => {
       ).not.toThrow();
     });
 
+    it('accepts a RegExp policy', () => {
+      expect(() =>
+        verifySubjectAlternativeName(/^user@example\.com$/, 'user@example.com')
+      ).not.toThrow();
+    });
+
     it('accepts a substring match without anchoring', () => {
       expect(() =>
         verifySubjectAlternativeName(

--- a/packages/verify/src/policy.ts
+++ b/packages/verify/src/policy.ts
@@ -2,7 +2,7 @@ import { PolicyError } from './error';
 import { CertificateExtensions } from './shared.types';
 
 export function verifySubjectAlternativeName(
-  policyIdentity: string,
+  policyIdentity: string | RegExp,
   signerIdentity: string | undefined
 ): void {
   if (signerIdentity === undefined || !signerIdentity.match(policyIdentity)) {

--- a/packages/verify/src/policy.ts
+++ b/packages/verify/src/policy.ts
@@ -8,7 +8,7 @@ import type { ObjectIdentifierValuePair } from '@sigstore/protobuf-specs';
 // tested against the full signerIdentity string. For exact matching, use
 // anchored patterns (e.g. '^user@example\\.com$').
 export function verifySubjectAlternativeName(
-  policyIdentity: string,
+  policyIdentity: string | RegExp,
   signerIdentity: string | undefined
 ): void {
   if (signerIdentity === undefined || !signerIdentity.match(policyIdentity)) {

--- a/packages/verify/src/shared.types.ts
+++ b/packages/verify/src/shared.types.ts
@@ -26,7 +26,10 @@ export type CertificateIdentity = {
   extensions?: CertificateExtensions;
 };
 
-export type VerificationPolicy = CertificateIdentity;
+export type VerificationPolicy = {
+  subjectAlternativeName?: string | RegExp;
+  extensions?: CertificateExtensions;
+};
 
 export type Signer = {
   key: crypto.KeyObject;

--- a/packages/verify/src/shared.types.ts
+++ b/packages/verify/src/shared.types.ts
@@ -31,7 +31,11 @@ export type CertificateIdentity = {
   oids?: ObjectIdentifierValuePair[];
 };
 
-export type VerificationPolicy = CertificateIdentity;
+export type VerificationPolicy = {
+  subjectAlternativeName?: string | RegExp;
+  extensions?: CertificateExtensions;
+  oids?: ObjectIdentifierValuePair[];
+};
 
 export type Signer = {
   key: crypto.KeyObject;


### PR DESCRIPTION
relates to https://github.com/docker/actions-toolkit/pull/929

#### Summary

Adds support for `RegExp` when verifying policy `subjectAlternativeName`. This is similar to cosign behavior with `--certificate-identity-regexp` flag:

https://github.com/sigstore/cosign/blob/10e56727c01bd682da2d536819c1493a84884940/doc/cosign_verify.md?plain=1#L89

```
--certificate-identity-regexp string                                                       A regular expression alternative to --certificate-identity. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --certificate-identity or --certificate-identity-regexp must be set for keyless flows.
```

This is specially useful when we want to match a dynamic `subjectAlternativeName` when signing using the github actions provider like: https://oci.dag.dev/?image=public.ecr.aws%2Fq3b5f1u4%2Ftest-docker-action%40sha256%3A670d819051bdec9cb7e4789217cd2fae3e4f1359376421ada2af1e4d53f84d3e&jq=.layers%5B0%5D.annotations%5B%22dev.sigstore.cosign%2Fcertificate%22%5D&render=x509

```
https://github.com/docker/github-builder-experimental/.github/workflows/build.yml@refs/heads/build-reusable-workflow
```

Where the ref changes based on user invocation.

#### Release Note

* Regexp support for policy `subjectAlternativeName` verifier

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
