### PR TITLE
Upgrade TypeScript to 6.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "nock": "^13.5.5",
         "prettier": "^3.8.3",
         "shx": "^0.4.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.4"
       },
       "engines": {
@@ -14026,9 +14026,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
     "nock": "^13.5.5",
     "prettier": "^3.8.3",
     "shx": "^0.4.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
     "@swc/core-darwin-arm64": "1.5.0",
     "@swc/core-darwin-x64": "1.5.0",
+    "@swc/core-linux-arm-gnueabihf": "1.5.0 ",
     "@swc/core-linux-arm64-gnu": "1.5.0",
     "@swc/core-linux-arm64-musl": "1.5.0",
-    "@swc/core-linux-arm-gnueabihf": "1.5.0 ",
     "@swc/core-linux-x64-gnu": "1.5.0",
     "@swc/core-linux-x64-musl": "1.5.0",
     "@swc/core-win32-arm64-msvc": "1.5.0",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "importHelpers": true,
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node", "jest"]
   },
   "exclude": ["./dist"],
   "references": [

--- a/packages/mock/tsconfig.json
+++ b/packages/mock/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "composite": true
+    "composite": true,
+    "types": ["node", "jest"]
   },
   "exclude": [
     "./dist",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,6 +2,7 @@
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "types": ["node"],
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "allowUnreachableCode": false,


### PR DESCRIPTION
Bumps the `typescript` devDependency from `^5.9.3` to `^6.0.3`.

## Why the tsconfig changes?

TypeScript 6.0 changed automatic `@types` acquisition: `@types/*` packages found in `node_modules` are no longer implicitly included as ambient globals. After the upgrade the build fails with 493 `TS2304`/`TS2591`/`TS2593` errors about missing `Buffer`, `describe`, `expect`, etc.

See: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#automatic-type-acquisition-changes-new-defaults-for-node-and-dom-types

## Changes

- `tsconfig.base.json`: add `"types": ["node"]` so `@types/node` is included for every package.
- `packages/cli/tsconfig.json`: `"types": ["node", "jest"]` — this package includes its `__tests__` in the build.
- `packages/mock/tsconfig.json`: `"types": ["node", "jest"]` — has `*.test.ts` files outside `__tests__/` that are picked up by the build.

## Verification

- `npm run build` ✅ (0 errors)
- `npm test` ✅ (715/715 tests passing across 96 suites)