### PR TITLE
Support DSSE bundles with Rekor v2 hashedrekord entries

### DIFF
--- a/.changeset/dsse-hashedrekord-verify.md
+++ b/.changeset/dsse-hashedrekord-verify.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/verify': minor
+---
+
+Support verification of DSSE bundles with a Rekor v2 `hashedrekord` transparency log entry, where the entry's digest is computed over the DSSE pre-authentication encoding (PAE) rather than the envelope payload

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -28,7 +28,7 @@ jobs:
       run: npm ci
     - name: Build sigstore-js
       run: npm run build
-    - uses: sigstore/sigstore-conformance@e2cc8e51870bb9af4e4ae3342e97cf5f7ea2cdd8 # v0.0.28
+    - uses: sigstore/sigstore-conformance@21533cde107c734ebc153c3e3a24d75fc9811a36 # v0.0.29
       with:
         entrypoint: ${{ github.workspace }}/packages/conformance/bin/run
 
@@ -47,7 +47,7 @@ jobs:
       run: npm ci
     - name: Build sigstore-js
       run: npm run build
-    - uses: sigstore/sigstore-conformance@e2cc8e51870bb9af4e4ae3342e97cf5f7ea2cdd8 # v0.0.28
+    - uses: sigstore/sigstore-conformance@21533cde107c734ebc153c3e3a24d75fc9811a36 # v0.0.29
       with:
         entrypoint: ${{ github.workspace }}/packages/conformance/bin/run
         environment: staging

--- a/packages/conformance/src/commands/verify-bundle.ts
+++ b/packages/conformance/src/commands/verify-bundle.ts
@@ -161,6 +161,10 @@ class MessageDigestSignatureContent {
     );
   }
 
+  public compareSignedDigest(digest: Buffer): boolean {
+    return this.compareDigest(digest);
+  }
+
   verifySignature(key: crypto.KeyObject): boolean {
     // Export public key to JWK format
     const jwk = key.export({ format: 'jwk' });

--- a/packages/verify/src/__tests__/bundle/dsse.test.ts
+++ b/packages/verify/src/__tests__/bundle/dsse.test.ts
@@ -55,6 +55,30 @@ describe('DSSESignatureContent', () => {
     });
   });
 
+  describe('#compareSignedDigest', () => {
+    describe('when the digest does NOT match the PAE hash', () => {
+      it('returns false', () => {
+        expect(subject.compareSignedDigest(Buffer.from(''))).toBe(false);
+      });
+    });
+
+    describe('when the digest matches the payload hash (but not the PAE)', () => {
+      const payloadDigest = core.digest('sha256', env.payload);
+
+      it('returns false', () => {
+        expect(subject.compareSignedDigest(payloadDigest)).toBe(false);
+      });
+    });
+
+    describe('when the digest matches the PAE hash', () => {
+      const expectedDigest = core.digest('sha256', pae);
+
+      it('returns true', () => {
+        expect(subject.compareSignedDigest(expectedDigest)).toBe(true);
+      });
+    });
+  });
+
   describe('#compareSignature', () => {
     describe('when the signature does NOT match the payload hash', () => {
       it('returns false', () => {

--- a/packages/verify/src/__tests__/bundle/message.test.ts
+++ b/packages/verify/src/__tests__/bundle/message.test.ts
@@ -46,6 +46,20 @@ describe('MessageSignatureContent', () => {
     });
   });
 
+  describe('#compareSignedDigest', () => {
+    describe('when the digest does NOT match the message hash', () => {
+      it('returns false', () => {
+        expect(subject.compareSignedDigest(Buffer.from(''))).toBe(false);
+      });
+    });
+
+    describe('when the digest matches the message hash', () => {
+      it('returns true', () => {
+        expect(subject.compareSignedDigest(messageDigest)).toBe(true);
+      });
+    });
+  });
+
   describe('#compareSignature', () => {
     describe('when the signature does NOT match the message signature', () => {
       it('returns false', () => {

--- a/packages/verify/src/bundle/dsse.ts
+++ b/packages/verify/src/bundle/dsse.ts
@@ -32,6 +32,16 @@ export class DSSESignatureContent implements SignatureContent {
     );
   }
 
+  // For a DSSE envelope the signature is computed over the pre-authentication
+  // encoding (PAE), so the digest of the signed bytes is the digest of the PAE.
+  // This is what a Rekor v2 hashedrekord entry records for a DSSE envelope.
+  public compareSignedDigest(digest: Buffer): boolean {
+    return crypto.bufferEqual(
+      digest,
+      crypto.digest('sha256', this.preAuthEncoding)
+    );
+  }
+
   public compareSignature(signature: Buffer): boolean {
     return crypto.bufferEqual(signature, this.signature);
   }

--- a/packages/verify/src/bundle/message.ts
+++ b/packages/verify/src/bundle/message.ts
@@ -53,6 +53,12 @@ export class MessageSignatureContent implements SignatureContent {
     return crypto.bufferEqual(digest, this.messageDigest);
   }
 
+  // For a message signature the signature is computed over the artifact, so the
+  // digest of the signed bytes is the artifact's message digest.
+  public compareSignedDigest(digest: Buffer): boolean {
+    return this.compareDigest(digest);
+  }
+
   public verifySignature(key: crypto.KeyObject): boolean {
     return crypto.verify(
       this.artifact,

--- a/packages/verify/src/shared.types.ts
+++ b/packages/verify/src/shared.types.ts
@@ -61,7 +61,14 @@ export type VerificationKey =
 export type SignatureContent = {
   signature: Buffer;
   compareSignature(signature: Buffer): boolean;
+  // Compares the given digest against the digest of the artifact's payload.
+  // For a DSSE envelope this is the digest of the envelope payload.
   compareDigest(digest: Buffer): boolean;
+  // Compares the given digest against the digest of the bytes that the
+  // signature actually covers. For a message signature this is the digest of
+  // the artifact; for a DSSE envelope this is the digest of the pre-authentication
+  // encoding (PAE). Used when verifying hashedrekord tlog entries.
+  compareSignedDigest(digest: Buffer): boolean;
   verifySignature(key: crypto.KeyObject): boolean;
 };
 

--- a/packages/verify/src/tlog/hashedrekord.ts
+++ b/packages/verify/src/tlog/hashedrekord.ts
@@ -81,10 +81,10 @@ function verifyHashedrekord001TLogBody(
     });
   }
 
-  // Ensure that the bundle's message digest matches the tlog entry
+  // Ensure that the bundle's signed digest matches the tlog entry
   const tlogDigest = tlogEntry.spec.data.hash?.value || '';
 
-  if (!content.compareDigest(Buffer.from(tlogDigest, 'hex'))) {
+  if (!content.compareSignedDigest(Buffer.from(tlogDigest, 'hex'))) {
     throw new VerificationError({
       code: 'TLOG_BODY_ERROR',
       message: 'digest mismatch',
@@ -108,10 +108,10 @@ function verifyHashedrekord002TLogBody(
     });
   }
 
-  // Ensure that the bundle's message digest matches the tlog entry
+  // Ensure that the bundle's signed digest matches the tlog entry
   const tlogHash = spec.data?.digest || Buffer.from('');
 
-  if (!content.compareDigest(tlogHash)) {
+  if (!content.compareSignedDigest(tlogHash)) {
     throw new VerificationError({
       code: 'TLOG_BODY_ERROR',
       message: 'digest mismatch',


### PR DESCRIPTION
## Summary

sigstore-conformance **v0.0.29** ([PR #371](https://github.com/sigstore/sigstore-conformance/pull/371), "DSSE-with-hashedrekord on Rekor v2") introduces DSSE bundles whose transparency log entry is a `hashedrekord/0.0.2`. Unlike legacy `dsse`/`intoto` entries, the entry's `data.digest` is computed over the DSSE **pre-authentication encoding (PAE)** — the bytes the signature actually covers — rather than over the envelope payload.

`@sigstore/verify` previously compared the tlog digest against `Hash(payload)` for DSSE content, so the new happy-path bundle was incorrectly rejected with a digest mismatch.

## Changes

- Add `compareSignedDigest(digest)` to the `SignatureContent` interface and all implementers. It compares against the digest of the signed bytes:
  - **DSSE** → `Hash(PAE(payloadType, payload))`
  - **message signature** → the artifact's message digest (delegates to `compareDigest`)
- Use `compareSignedDigest` in the `hashedrekord` v0.0.1 / v0.0.2 tlog verifiers for the digest check (signature check unchanged). `compareDigest` is left intact so legacy Rekor v1 `dsse`/`intoto` verification (which compares `Hash(payload)`) is unaffected.
- Bump the conformance pin in CI from v0.0.28 → **v0.0.29** so the new `rekor2-dsse-*` fixtures are exercised.

## Validation

- `npm run lint:check`, `npm run build`, and the `@sigstore/verify` test suite all pass (incl. new `#compareSignedDigest` unit tests).
- Ran the conformance entrypoint against all four real v0.0.29 fixtures: `rekor2-dsse-happy-path` **verifies**; the three `_fail` fixtures are correctly **rejected**.