### PR TITLE
Require inclusion promise in Rekor entry when used as timestamp source

### DIFF
--- a/.changeset/wide-garlics-smile.md
+++ b/.changeset/wide-garlics-smile.md
@@ -1,0 +1,6 @@
+---
+'sigstore': patch
+'@sigstore/verify': patch
+---
+
+Require inclusion promise in Rekor entry when used as timestamp source

--- a/packages/client/src/__tests__/__fixtures__/bundles/valid.ts
+++ b/packages/client/src/__tests__/__fixtures__/bundles/valid.ts
@@ -152,6 +152,10 @@ export const v2 = {
             logId: { keyId: 'wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0=' },
             kindVersion: { kind: 'hashedrekord', version: '0.0.1' },
             integratedTime: '1667957590',
+            inclusionPromise: {
+              signedEntryTimestamp:
+                'MEUCIFUNcHgHB318gCNJR0/CH4E0daODbnfePyzKCDqrt3twAiEA9N+ZObaLwVJwvOtPgkfoBa5NzjTH0eC06YBlOyZlMiY=',
+            },
             inclusionProof: {
               logIndex: '2594072',
               rootHash: 'kAnoYYy8iB3NjC5tE2l6pGBqY3uw3CBJ6x2cBBQXu0U=',
@@ -221,6 +225,10 @@ export const v3 = {
             logId: { keyId: 'wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0=' },
             kindVersion: { kind: 'hashedrekord', version: '0.0.1' },
             integratedTime: '1667957590',
+            inclusionPromise: {
+              signedEntryTimestamp:
+                'MEUCIFUNcHgHB318gCNJR0/CH4E0daODbnfePyzKCDqrt3twAiEA9N+ZObaLwVJwvOtPgkfoBa5NzjTH0eC06YBlOyZlMiY=',
+            },
             inclusionProof: {
               logIndex: '2594072',
               rootHash: 'kAnoYYy8iB3NjC5tE2l6pGBqY3uw3CBJ6x2cBBQXu0U=',

--- a/packages/verify/src/__tests__/timestamp/index.test.ts
+++ b/packages/verify/src/__tests__/timestamp/index.test.ts
@@ -33,15 +33,31 @@ describe('getTLogTimestamp', () => {
       TransparencyLogEntry.fromJSON({
         logId: { keyId: 'wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0=' },
         integratedTime: '1667957590',
+        inclusionPromise: { signedEntryTimestamp: '' },
       })
     );
 
     it('does NOT throw an error', () => {
       const result = getTLogTimestamp(tlogEntry);
 
-      expect(result.type).toEqual('transparency-log');
-      expect(result.logID).toEqual(keyID);
-      expect(result.timestamp).toBeDefined();
+      expect(result).toBeDefined();
+      expect(result!.type).toEqual('transparency-log');
+      expect(result!.logID).toEqual(keyID);
+      expect(result!.timestamp).toBeDefined();
+    });
+  });
+
+  describe('when the tlog entry has no inclusion promise', () => {
+    const tlogEntry: TLogEntry = fromPartial(
+      TransparencyLogEntry.fromJSON({
+        logId: { keyId: 'wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0=' },
+        integratedTime: '1667957590',
+      })
+    );
+
+    it('returns undefined', () => {
+      const result = getTLogTimestamp(tlogEntry);
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/packages/verify/src/timestamp/index.ts
+++ b/packages/verify/src/timestamp/index.ts
@@ -43,7 +43,12 @@ export function getTSATimestamp(
 
 export function getTLogTimestamp(
   entry: TransparencyLogEntry
-): TimestampVerificationResult {
+): TimestampVerificationResult | undefined {
+  // Only entries with an inclusion promise provide a verifiable timestamp
+  if (!entry.inclusionPromise) {
+    return undefined;
+  }
+
   return {
     type: 'transparency-log',
     logID: entry.logId.keyId,

--- a/packages/verify/src/verifier.ts
+++ b/packages/verify/src/verifier.ts
@@ -21,7 +21,11 @@ import {
   verifyOIDs,
   verifySubjectAlternativeName,
 } from './policy';
-import { getTLogTimestamp, getTSATimestamp } from './timestamp';
+import {
+  TimestampVerificationResult,
+  getTLogTimestamp,
+  getTSATimestamp,
+} from './timestamp';
 import { verifyTLogBody, verifyTLogInclusion } from './tlog';
 
 import type {
@@ -81,22 +85,29 @@ export class Verifier {
 
   // Checks that all of the timestamps in the entity are valid and returns them
   private verifyTimestamps(entity: SignedEntity): Date[] {
-    let timestampCount = 0;
+    const timestamps: TimestampVerificationResult[] = [];
 
-    const timestamps = entity.timestamps.map((timestamp) => {
+    for (const timestamp of entity.timestamps) {
       switch (timestamp.$case) {
         case 'timestamp-authority':
-          timestampCount++;
-          return getTSATimestamp(
-            timestamp.timestamp,
-            entity.signature.signature,
-            this.trustMaterial.timestampAuthorities
+          timestamps.push(
+            getTSATimestamp(
+              timestamp.timestamp,
+              entity.signature.signature,
+              this.trustMaterial.timestampAuthorities
+            )
           );
-        case 'transparency-log':
-          timestampCount++;
-          return getTLogTimestamp(timestamp.tlogEntry);
+          break;
+        case 'transparency-log': {
+          const result = getTLogTimestamp(timestamp.tlogEntry);
+          /* istanbul ignore else */
+          if (result) {
+            timestamps.push(result);
+          }
+          break;
+        }
       }
-    });
+    }
 
     // Check for duplicate timestamps
     if (containsDupes(timestamps)) {
@@ -106,10 +117,10 @@ export class Verifier {
       });
     }
 
-    if (timestampCount < this.options.timestampThreshold) {
+    if (timestamps.length < this.options.timestampThreshold) {
       throw new VerificationError({
         code: 'TIMESTAMP_ERROR',
-        message: `expected ${this.options.timestampThreshold} timestamps, got ${timestampCount}`,
+        message: `expected ${this.options.timestampThreshold} timestamps, got ${timestamps.length}`,
       });
     }
 


### PR DESCRIPTION
Require inclusion promise in Rekor entry when used as timestamp source