### PR TITLE
Use native fetch in CLI oauth tests to avoid msw/agent-base conflict

### DIFF
--- a/packages/cli/src/__tests__/oauth/index.test.ts
+++ b/packages/cli/src/__tests__/oauth/index.test.ts
@@ -1,5 +1,4 @@
  import * as jose from 'jose';
-import fetch from 'make-fetch-happen';
 import nock from 'nock';
 import open from 'open';
 import { OAuthIdentityProvider } from '../../oauth';

--- a/packages/cli/src/__tests__/oauth/server.test.ts
+++ b/packages/cli/src/__tests__/oauth/server.test.ts
@@ -1,4 +1,3 @@
-import fetch from 'make-fetch-happen';
 import { URLSearchParams } from 'url';
 import { CallbackServer } from '../../oauth/server';
 


### PR DESCRIPTION
The CI test job [`Run tests (20.17.0, ubuntu-latest, bash, /tmp/jest)`](https://github.com/sigstore/sigstore-js/actions/runs/26261818938/job/77296704625) (and every sibling matrix job in that run) fails on PR #1647 with two CLI OAuth tests timing out at 5000 ms.

## Root cause

PR #1647 bumps `@tufjs/repo-mock` to `4.0.2`, which transitively installs `nock@14`. `nock@14` now depends on `@mswjs/interceptors`, which **globally monkey‑patches Node's `http` module** the moment it's required. Because Jest workers reuse a process across test files, that patch leaks from the `client`/`tuf` projects (which use `@tufjs/repo-mock`) into the `cli` project.

The CLI OAuth tests then call `make-fetch-happen` → `@npmcli/agent` → `agent-base@7`. `agent-base@7`'s `createConnection` returns the socket asynchronously, but `@mswjs/interceptors`' `MockHttpSocket.passthrough` expects a synchronous return, producing:

```
No socket was returned in the `connect()` function
   at Agent.createConnection (node_modules/agent-base/src/index.ts:176:10)
   at MockHttpSocket.passthrough (node_modules/@mswjs/interceptors/src/interceptors/ClientRequest/MockHttpSocket.ts:192:25)
```

## Changes

- **`packages/cli/src/__tests__/oauth/server.test.ts`**, **`packages/cli/src/__tests__/oauth/index.test.ts`**: drop the `make-fetch-happen` import and use Node's built-in `fetch`. Both tests only issue a trivial GET against a local callback server. Native `fetch` (undici) bypasses `http.Agent`/`agent-base` entirely, so the `@mswjs/interceptors` patch no longer applies.

```diff
-import fetch from 'make-fetch-happen';
```

The `make-fetch-happen` devDependency is left in place for now; it can be removed in a follow-up if no other test reintroduces it.