### PR TITLE
fix(sign): fetch existing Rekor entries by default

### DIFF
--- a/.changeset/rekor-fetch-on-conflict.md
+++ b/.changeset/rekor-fetch-on-conflict.md
@@ -1,0 +1,5 @@
+---
+"@sigstore/sign": patch
+---
+
+Fetch existing Rekor entries by default when a create request returns a conflict.

--- a/packages/sign/src/__tests__/witness/tlog/client.test.ts
+++ b/packages/sign/src/__tests__/witness/tlog/client.test.ts
@@ -125,6 +125,23 @@ describe('TLogClient', () => {
           .reply(409, {}, { Location: `/api/v1/log/entries/${uuid}` });
       });
 
+      describe('by default', () => {
+        const subject = new TLogClient({ rekorBaseURL });
+
+        describe('when the fetch is successful', () => {
+          beforeEach(() => {
+            nock(rekorBaseURL)
+              .get(`/api/v1/log/entries/${uuid}`)
+              .reply(200, rekorEntry);
+          });
+
+          it('returns a tlog entry', async () => {
+            const entry = await subject.createEntry(proposedEntry);
+            expect(entry).toBeTruthy();
+          });
+        });
+      });
+
       describe('when fetchOnConflict is false', () => {
         const subject = new TLogClient({
           rekorBaseURL,

--- a/packages/sign/src/witness/tlog/client.ts
+++ b/packages/sign/src/witness/tlog/client.ts
@@ -40,7 +40,7 @@ export class TLogClient implements TLog {
   private fetchOnConflict: boolean;
 
   constructor(options: TLogClientOptions) {
-    this.fetchOnConflict = options.fetchOnConflict ?? false;
+    this.fetchOnConflict = options.fetchOnConflict ?? true;
     this.rekor = new Rekor({
       baseURL: options.rekorBaseURL,
       retry: options.retry,


### PR DESCRIPTION
## Summary

- default `TLogClient` to fetching existing Rekor entries on 409 conflicts
- keep explicit `fetchOnConflict: false` behavior unchanged
- add coverage for the default 409 recovery path

## Context

This fixes a retry-after-success failure mode seen by npm provenance publishers. If Rekor commits a create-entry request but the client retries after a timeout or transient retryable failure, the retry receives `409 an equivalent entry already exists`. The client already has recovery logic for that condition, but the default was `fetchOnConflict: false`, so high-level callers such as npm provenance publishing treated the benign duplicate as a fatal `TLOG_CREATE_ENTRY_ERROR`.

Related downstream reports:

- Closes sigstore/sigstore-js#1708
- SocialGouv/code-du-travail-numerique#7419
- apify/apify-shared-js#649
- ChainSafe/lodestar#9703

## Verification

- `npm run build`
- `npm test --workspace @sigstore/sign -- witness/tlog/client.test.ts`
- `npm run lint:check -- --quiet`

Generated with AI assistance.
