### PR TITLE
Pin all @swc/core platform binaries as optionalDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       "optionalDependencies": {
         "@swc/core-darwin-arm64": "1.5.0",
         "@swc/core-darwin-x64": "1.5.0",
+        "@swc/core-linux-arm-gnueabihf": "1.5.0 ",
         "@swc/core-linux-arm64-gnu": "1.5.0",
         "@swc/core-linux-arm64-musl": "1.5.0",
         "@swc/core-linux-x64-gnu": "1.5.0",
@@ -5478,6 +5479,22 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.0.tgz",
+      "integrity": "sha512-BXaXytS4y9lBFRO6vwA6ovvy1d2ZIzS02i2R1oegoZzzNu89CJDpkYXYS9bId0GvK2m9Q9y2ofoZzKE2Rp3PqQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@swc/core-darwin-x64": "1.5.0",
     "@swc/core-linux-arm64-gnu": "1.5.0",
     "@swc/core-linux-arm64-musl": "1.5.0",
+    "@swc/core-linux-arm-gnueabihf": "1.5.0 ",
     "@swc/core-linux-x64-gnu": "1.5.0",
     "@swc/core-linux-x64-musl": "1.5.0",
     "@swc/core-win32-arm64-msvc": "1.5.0",


### PR DESCRIPTION
Follow-up to #1650 

This pull request adds a new platform-specific dependency to the project to improve support for additional environments.

Dependency updates:

* Added `@swc/core-linux-arm-gnueabihf` version `1.5.0` to the dependencies in `package.json` to support SWC on Linux ARM (gnueabihf) platforms.