### PR TITLE
Harden the @sigstore/core ASN.1/DER parser

### DIFF
--- a/.changeset/asn1-parser-hardening.md
+++ b/.changeset/asn1-parser-hardening.md
@@ -1,0 +1,5 @@
+---
+'@sigstore/core': patch
+---
+
+ASN.1 parser hardening

--- a/packages/core/src/__tests__/asn1/length.test.ts
+++ b/packages/core/src/__tests__/asn1/length.test.ts
@@ -57,6 +57,20 @@ describe('decodeLength', () => {
       );
     });
   });
+
+  describe('when the long-form length has a leading zero byte', () => {
+    const stream = streamFromBytes([0x82, 0x00, 0x80]);
+    it('throws an error', () => {
+      expect(() => decodeLength(stream)).toThrow('non-minimal length encoding');
+    });
+  });
+
+  describe('when a value less than 128 uses the long form', () => {
+    const stream = streamFromBytes([0x81, 0x7f]);
+    it('throws an error', () => {
+      expect(() => decodeLength(stream)).toThrow('non-minimal length encoding');
+    });
+  });
 });
 
 describe('encodeLength', () => {

--- a/packages/core/src/__tests__/asn1/malformed.test.ts
+++ b/packages/core/src/__tests__/asn1/malformed.test.ts
@@ -1,0 +1,99 @@
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { ASN1ParseError } from '../../asn1/error';
+import { ASN1Obj } from '../../asn1/obj';
+import { encodeLength } from '../../asn1/length';
+
+// Collection of malformed/adversarial DER inputs that the parser must reject
+// rather than crash on or silently mis-parse.
+describe('ASN1Obj.parseBuffer with malformed input', () => {
+  describe('deeply nested structures', () => {
+    // Wrap an empty SEQUENCE in `levels` additional SEQUENCEs.
+    function nestedSequence(levels: number): Buffer {
+      let buf = Buffer.from([0x30, 0x00]); // empty SEQUENCE
+      for (let i = 0; i < levels; i++) {
+        buf = Buffer.concat([
+          Buffer.from([0x30]),
+          encodeLength(buf.length),
+          buf,
+        ]);
+      }
+      return buf;
+    }
+
+    describe('when nesting is within the limit', () => {
+      it('parses successfully', () => {
+        expect(() => ASN1Obj.parseBuffer(nestedSequence(50))).not.toThrow();
+      });
+    });
+
+    describe('when nesting exceeds the maximum depth', () => {
+      it('throws an error', () => {
+        expect(() => ASN1Obj.parseBuffer(nestedSequence(200))).toThrow(
+          ASN1ParseError
+        );
+        expect(() => ASN1Obj.parseBuffer(nestedSequence(200))).toThrow(
+          'maximum nesting depth exceeded'
+        );
+      });
+    });
+  });
+
+  describe('trailing data after the top-level object', () => {
+    it('throws an error', () => {
+      // BOOLEAN (false) followed by an extra trailing byte
+      const buffer = Buffer.from('01010000', 'hex');
+      expect(() => ASN1Obj.parseBuffer(buffer)).toThrow(ASN1ParseError);
+      expect(() => ASN1Obj.parseBuffer(buffer)).toThrow('invalid trailing data');
+    });
+  });
+
+  describe('non-minimal length encoding', () => {
+    it('throws an error', () => {
+      // SEQUENCE with a long-form length encoding a value < 128
+      const buffer = Buffer.from('30810100', 'hex');
+      expect(() => ASN1Obj.parseBuffer(buffer)).toThrow(
+        'non-minimal length encoding'
+      );
+    });
+  });
+
+  describe('non-canonical boolean', () => {
+    it('throws an error when accessed as a boolean', () => {
+      // BOOLEAN with a non-canonical value (0x01 instead of 0xff)
+      const obj = ASN1Obj.parseBuffer(Buffer.from('010101', 'hex'));
+      expect(() => obj.toBoolean()).toThrow('invalid boolean');
+    });
+  });
+
+  describe('oversized OID arc', () => {
+    it('does not truncate arcs that exceed 32 bits', () => {
+      // OID with an arc value of 2^35 + 10 (would truncate in 32-bit math)
+      const obj = ASN1Obj.parseBuffer(
+        Buffer.from('06072a81808080800a', 'hex')
+      );
+      expect(obj.toOID()).toEqual('1.2.34359738378');
+    });
+  });
+
+  describe('bit string with invalid unused-bits count', () => {
+    it('throws an error when accessed as a bit string', () => {
+      // BIT STRING whose first byte (unused bits) is 8 (must be 0-7)
+      const obj = ASN1Obj.parseBuffer(Buffer.from('03020857', 'hex'));
+      expect(() => obj.toBitString()).toThrow('invalid bit string');
+    });
+  });
+});

--- a/packages/core/src/__tests__/asn1/obj.test.ts
+++ b/packages/core/src/__tests__/asn1/obj.test.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { ASN1TypeError } from '../../asn1/error';
+import { ASN1ParseError, ASN1TypeError } from '../../asn1/error';
 import { ASN1Obj } from '../../asn1/obj';
 
 describe('ASN1Obj', () => {
@@ -163,12 +163,21 @@ describe('ASN1Obj', () => {
         });
       });
 
-      describe('when the value is 0x01', () => {
-        // BOOLEAN (1 byte) 0x01
-        const buffer = Buffer.from('010101', 'hex');
+      describe('when the value is 0xff', () => {
+        // BOOLEAN (1 byte) 0xff
+        const buffer = Buffer.from('0101ff', 'hex');
         it('returns true', () => {
           const obj = ASN1Obj.parseBuffer(buffer);
           expect(obj.toBoolean()).toBe(true);
+        });
+      });
+
+      describe('when the value is non-canonical', () => {
+        // BOOLEAN (1 byte) 0x01 -- not a valid DER boolean
+        const buffer = Buffer.from('010101', 'hex');
+        it('throws an error', () => {
+          const obj = ASN1Obj.parseBuffer(buffer);
+          expect(() => obj.toBoolean()).toThrow(ASN1ParseError);
         });
       });
     });

--- a/packages/core/src/__tests__/asn1/parse.test.ts
+++ b/packages/core/src/__tests__/asn1/parse.test.ts
@@ -128,6 +128,18 @@ describe('parseBoolean', () => {
     expect(parseBoolean(Buffer.from([0x00]))).toEqual(false);
     expect(parseBoolean(Buffer.from([0xff]))).toEqual(true);
   });
+
+  it('rejects non-canonical boolean values', () => {
+    expect(() => parseBoolean(Buffer.from([0x01]))).toThrow('invalid boolean');
+    expect(() => parseBoolean(Buffer.from([0x7f]))).toThrow('invalid boolean');
+  });
+
+  it('rejects boolean values with the wrong length', () => {
+    expect(() => parseBoolean(Buffer.from([]))).toThrow('invalid boolean');
+    expect(() => parseBoolean(Buffer.from([0x00, 0x00]))).toThrow(
+      'invalid boolean'
+    );
+  });
 });
 
 describe('parseBitString', () => {
@@ -141,5 +153,24 @@ describe('parseBitString', () => {
     expect(parseBitString(Buffer.from([0x04, 0x57, 0xdf]))).toEqual([
       0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1,
     ]);
+  });
+
+  it('rejects bit strings with an invalid unused-bits count', () => {
+    expect(() => parseBitString(Buffer.from([0x08, 0x57]))).toThrow(
+      'invalid bit string'
+    );
+    expect(() => parseBitString(Buffer.from([0xff, 0x57]))).toThrow(
+      'invalid bit string'
+    );
+  });
+});
+
+describe('parseOID', () => {
+  it('parses OID arcs that exceed 32 bits without truncation', () => {
+    // Arc value 2^35 (34359738368) encoded as base-128: it would overflow a
+    // 32-bit accumulator and collide with a smaller value if truncated.
+    expect(parseOID(Buffer.from('2a81808080800a', 'hex'))).toEqual(
+      '1.2.34359738378'
+    );
   });
 });

--- a/packages/core/src/asn1/length.ts
+++ b/packages/core/src/asn1/length.ts
@@ -40,12 +40,26 @@ export function decodeLength(stream: ByteStream): number {
   // Iterate over the bytes that encode the length.
   let len = 0;
   for (let i = 0; i < byteCount; i++) {
-    len = len * 256 + stream.getUint8();
+    const byte = stream.getUint8();
+
+    // The first byte of a multi-byte length must not be zero; a leading zero
+    // means the length could have been encoded in fewer bytes (non-minimal).
+    if (i === 0 && byte === 0x00) {
+      throw new ASN1ParseError('non-minimal length encoding');
+    }
+
+    len = len * 256 + byte;
   }
 
   // This is a valid ASN.1 length encoding, but we don't support it.
   if (len === 0) {
     throw new ASN1ParseError('indefinite length encoding not supported');
+  }
+
+  // Lengths less than 128 must use the short form; rejecting them here ensures
+  // the encoding is minimal (strict DER).
+  if (len < 128) {
+    throw new ASN1ParseError('non-minimal length encoding');
   }
 
   return len;

--- a/packages/core/src/asn1/obj.ts
+++ b/packages/core/src/asn1/obj.ts
@@ -38,7 +38,16 @@ export class ASN1Obj {
 
   // Constructs an ASN.1 object from a Buffer of DER-encoded bytes.
   public static parseBuffer(buf: Buffer<ArrayBuffer>): ASN1Obj {
-    return parseStream(new ByteStream(buf));
+    const stream = new ByteStream(buf);
+    const obj = parseStream(stream);
+
+    // Ensure the entire buffer was consumed; trailing data after the top-level
+    // object indicates a malformed (or maliciously padded) encoding.
+    if (stream.position !== stream.length) {
+      throw new ASN1ParseError('invalid trailing data');
+    }
+
+    return obj;
   }
 
   public toDER(): Buffer {
@@ -124,7 +133,16 @@ export class ASN1Obj {
 /////////////////////////////////////////////////////////////////////////////
 // Internal stream parsing functions
 
-function parseStream(stream: ByteStream): ASN1Obj {
+// Maximum nesting depth for parsed ASN.1 objects. Bounds the mutual recursion
+// between parseStream and collectSubs so that deeply nested DER cannot exhaust
+// the call stack (denial of service).
+const MAX_DEPTH = 100;
+
+function parseStream(stream: ByteStream, depth = 0): ASN1Obj {
+  if (depth > MAX_DEPTH) {
+    throw new ASN1ParseError('maximum nesting depth exceeded');
+  }
+
   // Parse tag, length, and value from stream
   const tag = new ASN1Tag(stream.getUint8());
   const len = decodeLength(stream);
@@ -137,12 +155,16 @@ function parseStream(stream: ByteStream): ASN1Obj {
   // are embedded in OCTESTRING objects, so we need to check those
   // for children as well.
   if (tag.constructed) {
-    subs = collectSubs(stream, len);
+    subs = collectSubs(stream, len, depth);
   } else if (tag.isOctetString()) {
     // Attempt to parse children of OCTETSTRING objects. If anything fails,
-    // assume the object is not constructed and treat as primitive.
+    // assume the object is not constructed and treat as primitive. This is
+    // intentional: it transparently unwraps DER content embedded in an OCTET
+    // STRING (e.g. X.509 extnValue, CMS eContent). The error is swallowed
+    // because a parse failure simply means the bytes are an opaque primitive
+    // value rather than a nested structure.
     try {
-      subs = collectSubs(stream, len);
+      subs = collectSubs(stream, len, depth);
     } catch (e) {
       // Fail silently and treat as primitive
     }
@@ -156,7 +178,11 @@ function parseStream(stream: ByteStream): ASN1Obj {
   return new ASN1Obj(tag, value, subs);
 }
 
-function collectSubs(stream: ByteStream, len: number): ASN1Obj[] {
+function collectSubs(
+  stream: ByteStream,
+  len: number,
+  depth: number
+): ASN1Obj[] {
   // Calculate end of object content
   const end = stream.position + len;
 
@@ -171,7 +197,7 @@ function collectSubs(stream: ByteStream, len: number): ASN1Obj[] {
   // Parse all children
   const subs: ASN1Obj[] = [];
   while (stream.position < end) {
-    subs.push(parseStream(stream));
+    subs.push(parseStream(stream, depth + 1));
   }
 
   // When we're done parsing children, we should be at the end of the object

--- a/packages/core/src/asn1/parse.ts
+++ b/packages/core/src/asn1/parse.ts
@@ -13,6 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import { ASN1ParseError } from './error';
+
 const RE_TIME_SHORT_YEAR =
   /^(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})(\.\d{3})?Z$/;
 const RE_TIME_LONG_YEAR =
@@ -93,17 +95,19 @@ export function parseOID(buf: Buffer): string {
 
   let oid = `${first}.${second}`;
 
-  // Consume remaining bytes
-  let val = 0;
+  // Consume remaining bytes. Use a BigInt accumulator so that arcs which
+  // exceed 32 bits are not silently truncated (a truncated arc could be made
+  // to collide with a trusted OID).
+  let val = 0n;
   for (; pos < end; ++pos) {
     n = buf[pos];
-    val = (val << 7) + (n & 0x7f);
+    val = (val << 7n) + BigInt(n & 0x7f);
 
     // If the left-most bit is NOT set, then this is the last byte in the
     // sequence and we can add the value to the OID and reset the accumulator
     if ((n & 0x80) === 0) {
       oid += `.${val}`;
-      val = 0;
+      val = 0n;
     }
   }
 
@@ -113,7 +117,20 @@ export function parseOID(buf: Buffer): string {
 // Parse a boolean from the DER-encoded buffer
 // https://learn.microsoft.com/en-us/windows/win32/seccertenroll/about-basic-types#boolean
 export function parseBoolean(buf: Buffer): boolean {
-  return buf[0] !== 0;
+  // DER requires a BOOLEAN to be a single byte that is either 0x00 (false) or
+  // 0xff (true). Reject any other (non-canonical) encoding.
+  if (buf.length !== 1) {
+    throw new ASN1ParseError('invalid boolean');
+  }
+
+  switch (buf[0]) {
+    case 0x00:
+      return false;
+    case 0xff:
+      return true;
+    default:
+      throw new ASN1ParseError('invalid boolean');
+  }
 }
 
 // Parse a bit string from the DER-encoded buffer
@@ -121,6 +138,11 @@ export function parseBoolean(buf: Buffer): boolean {
 export function parseBitString(buf: Buffer): number[] {
   // First byte tell us how many unused bits are in the last byte
   const unused = buf[0];
+
+  // The number of unused bits must be in the range 0-7.
+  if (unused > 7) {
+    throw new ASN1ParseError('invalid bit string');
+  }
 
   const start = 1;
   const end = buf.length;


### PR DESCRIPTION
## Summary

Adds a set of strictness and robustness checks to the custom, zero-dependency DER parser in `@sigstore/core` (used to parse X.509 certificates and RFC 3161 timestamps). These changes make the parser stricter about malformed and non-canonical input. **No public interfaces change** — only behavior on malformed input differs.

## Fixes

- **Recursion-depth limit** — bound the `parseStream`/`collectSubs` mutual recursion (`MAX_DEPTH = 100`) so deeply nested input can't exhaust the call stack.
- **OID arc overflow** — accumulate OID arc components with `BigInt` instead of 32-bit shifts, so large arcs are no longer silently truncated.
- **Strict DER length** — reject non-minimal length encodings (leading-zero long-form bytes and long-form encodings of values < 128).
- **Canonical BOOLEAN** — accept only the canonical single-byte `0x00`/`0xff` encodings.
- **Top-level trailing data** — `parseBuffer` now asserts the entire buffer was consumed and rejects trailing bytes after the outermost object.
- **BIT STRING validation** — validate that the unused-bits count is in the range 0–7.
- **OCTET STRING fallback** — document the intentional speculative-parse fallback that transparently unwraps DER embedded in an OCTET STRING (e.g. X.509 `extnValue`, CMS `eContent`).

## Tests

- New `__tests__/asn1/malformed.test.ts` fuzz/malformed-input corpus (deep nesting, oversized OID arcs, non-minimal lengths, non-canonical booleans, trailing bytes, invalid bit-string unused-bits).
- Extended `parse.test.ts`, `length.test.ts`, and `obj.test.ts` to cover the new strict behaviors. One existing test that asserted the previous lenient BOOLEAN behavior was updated to the canonical contract.

## Compatibility

The only in-repo consumer of these symbols is `@sigstore/verify`; its full test suite passes unchanged, confirming the stricter checks reject no real-world certificate or timestamp fixtures.

## Validation

- `npm run lint:check` ✅
- `npm run build` ✅
- `npm test` → 747 passed ✅