### PR TITLE
conformance: Add managed key verification support

### DIFF
--- a/.changeset/rare-deer-wait.md
+++ b/.changeset/rare-deer-wait.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/conformance': minor
+---
+
+Support for managed key verification tests

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -31,7 +31,6 @@ jobs:
     - uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
       with:
         entrypoint: ${{ github.workspace }}/packages/conformance/bin/run
-        xfail: "test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root]"
 
   conformance-staging:
     name: Conformance Test (Staging)
@@ -52,4 +51,3 @@ jobs:
       with:
         entrypoint: ${{ github.workspace }}/packages/conformance/bin/run
         environment: staging
-        xfail: "test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root]"

--- a/packages/conformance/src/commands/verify-bundle.ts
+++ b/packages/conformance/src/commands/verify-bundle.ts
@@ -18,11 +18,15 @@ export default class VerifyBundle extends Command {
     'certificate-identity': Flags.string({
       description:
         'The expected identity in the signing ceritifcate SAN extension',
-      required: true,
+      required: false,
     }),
     'certificate-oidc-issuer': Flags.string({
       description: 'the expected OIDC issuer for the signing certificate',
-      required: true,
+      required: false,
+    }),
+    key: Flags.string({
+      description: 'path to PEM-encoded public key file',
+      required: false,
     }),
     'trusted-root': Flags.string({
       description: 'path to trusted root',
@@ -44,6 +48,17 @@ export default class VerifyBundle extends Command {
   public async run(): Promise<void> {
     const { args, flags } = await this.parse(VerifyBundle);
 
+    const keyPath = flags['key'];
+
+    if (
+      !keyPath &&
+      (!flags['certificate-identity'] || !flags['certificate-oidc-issuer'])
+    ) {
+      this.error(
+        '--certificate-identity and --certificate-oidc-issuer are required when --key is not provided'
+      );
+    }
+
     const trustedRootPath = flags['trusted-root'];
     const bundle = await fs
       .readFile(flags.bundle)
@@ -53,18 +68,32 @@ export default class VerifyBundle extends Command {
     const trustMaterial = trustedRootPath
       ? await trustMaterialFromPath(trustedRootPath)
       : await trustMaterialFromTUF(flags['staging']);
-    const verifier = new Verifier(trustMaterial);
 
-    const policy = {
-      subjectAlternativeName: flags['certificate-identity'],
-      extensions: { issuer: flags['certificate-oidc-issuer'] },
-    };
+    // Override the public key finder with the externally-provided key
+    if (keyPath) {
+      const keyPEM = await fs.readFile(keyPath);
+      const publicKey = crypto.createPublicKey(keyPEM);
+      trustMaterial.publicKey = () => ({
+        publicKey,
+        validFor: () => true,
+      });
+    }
+
+    const verifier = new Verifier(trustMaterial);
 
     const signedEntity = isDigest(args.fileOrDigest)
       ? await signedEntityFromDigest(bundle, args.fileOrDigest)
       : await signedEntityFromFile(bundle, args.fileOrDigest);
 
-    verifier.verify(signedEntity, policy);
+    if (keyPath) {
+      verifier.verify(signedEntity);
+    } else {
+      const policy = {
+        subjectAlternativeName: flags['certificate-identity'],
+        extensions: { issuer: flags['certificate-oidc-issuer'] },
+      };
+      verifier.verify(signedEntity, policy);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Adds `--key` flag support to the conformance CLI's `verify-bundle` command, enabling verification of bundles signed with managed (non-Fulcio) key pairs. This is the only missing capability blocking 100% compliance with the [sigstore-conformance](https://github.com/sigstore/sigstore-conformance) test suite.

## Changes

### `packages/conformance/src/commands/verify-bundle.ts`

- Add `--key` flag accepting a path to a PEM-encoded public key file
- Make `--certificate-identity` and `--certificate-oidc-issuer` optional (only required when `--key` is not provided)
- When `--key` is provided, override the trust material's `publicKey` finder with the externally-provided key and skip certificate identity policy verification
- No changes to the `@sigstore/verify` library — it already supports public key verification via `KeyFinderFunc`

### `.github/workflows/conformance.yml`

- Remove `xfail` entries for `managed-key-happy-path` and `managed-key-and-trusted-root` from both production and staging jobs

## Previously failing tests

| Test | Reason |
|------|--------|
| `test_verify[managed-key-happy-path-PATH]` | CLI didn't support `--key` flag |
| `test_verify[managed-key-happy-path-DIGEST]` | CLI didn't support `--key` flag |
| `test_verify[managed-key-and-trusted-root-PATH]` | CLI didn't support `--key` flag |
| `test_verify[managed-key-and-trusted-root-DIGEST]` | CLI didn't support `--key` flag |

Refs: github/package-security#4523