### PR TITLE
Deduplicate transparency-log entries when counting toward the threshold

### DIFF
--- a/.changeset/dedup-tlog-entries.md
+++ b/.changeset/dedup-tlog-entries.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/verify": patch
+---
+
+Deduplicate transparency-log entries before counting them toward `tlogThreshold`, so repeated copies of a single entry no longer over-count. This matches the existing duplicate checks for timestamps and SCTs in the same verifier.

--- a/packages/verify/src/__tests__/verifier.test.ts
+++ b/packages/verify/src/__tests__/verifier.test.ts
@@ -182,6 +182,33 @@ describe('Verifier', () => {
       });
     });
 
+    describe('when the bundle repeats a single inclusion-proof tlog entry', () => {
+      // A proof-only entry (no inclusion promise) produces no tlog timestamp,
+      // so duplicating it is not caught by the timestamp duplicate check. The
+      // tlog counting itself has to reject the repeat, otherwise N copies of
+      // one entry would satisfy an N-of-N tlog threshold.
+      const subject = new Verifier(trustMaterial, {
+        tlogThreshold: 2,
+        timestampThreshold: 1,
+      });
+      const bundle = bundleFromJSON(
+        bundles.V3.MESSAGE_SIGNATURE.TLOG_HASHEDREKORDV002
+      );
+
+      bundle.verificationMaterial.tlogEntries.push({
+        ...bundle.verificationMaterial.tlogEntries[0],
+      });
+
+      const signedEntity = toSignedEntity(bundle, bundles.ARTIFACT);
+
+      it('throws an error', () => {
+        expect(() => subject.verify(signedEntity)).toThrowWithCode(
+          VerificationError,
+          'TLOG_ERROR'
+        );
+      });
+    });
+
     describe('when the tlog timestamp threshold is not met', () => {
       const subject = new Verifier(trustMaterial, { tlogThreshold: 2 });
       const bundle = bundleFromJSON(

--- a/packages/verify/src/verifier.ts
+++ b/packages/verify/src/verifier.ts
@@ -162,18 +162,28 @@ export class Verifier {
 
   // Checks that the tlog entries are valid for the supplied content
   private verifyTLogs({ signature: content, tlogEntries }: SignedEntity): void {
-    let tlogCount = 0;
+    const entryIDs: { logID: Buffer; logIndex: string }[] = [];
 
     tlogEntries.forEach((entry) => {
-      tlogCount++;
       verifyTLogInclusion(entry, this.trustMaterial.tlogs);
       verifyTLogBody(entry, content);
+      entryIDs.push({ logID: entry.logId.keyId, logIndex: entry.logIndex });
     });
 
-    if (tlogCount < this.options.tlogThreshold) {
+    // Check for duplicate entries so that repeated copies of a single entry
+    // cannot be counted more than once toward the threshold. The timestamp and
+    // SCT checks above dedupe their collections the same way.
+    if (containsDupes(entryIDs)) {
       throw new VerificationError({
         code: 'TLOG_ERROR',
-        message: `expected ${this.options.tlogThreshold} tlog entries, got ${tlogCount}`,
+        message: 'duplicate tlog entry',
+      });
+    }
+
+    if (entryIDs.length < this.options.tlogThreshold) {
+      throw new VerificationError({
+        code: 'TLOG_ERROR',
+        message: `expected ${this.options.tlogThreshold} tlog entries, got ${entryIDs.length}`,
       });
     }
   }


### PR DESCRIPTION
Hi, I do supply-chain security work and was reading through the `@sigstore/verify` verifier.

`Verifier.verifyTLogs` counts each transparency-log entry toward `tlogThreshold` with a plain counter and no distinctness check. The same verifier already guards against duplicates for the other two threshold-gated collections: timestamps go through `containsDupes` before the timestamp threshold, and SCTs go through `containsDupes` before the ctlog threshold. Tlog entries were the one collection left without that guard.

In practice this only changes an outcome when a caller sets `tlogThreshold` above the default of 1 (for example, to require witnessing by more than one log). At the default of 1 a single entry already satisfies the check and duplicating it buys nothing, so this is a hardening/consistency fix rather than a break in the common path. The existing "duplicate TLog entries" test passes today because that fixture's entry carries an inclusion promise, so the duplicate is caught earlier by the timestamp `containsDupes` check. Proof-only entries (the Rekor v2 default) produce no tlog timestamp, so they slip past that check and reach the tlog counter, where the repeat currently counts twice.

sigstore-go does the equivalent check ("disallow duplicate entries, as a malicious actor could use duplicates to bypass the threshold"), matching entries by log key ID and log index, so this also lines the two implementations up.

The change collects `{ logID, logIndex }` per entry and runs the existing `containsDupes` helper over them before the threshold comparison, in the same shape as the timestamp and SCT checks right above it. Distinct entries (different log or different index) are unaffected.

Testing: added a case that repeats a single inclusion-proof entry with `tlogThreshold: 2` and asserts it now throws `TLOG_ERROR`. It fails before the change (verify returns without error) and passes after. `npx jest packages/verify` is green (155 tests), and prettier/eslint are clean on the touched files. Included a changeset.
