### PR TITLE
Pin all @swc/core platform binaries as optionalDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,17 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.5.0",
+        "@swc/core-darwin-x64": "1.5.0",
+        "@swc/core-linux-arm64-gnu": "1.5.0",
+        "@swc/core-linux-arm64-musl": "1.5.0",
+        "@swc/core-linux-x64-gnu": "1.5.0",
+        "@swc/core-linux-x64-musl": "1.5.0",
+        "@swc/core-win32-arm64-msvc": "1.5.0",
+        "@swc/core-win32-ia32-msvc": "1.5.0",
+        "@swc/core-win32-x64-msvc": "1.5.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -5438,6 +5449,150 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.0.tgz",
+      "integrity": "sha512-dyA25zQjm3xmMFsRPFgBpSqWSW9TITnkndZkZAiPYLjBxH9oTNMa0l09BePsaqEeXySY++tUgAeYu/9onsHLbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.0.tgz",
+      "integrity": "sha512-cO7kZMMA/fcQIBT31LBzcVNSk3AZGVYLqvEPnJhFImjPm3mGKUd6kWpARUEGR68MyRU2VsWhE6eCjMcM+G7bxw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.0.tgz",
+      "integrity": "sha512-Bu4/41pGadXKnRsUbox0ig63xImATVH704oPCXcoOvNGkDyMjWgIAhzIi111vrwFNpj9utabgUE4AtlUa2tAOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.0.tgz",
+      "integrity": "sha512-lUFFvC8tsepNcTnKEHNrePWanVVef6PQ82Rv9wIeebgGHRUqDh6+CyCqodXez+aKz6NyE/PBIfp0r+jPx4hoJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.0.tgz",
+      "integrity": "sha512-c6LegFU1qdyMfk+GzNIOvrX61+mksm21Q01FBnXSy1nf1ACj/a86jmr3zkPl0zpNVHfPOw3Ry1QIuLQKD+67YA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.0.tgz",
+      "integrity": "sha512-I/V8aWBmfDWwjtM1bS8ASG+6PcO/pVFYyPP5g2ok46Vz1o1MnAUd18mHnWX43nqVJokaW+BD/G4ZMZ+gXRl4zQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.0.tgz",
+      "integrity": "sha512-nN685BvI7iM58xabrSOSQHUvIY10pcXh5H9DmS8LeYqG6Dkq7QZ8AwYqqonOitIS5C35MUfhSMLpOTzKoLdUqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.0.tgz",
+      "integrity": "sha512-3YjltmEHljI+TvuDOC4lspUzjBUoB3X5BhftRBprSTJx/czuMl0vdoZKs2Snzb5Eqqesp0Rl8q+iQ1E1oJ6dEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.0.tgz",
+      "integrity": "sha512-ZairtCwJsaxnUH85DcYCyGpNb9bUoIm9QXYW+VaEoXwbcB95dTIiJwN0aRxPT8B0B2MNw/CXLqjoPo6sDwz5iw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@swc/counter": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,17 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.4"
   },
+  "optionalDependencies": {
+    "@swc/core-darwin-arm64": "1.5.0",
+    "@swc/core-darwin-x64": "1.5.0",
+    "@swc/core-linux-arm64-gnu": "1.5.0",
+    "@swc/core-linux-arm64-musl": "1.5.0",
+    "@swc/core-linux-x64-gnu": "1.5.0",
+    "@swc/core-linux-x64-musl": "1.5.0",
+    "@swc/core-win32-arm64-msvc": "1.5.0",
+    "@swc/core-win32-ia32-msvc": "1.5.0",
+    "@swc/core-win32-x64-msvc": "1.5.0"
+  },
   "workspaces": [
     "./packages/*"
   ],


### PR DESCRIPTION
## Summary

Declares every supported `@swc/core-*` native binary in the root `package.json` so that `package-lock.json` records entries for all platforms, not just the one that ran `npm install`.

## Problem

Without this, contributors and CI runners on a different OS/arch than whoever last regenerated the lockfile hit `Bindings not found` errors when running the test suite — every Jest suite fails to transform because `@swc/core` can't find a native binary for the current platform.

This is a known npm behaviour: a regenerated lockfile only includes the optional dep matching the host platform, even though `@swc/core` declares all of them as `optionalDependencies`.

## Fix

Add all 9 platform binaries (darwin/linux/win × arm64/x64, plus musl and ia32 variants) as `optionalDependencies` at the root, pinned to the same version (`1.5.0`) that `@swc/jest` resolves `@swc/core` to. npm still only installs the binary matching the current platform at install time, but every platform's entry is now recorded in the lockfile.

## Verification

- `rm -rf node_modules && npm install` only installs `@swc/core-darwin-arm64` locally
- `package-lock.json` now contains entries for all 9 platforms
- `npm test` — all 96 suites / 715 tests pass