### PR TITLE
bump @sigstore/mock deps

### DIFF
--- a/.changeset/shiny-gifts-taste.md
+++ b/.changeset/shiny-gifts-taste.md
@@ -1,0 +1,6 @@
+---
+'@sigstore/mock': patch
+---
+
+Bump `@peculiar/webcrypt` from 1.5.0 to 1.7.1
+Bump `pkijs` from 3.3.3 to 3.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -4580,13 +4580,13 @@
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
       "license": "MIT",
       "dependencies": {
+        "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1"
       }
     },
@@ -4616,6 +4616,8 @@
     },
     "node_modules/@peculiar/json-schema": {
       "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -4624,18 +4626,29 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.5.0",
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+      "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
         "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
+        "@peculiar/utils": "^2.0.2",
+        "tslib": "^2.8.1",
+        "webcrypto-core": "^1.9.2"
       },
       "engines": {
-        "node": ">=10.12.0"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/@peculiar/x509": {
@@ -6822,13 +6835,13 @@
       }
     },
     "node_modules/asn1js": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
+        "pvutils": "^1.1.5",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -12497,9 +12510,9 @@
       }
     },
     "node_modules/pkijs": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.3.3.tgz",
-      "integrity": "sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@noble/hashes": "1.4.0",
@@ -14258,14 +14271,16 @@
       }
     },
     "node_modules/webcrypto-core": {
-      "version": "1.8.0",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+      "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.7.0",
         "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.1",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2"
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/which": {
@@ -14605,7 +14620,7 @@
       "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@peculiar/webcrypto": "^1.5.0",
+        "@peculiar/webcrypto": "^1.7.1",
         "@peculiar/x509": "^2.0.0",
         "@sigstore/protobuf-specs": "^0.5.0",
         "asn1js": "^3.0.7",
@@ -14613,7 +14628,7 @@
         "canonicalize": "^2.1.0",
         "jose": "^5.9.6",
         "nock": "^13.5.5",
-        "pkijs": "^3.3.3",
+        "pkijs": "^3.4.0",
         "pvutils": "^1.1.5",
         "reflect-metadata": "^0.2.2"
       },

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -30,7 +30,7 @@
     "make-fetch-happen": "^15.0.4"
   },
   "dependencies": {
-    "@peculiar/webcrypto": "^1.5.0",
+    "@peculiar/webcrypto": "^1.7.1",
     "@peculiar/x509": "^2.0.0",
     "@sigstore/protobuf-specs": "^0.5.0",
     "asn1js": "^3.0.7",
@@ -38,7 +38,7 @@
     "canonicalize": "^2.1.0",
     "jose": "^5.9.6",
     "nock": "^13.5.5",
-    "pkijs": "^3.3.3",
+    "pkijs": "^3.4.0",
     "pvutils": "^1.1.5",
     "reflect-metadata": "^0.2.2"
   },


### PR DESCRIPTION
This pull request updates dependencies in the `@sigstore/mock` package to keep the project up-to-date with the latest versions and security patches. The most important changes are:

**Dependency upgrades:**

* Upgraded `@peculiar/webcrypto` from version 1.5.0 to 1.7.1 in `package.json` to include the latest features and fixes.
* Upgraded `pkijs` from version 3.3.3 to 3.4.0 in `package.json` for improved compatibility and bug fixes.

**Documentation:**

* Updated the changeset file to document the dependency bumps for `@peculiar/webcrypto` and `pkijs`.